### PR TITLE
chore: shrink python-base image + fix the cleanup script that wasn't deleting anything

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,7 +32,7 @@ oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 # Imagen base CON TODAS las dependencias preinstaladas (para producción)
 oci.pull(
     name = "python_with_deps",
-    digest = "sha256:353e3b06777e03c2d577cce8e9c7d699dbd91013485c9cf1abead455a09b6d85",
+    digest = "sha256:3b57738d8edceae335f68b411ad696d8067fd773ead4e0fb9f8d95a32a8bd2f0",
     image = "europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/python-base",
     platforms = [
         "linux/amd64",

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,12 +1,14 @@
 # docker/Dockerfile.base
 # Imagen base con TODAS las dependencias del monorepo pre-instaladas
 # Se construye UNA VEZ y se reutiliza en todos los servicios
+#
+# Sincronizada con requirements_lock.txt (mantener orden alfabético).
+# Si añades/quitas una dep en cualquier requirements.txt, regenera el lock
+# y actualiza esta lista (ver docs/operations.md).
 
 FROM python:3.12-slim@sha256:4386a385d81dba9f72ed72a6fe4237755d7f5440c84b417650f38336bbc43117
 
-# Instalar todas las dependencias (combinadas de requirements_lock.txt)
 RUN pip install --no-cache-dir \
-    attrs==25.3.0 \
     beautifulsoup4==4.13.5 \
     black==25.1.0 \
     blinker==1.9.0 \
@@ -24,10 +26,8 @@ RUN pip install --no-cache-dir \
     google-auth-oauthlib==1.2.2 \
     googleapis-common-protos==1.70.0 \
     gunicorn==23.0.0 \
-    h11==0.16.0 \
     httplib2==0.31.0 \
     idna==3.10 \
-    importlib-metadata==8.7.0 \
     iniconfig==2.1.0 \
     itsdangerous==2.2.0 \
     jinja2==3.1.6 \
@@ -35,7 +35,6 @@ RUN pip install --no-cache-dir \
     mccabe==0.7.0 \
     mypy-extensions==1.1.0 \
     oauthlib==3.3.1 \
-    outcome==1.3.0.post0 \
     packaging==25.0 \
     pathspec==0.12.1 \
     platformdirs==4.4.0 \
@@ -48,31 +47,20 @@ RUN pip install --no-cache-dir \
     pyflakes==3.4.0 \
     pygments==2.19.2 \
     pyparsing==3.2.4 \
-    pysocks==1.7.1 \
     pytest==8.4.2 \
     python-dateutil==2.9.0.post0 \
     python-dotenv==1.1.1 \
     python-json-logger==4.1.0 \
-    pytz==2025.2 \
     requests==2.32.5 \
     requests-mock==1.12.1 \
     requests-oauthlib==2.0.0 \
     rsa==4.9.1 \
-    selenium==4.35.0 \
     six==1.17.0 \
-    sniffio==1.3.1 \
-    sortedcontainers==2.4.0 \
     soupsieve==2.8 \
-    trio==0.30.0 \
-    trio-websocket==0.12.2 \
     typing-extensions==4.14.1 \
     unidecode==1.4.0 \
     uritemplate==4.2.0 \
-    urllib3[socks]==2.5.0 \
-    webdriver-manager==4.0.2 \
-    websocket-client==1.8.0 \
-    werkzeug==3.1.3 \
-    wsproto==1.2.0 \
-    zipp==3.23.0
+    urllib3==2.5.0 \
+    werkzeug==3.1.3
 
 ENV PYTHONUNBUFFERED=1

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,16 +1,43 @@
-```
-docker build -f docker/Dockerfile.base -t bazel/python-base-all:latest .
-docker tag bazel/python-base-all:latest \
-  europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/python-base:latest
-docker push europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/python-base:latest
-```
+# `python-base` Docker image
 
+Pre-built base used by every service image. Built once and reused via the
+digest pinned in `MODULE.bazel`. The dependency list in `Dockerfile.base`
+must stay in sync with `requirements_lock.txt` — when the lockfile changes,
+rebuild and re-pin.
 
+## Rebuild & push (multi-arch)
+
+```bash
+# One-time builder setup
 docker buildx create --name mi_builder --driver docker-container --use
-docker buildx ls
 
+# Auth to Artifact Registry (one-time per machine)
+gcloud auth configure-docker europe-southwest1-docker.pkg.dev
 
-docker buildx build --platform linux/amd64,linux/arm64 \
--f docker/Dockerfile.base \
--t europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/python-base:latest \
---push .
+# Build for amd64 + arm64 and push in one shot
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -f docker/Dockerfile.base \
+  -t europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/python-base:latest \
+  --push .
+```
+
+After the push, grab the new digest and update `MODULE.bazel`:
+
+```bash
+gcloud artifacts docker images list \
+  europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/python-base \
+  --include-tags --filter='tags:latest' \
+  --format='value(version)' | head -1
+```
+
+Then in `MODULE.bazel`, replace the `digest = "sha256:..."` of the
+`oci.pull(name = "python_with_deps", ...)` block with the new value.
+
+## Local-only build (single arch, no push)
+
+Only useful if you want to inspect the image without pushing:
+
+```bash
+docker build -f docker/Dockerfile.base -t bazel/python-base-all:latest .
+```

--- a/scripts/clean-images-artifact.sh
+++ b/scripts/clean-images-artifact.sh
@@ -1,62 +1,106 @@
 #!/bin/bash
-set -e # El script se detendrá si un comando falla
+# Garbage-collect Artifact Registry to stay inside the free tier.
+#
+# Two strategies:
+#   - SIMPLE_IMAGES (web, scraper_job, teams_analyzer): single-arch images
+#     pushed via rules_oci's oci_push. Keep only the most recent digest, drop
+#     the rest.
+#   - MULTI_ARCH_IMAGES (python-base): multi-arch images pushed via docker
+#     buildx. The tagged "latest" is a manifest list referencing per-arch
+#     children that are themselves untagged — never delete recent untagged
+#     digests, only the orphans older than $UNTAGGED_MIN_AGE_HOURS.
+#
+# Set DRY_RUN=1 to preview without deleting.
 
-# --- CONFIGURACIÓN ---
-# Repositorio de Artifact Registry
+set -euo pipefail
+
 REPO="europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker"
-
-# Imágenes a limpiar con la estrategia "mantener solo la última"
-SIMPLE_IMAGES=("web" "scraper_job")
-
-# Imágenes a limpiar con la estrategia "borrar solo las no etiquetadas"
+SIMPLE_IMAGES=("web" "scraper_job" "teams_analyzer")
 MULTI_ARCH_IMAGES=("python-base")
+UNTAGGED_MIN_AGE_HOURS="${UNTAGGED_MIN_AGE_HOURS:-24}"
+DRY_RUN="${DRY_RUN:-0}"
 
+run() {
+    if [ "$DRY_RUN" = "1" ]; then
+        echo "[DRY_RUN] $*"
+    else
+        "$@"
+    fi
+}
 
-# --- LÓGICA DE LIMPIEZA PARA IMÁGENES SIMPLES ---
-echo "--- Limpiando imágenes simples (manteniendo la más reciente) ---"
+# --- SIMPLE: keep only the newest digest per image ---
+echo "--- Simple images (keep newest only) ---"
 for IMAGE in "${SIMPLE_IMAGES[@]}"; do
-    echo "[INFO] Limpiando el repositorio: $IMAGE"
+    echo "[INFO] Cleaning $IMAGE"
 
-    # Obtiene la lista de todos los digests (hashes) ordenados por fecha, del más nuevo al más viejo
+    # Note: the resource field is `version` (sha256:...), not `digest`. The
+    # `DIGEST` column in `gcloud artifacts docker images list` output is
+    # cosmetic — using --format="get(digest)" returns empty.
     DIGESTS_TO_DELETE=$(gcloud artifacts docker images list "$REPO/$IMAGE" \
         --sort-by=~CREATE_TIME \
-        --format="get(digest)" | tail -n +2) # tail -n +2 se salta la primera línea (la más nueva)
+        --format="value(version)" \
+        --quiet 2>/dev/null | tail -n +2 || true)
 
     if [ -z "$DIGESTS_TO_DELETE" ]; then
-        echo "[OK] No hay imágenes antiguas que borrar para $IMAGE."
+        echo "[OK] Nothing to delete for $IMAGE."
         continue
     fi
 
-    for DIGEST in $DIGESTS_TO_DELETE; do
-        echo "[ACTION] Borrando imagen antigua: $IMAGE@$DIGEST"
-        gcloud artifacts docker images delete "$REPO/$IMAGE@$DIGEST" --delete-tags --quiet
-    done
-    echo "[OK] Limpieza de $IMAGE completada."
-done
-
-echo "" # Línea en blanco para separar
-
-# --- LÓGICA DE LIMPIEZA PARA IMÁGENES MULTI-ARQUITECTURA ---
-echo "--- Limpiando imágenes multi-arquitectura (borrando las no etiquetadas) ---"
-for IMAGE in "${MULTI_ARCH_IMAGES[@]}"; do
-    echo "[INFO] Limpiando el repositorio: $IMAGE"
-
-    # Obtiene solo los digests de las imágenes que NO tienen ninguna etiqueta
-    UNTAGGED_DIGESTS=$(gcloud artifacts docker images list "$REPO/$IMAGE" \
-        --filter="NOT TAGS:*" \
-        --format="get(digest)")
-
-    if [ -z "$UNTAGGED_DIGESTS" ]; then
-        echo "[OK] No hay imágenes no etiquetadas que borrar para $IMAGE."
-        continue
-    fi
-
-    for DIGEST in $UNTAGGED_DIGESTS; do
-        echo "[ACTION] Borrando imagen no etiquetada: $IMAGE@$DIGEST"
-        gcloud artifacts docker images delete "$REPO/$IMAGE@$DIGEST" --quiet
-    done
-    echo "[OK] Limpieza de $IMAGE completada."
+    while IFS= read -r DIGEST; do
+        [ -z "$DIGEST" ] && continue
+        echo "[ACTION] Deleting old digest: $IMAGE@$DIGEST"
+        run gcloud artifacts docker images delete "$REPO/$IMAGE@$DIGEST" \
+            --delete-tags --quiet
+    done <<< "$DIGESTS_TO_DELETE"
+    echo "[OK] $IMAGE cleaned."
 done
 
 echo ""
-echo "--- Limpieza finalizada ---"
+
+# --- MULTI-ARCH: drop only orphan untagged digests older than $UNTAGGED_MIN_AGE_HOURS ---
+echo "--- Multi-arch images (drop untagged orphans older than ${UNTAGGED_MIN_AGE_HOURS}h) ---"
+
+# Compute the cutoff timestamp in RFC3339 (works on both BSD and GNU date).
+if date -v-1H +%s >/dev/null 2>&1; then
+    CUTOFF=$(date -u -v-"${UNTAGGED_MIN_AGE_HOURS}"H +%Y-%m-%dT%H:%M:%SZ)
+else
+    CUTOFF=$(date -u -d "-${UNTAGGED_MIN_AGE_HOURS} hours" +%Y-%m-%dT%H:%M:%SZ)
+fi
+echo "[INFO] Cutoff: $CUTOFF"
+
+for IMAGE in "${MULTI_ARCH_IMAGES[@]}"; do
+    echo "[INFO] Cleaning $IMAGE"
+
+    # Two passes: a manifest list cannot be deleted before its children, but
+    # children also cannot be deleted while a parent references them. Hit it
+    # twice and tolerate "referenced by parent" errors on the first pass —
+    # the second pass mops up whatever was blocked.
+    for PASS in 1 2; do
+        UNTAGGED_DIGESTS=$(gcloud artifacts docker images list "$REPO/$IMAGE" \
+            --filter="-tags:* AND createTime<\"$CUTOFF\"" \
+            --format="value(version)" \
+            --quiet 2>/dev/null || true)
+
+        if [ -z "$UNTAGGED_DIGESTS" ]; then
+            [ "$PASS" = "1" ] && echo "[OK] No old untagged digests for $IMAGE."
+            break
+        fi
+
+        while IFS= read -r DIGEST; do
+            [ -z "$DIGEST" ] && continue
+            echo "[ACTION] Deleting orphan (pass $PASS): $IMAGE@$DIGEST"
+            if [ "$DRY_RUN" = "1" ]; then
+                echo "[DRY_RUN] gcloud artifacts docker images delete $REPO/$IMAGE@$DIGEST --quiet"
+            else
+                gcloud artifacts docker images delete \
+                    "$REPO/$IMAGE@$DIGEST" --quiet 2>&1 \
+                    | grep -vE 'manifest has referenced parents|failed precondition' \
+                    || true
+            fi
+        done <<< "$UNTAGGED_DIGESTS"
+    done
+    echo "[OK] $IMAGE cleaned."
+done
+
+echo ""
+echo "--- Done ---"


### PR DESCRIPTION
## Summary

Two related fixes in one PR — both about Artifact Registry hygiene.

### 1. Slim down \`python-base\`

\`Dockerfile.base\` was still installing 14 packages no service uses anymore (Selenium-era leftovers): selenium, webdriver-manager, trio, trio-websocket, attrs, sortedcontainers, outcome, sniffio, websocket-client, wsproto, pysocks, importlib-metadata, zipp, pytz.

Sync'd with \`requirements_lock.txt\`. ~50MB uncompressed off the base, propagated to every service image. README rewritten now that we've actually exercised the rebuild + repin flow.

New digest pinned in \`MODULE.bazel\`: \`sha256:3b57738d8edceae335f68b411ad696d8067fd773ead4e0fb9f8d95a32a8bd2f0\`

### 2. Fix \`scripts/clean-images-artifact.sh\` that was never deleting anything

Two bugs kept it from doing its job since it shipped:

- It asked gcloud for \`--format=\"get(digest)\"\`, but the field on AR image resources is \`version\` (\`DIGEST\` is just the table column header). Output was always empty, the empty-string check passed, the loop terminated cheerfully without deleting. **Cero borrados since the script was added** — that explains why AR sat at 410MB / 500MB free tier despite the cleanup step running on every deploy.
- For multi-arch images (\`python-base\`) the \`NOT TAGS:*\` filter also matched per-arch children of the current \`latest\` manifest list — deleting those would break \`latest\`. Added a server-side \`createTime\` filter so we only touch orphans older than 24h.
- Also for multi-arch: gcloud refuses to delete a child while its parent manifest list still references it. Now runs two passes; the first deletes parent lists and standalone digests, the second mops up children left behind.

Plus: added \`teams_analyzer\` to SIMPLE_IMAGES so the upcoming Cloud Run Job is covered, and a \`DRY_RUN=1\` switch for local testing.

## Why bundle them

Without fix #2, fix #1 alone wouldn't have shrunk AR — the old digests would have stayed forever. Verifying #2 here is also the cleanest place: I needed AR with multi-arch images to test against, which is exactly what #1 produces.

## Verification

Locally:
- \`bazel build //...\` ✓
- \`core_tests\`, \`teams_analyzer_tests\`, \`scraper_job_tests\`, \`web_tests\` ✓
- \`flake8 / black --check\` ✓
- \`DRY_RUN=1 bash scripts/clean-images-artifact.sh\` shows the expected digests
- Real run cleared 8 web + 6 scraper_job + 10 python-base orphan digests; \`teams_analyzer\` correctly skipped (no image yet)

After the run, AR shows 7 image digests total (was ~25). Repo bytes will shrink once GCP's async blob GC catches up.

## Test plan

- [ ] Review the dep list in Dockerfile.base against requirements_lock.txt
- [ ] Review the new two-pass / cutoff logic in the cleanup script
- [ ] Once merged: confirm the next CI deploy's cleanup step actually deletes (it should)
- [ ] After merge: free path to push the teams_analyzer image without crossing free tier