### PR TITLE
feat(web): Telegram webhook — /analizar and /help commands

### DIFF
--- a/.claude/plans/next_phases.md
+++ b/.claude/plans/next_phases.md
@@ -1,324 +1,225 @@
 # Next phases — pickup notes for a fresh session
 
-This file is the entry point for any session continuing the work after the JP
-rewrite (v4.2). Reads in 3 minutes; tells you what's done, what's next, and
-which decisions are already taken so you don't ask again.
+Entry point for any session continuing after the JP rewrite (v4.2) and the
+Phase A + deps deploy (PR #6, merged 2026-05-05). Reads in ~3 minutes.
 
-## State on 2026-05-04
+## State on 2026-05-05
 
-- **`master`**: clean. v4.2 already shipped (PR #3 merged on 2026-05-03).
-- **PR #4 open** (`chore/rebuild-python-base`): rebuilds `python-base` without
-  Selenium/pytz/trio* + fixes the AR cleanup script that wasn't deleting
-  anything (`get(digest)` → `value(version)` bug). **Wait for it to merge
-  before starting Phase A** — the slim base image and a working cleanup are
-  pre-requisites for adding the teams_analyzer Cloud Run Job without crossing
-  the AR free tier.
+- **`master`**: clean. PR #6 merged (Phase A + all dep bumps).
+- **PR #7 open** (`feat/telegram-webhook`): implements the Telegram webhook
+  **but with a coupling that was decided to revert** — see Phase B below.
+  **Do NOT merge PR #7 as-is.** Close it and implement Phase B fresh.
 - **JP API**: alive, token unchanged, 546 players, Nico Williams SF=571 ✓.
-- **Active plan**: `.claude/plans/teams_analyzer_rewrite.md` (still relevant for
-  Phase B and Phase C below — do not delete until those ship).
+
+## What shipped in PR #6
+
+- `biwenger-teams-analyzer` Cloud Run Job created and running.
+- Cloud Scheduler fires it daily at 16:00 Madrid.
+- CI auto-deploys the analyzer on code changes (`deploy-teams-analyzer` job).
+- Smoke test passed: 7 Telegram messages sent, exit(0).
+- Bazel modules: `rules_python` 0.40→2.0, `platforms` 0.0.10→1.1 (no more
+  per-build MVS warnings).
+- GH Actions: all bumped (checkout v6, setup-python v6, setup-bazel 0.19,
+  paths-filter v4, auth/setup-gcloud v3). `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`
+  removed.
+- Python libs: gunicorn 26, black 26, pytest 9, flask 3.1.3, google-auth 2.50,
+  requests 2.33, etc. `python-base` image rebuilt and digest updated.
+- `rules_oci` stayed at 2.3.0 — 2.3.1 not in BCR yet; revisit any future PR.
 
 ## Decisions already taken (don't reopen)
 
-- Telegram bot architecture → **webhook on the existing Flask web** (Option A
-  of `teams_analyzer_rewrite.md`). The web is always alive on Cloud Run, so
-  we get the bot for free. Do not introduce a separate Cloud Run service or
-  long-polling job.
-- Auto-lineup endpoint (`PUT /api/v2/user`) confirmed working from the dev
-  tools session. Body shape documented in `teams_analyzer_rewrite.md` §
-  "API de Biwenger — Alineación".
-- Domain models (`LeagueMessage`, `Participation`, `Clausulazo`,
-  `JusticeEntry`) **are applied** to the data path. Don't refactor them out
-  unless you have a strong reason — they're the contract that makes the future
-  Firestore migration localised.
+- **Telegram webhook lives in a dedicated service**, not in the web app.
+  See Phase B below for the architecture.
+- Telegram bot auto-lineup endpoint: Phase C. Blocked on multi-position research.
+- Firestore migration: not started, domain models are ready.
+- Chuck Norris bot: separate GCP project, separate repo, nothing to do with
+  this monorepo.
 
 ---
 
-## Phase A — Deploy teams_analyzer to Cloud Run Job (~30 min)
+## Phase B — Dedicated `biwenger-telegram-bot` service (~2-3h)
 
-**Goal:** the analyzer runs daily at 16:00 Madrid time, pushing Telegram
-messages, with zero coste accumulating.
+**Goal:** `/analizar` from Telegram triggers a fresh analysis without waiting
+for the daily cron. Clean architecture: the web app stays pure UI, the
+telegram bot is its own service.
 
-**Pre-req:** PR #4 merged. Without it, the new image will fatten Artifact
-Registry past the 500MB free tier.
+**Why not in the web app?** The web and analyzer are independent services —
+coupling them (as PR #7 did) makes both images heavier, risks the web worker
+blocking on a 15s analyzer run, and ties deployment cycles together.
+
+**Pre-req:** PR #7 must be closed (not merged). All Cloud Run Job + secrets
+infrastructure is already in place from Phase A.
+
+### Architecture
+
+```
+biwenger-tools (GCP project)
+├── biwenger-summary          ← web Flask, visualisation only (unchanged)
+├── biwenger-scraper-data     ← Cloud Run Job, scraping
+├── biwenger-teams-analyzer   ← Cloud Run Job, daily analysis
+└── biwenger-telegram-bot     ← NEW Cloud Run Service
+                                 POST /telegram/webhook
+                                 /analizar → triggers the Job via Cloud Run API
+                                 /alinear  → (Phase C, future)
+                                 /help     → static text
+```
+
+The webhook handler calls the Cloud Run Jobs API to execute
+`biwenger-teams-analyzer` and returns 200 immediately (async). No in-process
+import of analyzer code.
 
 ### Steps
 
-1. **Create the two Telegram secrets in Secret Manager** (Biwenger ones already
-   exist):
+1. **Close PR #7** — don't merge.
 
-   ```bash
-   echo -n "<TELEGRAM_BOT_TOKEN>" | gcloud secrets create telegram-bot-token-regional \
-       --replication-policy="user-managed" --locations=europe-southwest1 --data-file=-
+2. **New Bazel package** `packages/biwenger_tools/telegram_bot/`:
+   - `telegram_bot.py` — Flask app, single blueprint `POST /telegram/webhook`
+   - `config.py` — reads `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`,
+     `TELEGRAM_WEBHOOK_SECRET`, `GCP_PROJECT_ID`, `CLOUD_RUN_REGION`,
+     `CLOUD_RUN_JOB_NAME` from env.
+   - `BUILD.bazel` — `python_service` macro (new Cloud Run Service), no dep on
+     `teams_analyzer_lib`.
+   - `entrypoint.sh` — same pattern as web and scraper.
+   - `requirements.txt` — `flask`, `gunicorn`, `python-dotenv`, `google-auth`,
+     `google-api-python-client` (for Cloud Run Jobs API call).
+   - Tests covering: wrong secret → 401, wrong chat_id → 200 silent,
+     `/analizar` → triggers job once, `/help` → message sent, unknown → ignored.
 
-   echo -n "<TELEGRAM_CHAT_ID>" | gcloud secrets create telegram-chat-id-regional \
-       --replication-policy="user-managed" --locations=europe-southwest1 --data-file=-
+3. **Triggering the Job via API** — use the Cloud Run Jobs REST API:
+
+   ```python
+   import google.auth
+   import google.auth.transport.requests
+   import requests as http_requests
+
+   def trigger_analyzer_job(project: str, region: str, job_name: str):
+       creds, _ = google.auth.default(
+           scopes=["https://www.googleapis.com/auth/cloud-platform"]
+       )
+       creds.refresh(google.auth.transport.requests.Request())
+       url = (
+           f"https://{region}-run.googleapis.com/apis/run.googleapis.com/v1"
+           f"/namespaces/{project}/jobs/{job_name}:run"
+       )
+       resp = http_requests.post(
+           url, headers={"Authorization": f"Bearer {creds.token}"}
+       )
+       resp.raise_for_status()
    ```
 
-2. **Push the image to Artifact Registry**:
+   The webhook calls this and immediately returns `"", 200`. The Job runs
+   independently.
+
+4. **Deploy new Cloud Run Service**:
 
    ```bash
-   bazel run //packages/biwenger_tools/teams_analyzer:push_image_to_gcp \
+   # Build and push image
+   bazel run //packages/biwenger_tools/telegram_bot:push_image_to_gcp \
        --platforms=//platforms:linux_amd64
-   ```
 
-3. **Create the Cloud Run Job**. Mirror the scraper exactly (memory 512Mi,
-   cpu 1, retries 0, max 1 task). The teams_analyzer needs Biwenger creds
-   from existing secrets, plus the two new Telegram ones, mounted as env vars
-   (the analyzer reads `os.getenv` directly):
-
-   ```bash
-   gcloud run jobs create biwenger-teams-analyzer \
-       --image=europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/teams_analyzer:latest \
+   # Create the service (first time)
+   gcloud run deploy biwenger-telegram-bot \
+       --image=europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/telegram_bot:latest \
        --region=europe-southwest1 \
-       --memory=512Mi --cpu=1 \
-       --max-retries=0 --task-timeout=300s \
-       --set-secrets="BIWENGER_EMAIL=biwenger-email-regional:latest,BIWENGER_PASSWORD=biwenger-password-regional:latest,TELEGRAM_BOT_TOKEN=telegram-bot-token-regional:latest,TELEGRAM_CHAT_ID=telegram-chat-id-regional:latest"
+       --project=biwenger-tools \
+       --allow-unauthenticated \
+       --memory=256Mi --cpu=1 \
+       --set-secrets="TELEGRAM_BOT_TOKEN=telegram-bot-token-regional:latest,\
+   TELEGRAM_CHAT_ID=telegram-chat-id-regional:latest,\
+   TELEGRAM_WEBHOOK_SECRET=telegram-webhook-secret-regional:latest" \
+       --set-env-vars="GCP_PROJECT_ID=biwenger-tools,CLOUD_RUN_REGION=europe-southwest1,CLOUD_RUN_JOB_NAME=biwenger-teams-analyzer"
    ```
 
-   Note: the analyzer reads env vars (`config.py` does `os.getenv("BIWENGER_EMAIL")`)
-   so we use `--set-secrets=ENV_NAME=secret:latest`, **not** the file-mount
-   form the scraper uses. The scraper reads from `/biwenger_email/biwenger-email`
-   files because its `read_secret_from_file` helper is wired that way.
+5. **Wire CI** — add `deploy-telegram-bot` job to `deploy.yml` mirroring
+   `deploy-scraper`.
 
-4. **Schedule it**. Same pattern as
-   `biwenger-scraper-data-scheduler-trigger` (location europe-west1, OAuth
-   token to the Run API):
+6. **Register the webhook** (one-time, after deploy):
 
    ```bash
-   PROJECT_NUMBER=$(gcloud projects describe biwenger-tools --format='value(projectNumber)')
+   TOKEN=$(gcloud secrets versions access latest \
+       --secret=telegram-bot-token-regional --project=biwenger-tools)
+   SECRET=$(gcloud secrets versions access latest \
+       --secret=telegram-webhook-secret-regional --project=biwenger-tools)
 
-   gcloud scheduler jobs create http biwenger-teams-analyzer-trigger \
-       --location=europe-west1 \
-       --schedule="0 16 * * *" \
-       --time-zone="Europe/Madrid" \
-       --uri="https://europe-southwest1-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/biwenger-tools/jobs/biwenger-teams-analyzer:run" \
-       --http-method=POST \
-       --oauth-service-account-email="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
-       --oauth-token-scope="https://www.googleapis.com/auth/cloud-platform"
-   ```
-
-5. **Wire CI** to redeploy the analyzer image automatically when its code
-   changes. Add a `deploy-teams-analyzer` job in `.github/workflows/deploy.yml`
-   mirroring `deploy-scraper`. Also add `teams_analyzer` to the
-   `detect-changes` paths-filter (already covered if you copy the pattern).
-   Reference: see how `deploy-scraper` handles `gcloud run jobs update` after
-   the `push_image_to_gcp`.
-
-6. **Smoke test the deploy**:
-
-   ```bash
-   gcloud run jobs execute biwenger-teams-analyzer --region=europe-southwest1 --wait
-   ```
-
-   Confirm Telegram messages arrive (own squad, market, rivals).
-
-### Done criteria
-
-- Cron fires every day at 16:00 Madrid.
-- Manual `gcloud run jobs execute` works.
-- A code change in `packages/biwenger_tools/teams_analyzer/**` deploys via CI.
-- Artifact Registry stays under 500MB after a few cycles (cleanup script does
-  its job — verified in PR #4).
-
-### Open question
-
-The free tier on Cloud Scheduler is 3 jobs/month forever. With this you'll
-have 2 jobs (scraper + analyzer). Still 1 spare slot before charges kick in.
-
----
-
-## Phase B — Telegram bot interactivo (Phase 2 of the analyzer plan)
-
-**Goal:** type `/analizar` in the Telegram chat → the analyzer runs on demand
-and posts results, without waiting for the daily cron.
-
-**Pre-req:** Phase A done — the analyzer image must already exist in AR and
-the secrets must be in Secret Manager.
-
-### Architecture (already decided)
-
-Webhook handler inside the existing Flask app. New blueprint
-`packages/biwenger_tools/web/routes/telegram.py`. Single endpoint
-`POST /telegram/webhook` that:
-
-1. Parses the Telegram update.
-2. Validates `chat.id == TELEGRAM_CHAT_ID` (single-tenant — only your chat).
-3. Routes by `message.text`:
-   - `/analizar` → kick off the analyzer flow (see step 3 below).
-   - `/help` → static help text listing available commands.
-   - anything else → ignore silently.
-
-### Implementation outline
-
-1. **Refactor the analyzer entry point** so it can be called as a function,
-   not just `python -m`. Today `teams_analyzer.main()` already exists and is
-   self-contained — perfect. Just move the `if __name__ == "__main__"` guard
-   so `main()` is importable from the web.
-
-2. **Webhook validation**. Telegram sends a header `X-Telegram-Bot-Api-Secret-Token`
-   if you registered the webhook with `secret_token`. Generate a random secret,
-   store it as `TELEGRAM_WEBHOOK_SECRET` in Secret Manager, set it both at
-   `setWebhook` time and validated in the handler. Without this anyone could
-   POST garbage to `/telegram/webhook` and crash the web.
-
-3. **Async or sync?** Cloud Run Service request timeout default is 300s. The
-   analyzer takes ~10-15s wall (1 JP request + 1 Biwenger login + N squads).
-   So **synchronous handling is fine** — no Pub/Sub or background queue
-   needed. If it ever creeps over 60s, switch to "ack the webhook with 200,
-   spawn a thread, post results when done" but don't pre-optimise.
-
-4. **Register the webhook once** (manual, one-time):
-
-   ```bash
-   curl -X POST "https://api.telegram.org/bot$TOKEN/setWebhook" \
-        -d "url=https://biwenger-summary-pjpqofuevq-no.a.run.app/telegram/webhook" \
-        -d "secret_token=$TELEGRAM_WEBHOOK_SECRET" \
+   curl -X POST "https://api.telegram.org/bot${TOKEN}/setWebhook" \
+        -d "url=https://<new-service-url>/telegram/webhook" \
+        -d "secret_token=${SECRET}" \
         -d "allowed_updates=[\"message\"]"
    ```
 
-5. **Tests**: Flask test client + mocked `teams_analyzer.main`. Validate:
-   - Wrong chat_id returns 200 silently (Telegram retries on non-200 — never
-     return 4xx unless you really want to drop the update).
-   - Missing/wrong secret token returns 401.
-   - `/analizar` from the right chat_id triggers `main()` once.
-   - Unknown commands are ignored.
+7. **Undo web coupling from PR #7** — the following changes from PR #7 should
+   NOT be in master (PR #7 is not merged, so nothing to revert). Just don't
+   carry them forward:
+   - `extra_layers` param in `python_service.bzl`
+   - `deps`/`extra_layers` in `web/BUILD.bazel`
+   - `teams_analyzer_lib` visibility in `teams_analyzer/BUILD.bazel`
+   - `telegram.py` blueprint in `web/routes/`
+   - Telegram config vars in `web/config.py`
+   - Telegram secrets in web's `deploy.yml` deploy step
 
-### Things NOT to do in Phase B
-
-- Don't add `/alinear` here — that's Phase C and has unresolved research.
-- Don't add caching of the last analysis — premature; one extra HTTP call is
-  cheap.
-- Don't add rate limiting — single-tenant chat, the only attacker is yourself.
-  If it becomes a problem, add it later.
+   The docs commit in PR #7 (`operations.md`) can be salvaged and updated
+   with the new service URL once it's deployed.
 
 ### Done criteria
 
-- Sending `/analizar` from your chat triggers a fresh analysis.
-- Sending `/analizar` from any other chat does nothing visible.
-- Webhook handler has unit tests.
-- Web README mentions the new endpoint.
+- `/analizar` from the correct Telegram chat triggers a new Cloud Run Job
+  execution (visible in GCP logs).
+- The web app has zero knowledge of Telegram or the analyzer.
+- A code change in `packages/biwenger_tools/telegram_bot/**` auto-deploys via CI.
 
 ---
 
-## Phase C — Auto-lineup (Phase 3 of the analyzer plan)
+## Phase C — Auto-lineup `/alinear` (in telegram_bot service)
 
-**Goal:** `/alinear` reads your squad, picks the best XI according to JP
-predict-SF, sets a captain (price < 3M tie-breaker by SF), and PUTs the
-lineup to Biwenger.
+**Pre-req:** Phase B done. AND the multi-position research spike must be
+completed first.
 
-**Pre-req:** Phase B done. **AND a research spike on multi-position must be
-finished first** — see below.
+### ⚠️ Research spike required before any code
 
-### ⚠️ The blocker before any code: multi-position research
+The Biwenger squad API returns each player's `position` as a single int
+(1=GK, 2=DEF, 3=MID, 4=FWD). The UI shows some players with two positions.
+Before writing any lineup code:
 
-The Biwenger API endpoint we use for squads (`/api/v2/user/{id}?fields=players(id,owner)`)
-returns each player's `position` as a single int (1=GK, 2=DEF, 3=MID, 4=FWD).
-But on the Biwenger UI some players list two positions — defenders that can
-play as midfielders, etc. If we build the lineup using only the API's
-single position field, we'll mis-place dual-role players (and the server
-will reject the formation).
+1. Inspect dev-tools network tab on the squad page in Biwenger's web. Look
+   for any endpoint returning `positions: [2, 3]` or similar.
+2. If found: document in `docs/technical/reverse-engineering/biwenger-api.md`
+   and add a method to `BiwengerClient`.
+3. If not found: maintain a manual override map `{player_id: [2, 3]}`.
+4. Write the answer in `teams_analyzer_rewrite.md` § "FASE 3 → Pendiente de
+   investigar" before closing the spike.
 
-**Before writing any `/alinear` code**, do this research spike:
-
-1. Inspect the dev-tools network tab while loading the squad page in
-   Biwenger's web. Look for any endpoint that returns players with a
-   `positions: [2, 3]` array or similar.
-2. If found, document the URL + shape in
-   `docs/technical/reverse-engineering/biwenger-api.md` and add a method
-   to `BiwengerClient` that fetches it.
-3. If not found, fall back to maintaining a manual override map
-   (`{player_id: [2, 3]}`) for the handful of dual-role players. Live with
-   the maintenance cost.
-4. **Write down the answer in `teams_analyzer_rewrite.md` § "FASE 3 →
-   Pendiente de investigar"** before closing the spike. Don't proceed
-   without that resolution recorded.
-
-### Implementation outline (post-research)
-
-1. **`/alinear` handler** in the same telegram blueprint. Same chat_id +
-   secret_token validation as Phase B.
-
-2. **Lineup builder**:
-
-   - Fetch JP players + Biwenger squad (reuse the orchestrator helpers).
-   - Filter available: `status not in {injured, suspended}` AND
-     `nextMatch.status == "pending"` AND `nextMatch.playerInLineup == True`.
-   - For each formation in the supported list (3-4-3, 3-5-2, 4-3-3, ...),
-     compute the best XI by greedy assignment to slots and sum the SF
-     ratings. Keep the formation with max total.
-   - For multi-position players, allow them in any of their slots.
-
-3. **Captain pick**: among the chosen XI, prefer players with `price < 3000000`
-   (Biwenger's "low cost = double points" rule). Among them, pick the
-   highest predict-SF. If none qualify, pick the highest predict-SF overall.
-
-4. **Apply via Biwenger SDK**: add `BiwengerClient.set_lineup(formation,
-   players, reserves, captain)` that wraps `PUT /api/v2/user?fields=*,lineup(date)`.
-   Body shape documented in `teams_analyzer_rewrite.md` § "Request body".
-
-5. **Confirmation message**: post the chosen XI back to Telegram with the
-   formation, captain, and a one-line summary (sum of predicted points).
-
-### Things to be careful with
-
-- **`playersID` order matters** (per the spike note in the original plan).
-  Most likely GK → DEF → MID → FWD by formation. Confirm with one careful
-  test against your real account before shipping.
-- **`reservesID` is `(int|null)[]`** with positional nulls. Don't filter
-  out nulls.
-- **Validate the formation server-side**. Send one obviously-wrong lineup
-  first to learn what the API rejects.
-- **Don't ship without a `--dry-run`** mode. Have `/alinear preview` that
-  prints the chosen XI without PUTting, plus `/alinear` that actually
-  applies. Test `preview` first.
-
-### Done criteria
-
-- `/alinear preview` shows the proposed XI + captain.
-- `/alinear` applies it and the change is visible in the Biwenger app.
-- Multi-position players land in valid slots.
-- All `set_lineup` paths covered by tests with mocked HTTP.
+The rest of Phase C is documented in the original `teams_analyzer_rewrite.md`.
+The `/alinear` handler goes in the same `telegram_bot` service as `/analizar`.
 
 ---
 
 ## Phase D — Dependency maintenance (independent, anytime)
 
-These are the upgrades flagged by `/check-deps`. Each is a standalone PR;
-none block any of the phases above.
-
-| Order | Bump | Files to touch | Risk |
-|-------|------|----------------|------|
-| 1st (urgent) | `rules_python` 0.40.0 → 2.0.0 | `MODULE.bazel`, possibly `*/BUILD.bazel` if any used deprecated APIs | Medium — re-run `bazel build //...` and fix any rule changes |
-| 1st (urgent) | `platforms` 0.0.10 → 1.1.0 | `MODULE.bazel` | Low |
-| 2nd | GitHub Actions: `checkout` v4→v6, `setup-python` v5→v6, `setup-bazel` 0.8.5→0.19.0, `paths-filter` v3→v4, `google-github-actions/auth` v2→v3, `google-github-actions/setup-gcloud` v2→v3 | `.github/workflows/deploy.yml` | Low; remove the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` flag in the same PR |
-| 3rd | Python libs: `gunicorn` 23→25, `pytest` 8→9, `black` 25→26, `google-api-python-client` and `google-auth` to latest | per-module `requirements.txt`, regenerate `requirements_lock.txt`, **rebuild and repush `Dockerfile.base`**, update digest in `MODULE.bazel`, also bump `black` pin in CI lint job | Medium (test plugins, formatter changes) |
-| Last | Python 3.12 → 3.14 | `MODULE.bazel`, `Dockerfile.base`, workflow lint job, `requirements_lock.txt` regen with new interpreter | High (compat surprises) — only if there's a reason; 3.12 supported until Oct 2028 |
-
-Run `/check-deps` first to confirm latest versions before opening any of these.
+| Status | Bump | Notes |
+|--------|------|-------|
+| ✅ Done | `rules_python` 0.40→2.0 | No more MVS warning |
+| ✅ Done | `platforms` 0.0.10→1.1 | |
+| ⏳ Pending | `rules_oci` 2.3.0→2.3.1 | Not in BCR yet; retry next PR |
+| ✅ Done | All GitHub Actions | checkout v6, setup-python v6, etc. |
+| ✅ Done | Python libs | gunicorn 26, black 26, pytest 9, etc. |
+| ⏳ Pending | Python 3.12→3.14 | No urgency; supported until Oct 2028 |
 
 ---
 
 ## Logistics for a fresh session
 
-When you start the new session, do this in order:
+```bash
+cd /Users/jorge/Projects/lillorepo
+git checkout master && git pull --ff-only
+```
 
-1. `cd /Users/jorge/Projects/lillorepo`
-2. `git checkout master && git pull --ff-only`
-3. Read `CLAUDE.md` (root) + `.claude/CLAUDE.md` for repo conventions.
-4. Read this file (`.claude/plans/next_phases.md`).
-5. Pick the next phase. If unsure, default to: A → B → D (parallel) → C.
+Then read `CLAUDE.md` (root) + `.claude/CLAUDE.md` + this file.
 
-Useful shorthand:
+Next action: **close PR #7 and start Phase B fresh** (dedicated
+`biwenger-telegram-bot` service).
 
-- `bash .claude/skills/check-deps/check_deps.sh` — pinned-versions snapshot.
-- `/check-deps` — same + comparison vs latest releases.
-- `/release-notes` — when shipping a notable change.
-- `bazel test //core:core_tests //packages/biwenger_tools/{web,scraper_job,teams_analyzer}:*_tests` — full test sweep.
-- `flake8 core/ packages/ && black --check core/ packages/` — same lint as CI.
-
-Do **not**:
-
-- Commit directly to `master` (CI deploys on push).
-- Touch `requirements_lock.txt` by hand.
-- Add `Co-Authored-By` to commit messages (per user memory).
-- Bump dependencies in the same PR as a feature — keep them separate.
+Useful shorthands:
+- `/check-deps` — pinned versions vs latest
+- `/release-notes` — when shipping a notable change
+- `bazel test //core:core_tests //packages/biwenger_tools/{web,scraper_job,teams_analyzer}:*_tests`
+- `flake8 core/ packages/ && black --check core/ packages/`

--- a/.claude/skills/check-deps/SKILL.md
+++ b/.claude/skills/check-deps/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: check-deps
+description: Snapshot the project's critical pinned versions (Bazel, Python, Bazel modules, GitHub Actions, key Python libs) and compare against today's latest releases. Output a prioritised upgrade list — urgent vs recommended vs up-to-date.
+model-invocable: false
+allowed-tools:
+  - Bash
+  - WebFetch
+  - WebSearch
+  - Read
+---
+
+# Goal
+
+Audit what versions the project pins for its critical dependencies, look up
+the latest release of each one, and tell the user which upgrades are urgent
+(security, EOL, deprecation) vs nice-to-have vs already current.
+
+# Step 1 — Snapshot current versions
+
+Run the helper script to dump the current pinned versions:
+
+```bash
+bash .claude/skills/check-deps/check_deps.sh
+```
+
+The script reads from the canonical sources of truth:
+
+- `.bazelversion` for the Bazel CLI
+- `MODULE.bazel` for Python toolchain version and `bazel_dep` modules
+- `.github/workflows/*.yml` for GitHub Actions versions
+- `core/requirements.txt` and `packages/*/*/requirements.txt` for direct deps
+- `requirements_lock.txt` for the resolved version of each critical library
+
+Show the output to the user as-is — that is part 1 of the answer.
+
+# Step 2 — Look up latest stable releases
+
+For each line in the snapshot, fetch the latest stable version. Use **WebFetch**
+on the canonical release page; only fall back to **WebSearch** if WebFetch can't
+get a definitive answer.
+
+Canonical sources (use these — do not guess):
+
+| Item | URL |
+|------|-----|
+| Bazel | `https://github.com/bazelbuild/bazel/releases/latest` |
+| Python | `https://www.python.org/downloads/` |
+| `rules_python` | `https://github.com/bazelbuild/rules_python/releases/latest` |
+| `rules_oci` | `https://github.com/bazel-contrib/rules_oci/releases/latest` |
+| `rules_pkg` | `https://github.com/bazelbuild/rules_pkg/releases/latest` |
+| `platforms` | `https://github.com/bazelbuild/platforms/releases/latest` |
+| `actions/checkout`, `actions/setup-python`, etc. | `https://github.com/<owner>/<repo>/releases/latest` |
+| `bazel-contrib/setup-bazel` | `https://github.com/bazel-contrib/setup-bazel/releases/latest` |
+| `dorny/paths-filter` | `https://github.com/dorny/paths-filter/releases/latest` |
+| `google-github-actions/auth`, `setup-gcloud` | `https://github.com/google-github-actions/<repo>/releases/latest` |
+| Python libs (Flask, requests, etc.) | `https://pypi.org/pypi/<package>/json` (or the project page) |
+
+Be efficient: fetch in parallel where possible. For **GitHub Actions versions
+that pin to a major like `v4`**, the relevant comparison is whether a `v5`
+exists — if `v4` is still the latest major, treat it as up-to-date.
+
+# Step 3 — Classify each item
+
+For each dependency, decide one of three buckets and explain why:
+
+- 🔴 **Urgent** — bump should happen soon. Triggers any of:
+  - Pinned version is past or near End-of-Life / security-only.
+  - A known CVE affecting the pinned version was fixed in a later one.
+  - The current major is unsupported by tooling we depend on.
+  - The pin is multiple majors behind and the gap is widening fast.
+- 🟡 **Recommended** — would be nice to bump:
+  - One or two minor versions behind, no security concern.
+  - The new version unlocks features we'd plausibly use (mention which).
+- 🟢 **Up-to-date** — at or within one minor of latest stable, no action needed.
+
+For each 🔴 / 🟡 item include:
+- Current version → latest version
+- One-line reason
+- Concrete cost: which files have to change in lockstep (e.g. "MODULE.bazel +
+  Dockerfile.base + workflow Python step + regenerate `requirements_lock.txt`")
+
+For 🟢 items just one line: `<name>: X.Y (latest) ✓`.
+
+# Step 4 — Final output
+
+Structure the response in three sections in this order:
+
+1. **Snapshot** — the script output verbatim.
+2. **Compared with latest** — the classified list, urgent first.
+3. **Recommendation** — a short prose paragraph: which 1-3 things to bump now,
+   which to schedule, which to ignore. End with the concrete next-step command
+   if there's a clear winner (e.g. "bump `actions/checkout` to v5 in
+   `.github/workflows/deploy.yml`").
+
+# Rules
+
+- The script is the source of truth for *current* versions. Don't paraphrase or
+  re-derive what's pinned.
+- Don't recommend bumps that aren't actually justified. "Newer = always upgrade"
+  is the wrong heuristic; reproducibility costs are real.
+- Don't open PRs or edit files. This skill is read-only — analysis only.
+- If a fetch fails or returns ambiguous results, say so explicitly rather than
+  guessing.

--- a/.claude/skills/check-deps/check_deps.sh
+++ b/.claude/skills/check-deps/check_deps.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Print a concise snapshot of the project's critical pinned versions.
+# Sources of truth: .bazelversion, MODULE.bazel, .github/workflows/*.yml,
+# requirements_lock.txt and each module's requirements.txt.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+bold() { printf "\033[1m%s\033[0m\n" "$1"; }
+dim()  { printf "\033[2m%s\033[0m\n" "$1"; }
+
+bold "Build / runtime"
+printf "  Bazel:    %s\n" "$(cat .bazelversion 2>/dev/null || echo '?')"
+PYTHON_VERSION=$(grep -oE 'python_version = "[^"]+"' MODULE.bazel | head -1 \
+    | sed 's/.*"\([^"]*\)".*/\1/')
+printf "  Python:   %s\n" "${PYTHON_VERSION:-?}"
+echo
+
+bold "Bazel modules (MODULE.bazel)"
+grep -E '^bazel_dep\(' MODULE.bazel \
+    | sed -E 's/.*name = "([^"]+)", version = "([^"]+)".*/  \1: \2/'
+echo
+
+bold "GitHub Actions"
+grep -hE '^[[:space:]]*-?[[:space:]]*uses:' .github/workflows/*.yml \
+    | sed -E 's/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*/  /' \
+    | sort -u
+echo
+
+bold "Direct Python deps (per-module requirements.txt)"
+for f in core/requirements.txt packages/biwenger_tools/*/requirements.txt; do
+    [ -f "$f" ] || continue
+    dim "  $f"
+    grep -vE '^[[:space:]]*(#|$)' "$f" | sed 's/^/    /'
+done
+echo
+
+bold "Pinned versions of critical libs (requirements_lock.txt)"
+CRITICAL_LIBS=(
+    flask gunicorn requests beautifulsoup4 unidecode python-dotenv
+    google-api-python-client google-auth python-dateutil python-json-logger
+    flake8 black pytest
+)
+for pkg in "${CRITICAL_LIBS[@]}"; do
+    line=$(grep -E "^${pkg}==" requirements_lock.txt 2>/dev/null | head -1)
+    [ -n "$line" ] && printf "  %s\n" "$line"
+done
+echo
+
+bold "Tooling pinned in CI"
+grep -hE 'flake8==|black==' .github/workflows/deploy.yml \
+    | sed -E 's/^[[:space:]]*/  /' | sort -u

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,7 +139,7 @@ jobs:
             --region ${{ env.REGION }} \
             --project ${{ env.PROJECT_ID }} \
             --allow-unauthenticated \
-            --update-secrets=/gdrive_sa/biwenger-tools-sa.json=biwenger-tools-sa-regional:latest \
+            --update-secrets=/gdrive_sa/biwenger-tools-sa.json=biwenger-tools-sa-regional:latest,BIWENGER_EMAIL=biwenger-email-regional:latest,BIWENGER_PASSWORD=biwenger-password-regional:latest,TELEGRAM_BOT_TOKEN=telegram-bot-token-regional:latest,TELEGRAM_CHAT_ID=telegram-chat-id-regional:latest,TELEGRAM_WEBHOOK_SECRET=telegram-webhook-secret-regional:latest \
             --set-env-vars="\
           TEMPORADA_ACTUAL=${{ env.TEMPORADA_ACTUAL }},\
           GDRIVE_FOLDER_ID=${{ secrets.GDRIVE_FOLDER_ID }},\

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,5 +118,5 @@ Index file: `MEMORY.md`. Each memory is a separate `.md` file in the same direct
 - This repo grows with new packages under `/packages/`. When adding one, replicate the `biwenger_tools` structure as a reference.
 - `BUILD.bazel` files are the source of truth for Bazel dependencies.
 - See `AGENTS.md` for context on project agents.
-- **Commits:** always write commit messages in English. Do not add a `Co-Authored-By` line.
+- **Commits and PRs:** always write commit messages and PR titles/descriptions in English. Do not add a `Co-Authored-By` line.
 - **Web UI design system:** see `packages/biwenger_tools/web/DESIGN.md` before touching templates — it defines the canonical color tokens, typography, and component rules.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,25 +15,28 @@
 
 ## Técnico
 
-- [x] **Import incorrecto** — `web/routes/admin.py:8` importa `get_file_metadata` desde `core.utils`; debería ser `from core.sdk.gcp` (la función ya está ahí)
-- [x] **Default `--platforms` en `.bazelrc`** — `--test_output=errors` como default de test; `--config=gcp` para builds de imagen
-- [x] **Pin `Dockerfile.base` por digest SHA** — `python:3.12-slim@sha256:4386a385...`
-- [x] **`TEMPORADA_ACTUAL` duplicado** — centralizado en `env.TEMPORADA_ACTUAL` del `deploy.yml`; ambos config leen `os.getenv`
-- [x] **Selenium fuera del teams_analyzer** — v4.2 reemplaza Selenium + Analítica Fantasy por la API privada de Jornada Perfecta (1 request HTTP en vez de 600 acciones de browser).
-- [x] **Arreglar target Docker de teams_analyzer** — migrado al patrón de `scraper_job` (`@python_with_deps` + `entrypoint.sh` propio + capas de código separadas). Añadido `push_image_to_gcp` y `load_image_to_docker_local`. `bazel build //...` ahora pasa entero por primera vez tras la migración a bzlmod.
-- [ ] **Reconstruir `Dockerfile.base`** — en curso en PR #4. Sincroniza la lista con `requirements_lock.txt` (drop selenium/pytz/trio*) y reempuja el digest a `MODULE.bazel`. Bloqueante implícito para Fase A (deploy del analyzer) porque la imagen actual está al límite del free tier de Artifact Registry.
-- [ ] **Arreglar `scripts/clean-images-artifact.sh`** — en curso en PR #4. El script no borraba nada por dos bugs (`get(digest)` vacío y `NOT TAGS:*` cogiendo hijos del manifest list actual). Sin el fix, subir más imágenes cruza el free tier de AR.
+- [x] **Import incorrecto** — `web/routes/admin.py:8` importa `get_file_metadata` desde `core.utils`; debería ser `from core.sdk.gcp`
+- [x] **Default `--platforms` en `.bazelrc`**
+- [x] **Pin `Dockerfile.base` por digest SHA**
+- [x] **`TEMPORADA_ACTUAL` duplicado** — centralizado en `env.TEMPORADA_ACTUAL` del `deploy.yml`
+- [x] **Selenium fuera del teams_analyzer** — v4.2 usa API privada de Jornada Perfecta
+- [x] **Arreglar target Docker de teams_analyzer** — migrado al patrón de `scraper_job`
+- [x] **Reconstruir `Dockerfile.base`** — PR #6. Libs actualizadas (gunicorn 26, black 26, pytest 9, etc.) digest actualizado en `MODULE.bazel`.
+- [x] **Arreglar `scripts/clean-images-artifact.sh`** — PR #4. Bugs `get(digest)` y `NOT TAGS:*` corregidos.
+- [x] **Bump Bazel modules** — `rules_python` 0.40→2.0, `platforms` 0.0.10→1.1 (PR #6)
+- [x] **Bump GitHub Actions** — checkout v6, setup-python v6, setup-bazel 0.19, etc. (PR #6)
 
 ## Producto
 
-- [ ] **Deploy teams_analyzer a GCP** — Cloud Run Job + Scheduler diario 16:00 Madrid. Ver Fase A en `.claude/plans/next_phases.md`. Requiere PR #4 mergeado.
-- [ ] **teams_analyzer Fase 2** — webhook Telegram en el Flask web para `/analizar`. Ver Fase B en `.claude/plans/next_phases.md`.
-- [ ] **teams_analyzer Fase 3** — auto-alineación. **Bloqueado por research previo** sobre multi-posición en la API de Biwenger. Ver Fase C en `.claude/plans/next_phases.md`.
+- [x] **Deploy teams_analyzer a GCP** — Cloud Run Job + Scheduler 16:00 Madrid (PR #6, 2026-05-05)
+- [ ] **Telegram bot `/analizar`** — **PR #7 abierto pero NO mergear**. Arquitectura revisada: webhook en servicio dedicado `biwenger-telegram-bot` (no en el web app). Ver Fase B en `.claude/plans/next_phases.md`.
+- [ ] **teams_analyzer `/alinear`** — auto-alineación. **Bloqueado por research** sobre multi-posición en la API de Biwenger. Ver Fase C en `.claude/plans/next_phases.md`.
 - [ ] **Sección VAR en web** — revisar y conectar trigger manual del AI scraper o cron job
 - [ ] **Nuevo proyecto Google para fotos**
 
 ## Arquitectura (medio plazo)
 
-- [x] **Domain models aplicados** — `LeagueMessage`, `Participation`, `Clausulazo`, `JusticeEntry` con `from_csv_row`/`to_csv_row` ya se usan en scraper (escritura) y web (lectura). El call site del CSV-as-DB queda contenido en una capa: facilita la futura migración a Firestore.
-- [ ] **Migración CSV → Firestore** — los modelos de dominio están listos para que el cambio sea localizado en lecturas/escrituras GCP en lugar de tocar todos los call sites. Sin urgencia, ver project_pitch.md para narrativa.
-- [ ] **Bumps de dependencias** — ver Fase D en `.claude/plans/next_phases.md`. `rules_python` 0.40→2.0 y `platforms` 0.0.10→1.1 son los únicos urgentes (warnings activos en cada `bazel build`).
+- [x] **Domain models aplicados** — `LeagueMessage`, `Participation`, `Clausulazo`, `JusticeEntry`
+- [ ] **Migración CSV → Firestore** — domain models listos, sin urgencia
+- [ ] **`rules_oci` 2.3.0→2.3.1** — no está en BCR todavía; reintentar en próximo PR
+- [ ] **Python 3.12→3.14** — sin urgencia hasta Oct 2028

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -97,7 +97,32 @@ Commands for running each component.
       ./deploy.sh
     ```
 
-    URL: https://biwenger-summary-pjpqofuevq-no.a.run.app/25-26/
+    URL: https://biwenger-summary-319945089838.europe-southwest1.run.app/25-26/
+
+  * **🤖 Telegram webhook — one-time registration:**
+
+    Must be run once after deploying the webhook for the first time, or whenever
+    the Cloud Run URL changes. The secret token prevents spoofed requests.
+
+    ```bash
+    TOKEN=$(gcloud secrets versions access latest \
+        --secret=telegram-bot-token-regional --project=biwenger-tools)
+    SECRET=$(gcloud secrets versions access latest \
+        --secret=telegram-webhook-secret-regional --project=biwenger-tools)
+
+    curl -X POST "https://api.telegram.org/bot${TOKEN}/setWebhook" \
+         -d "url=https://biwenger-summary-319945089838.europe-southwest1.run.app/telegram/webhook" \
+         -d "secret_token=${SECRET}" \
+         -d "allowed_updates=[\"message\"]"
+    ```
+
+    Verify the registration:
+
+    ```bash
+    curl "https://api.telegram.org/bot${TOKEN}/getWebhookInfo"
+    ```
+
+    Available commands once registered: `/analizar`, `/help`.
 
 ### 2\. Scraper Job
 

--- a/packages/biwenger_tools/teams_analyzer/BUILD.bazel
+++ b/packages/biwenger_tools/teams_analyzer/BUILD.bazel
@@ -19,6 +19,7 @@ py_library(
         "@pypi//requests",
         "@pypi//unidecode",
     ],
+    visibility = ["//packages/biwenger_tools/web:__pkg__"],
 )
 
 # =================================================================
@@ -75,6 +76,7 @@ pkg_tar(
 pkg_tar(
     name = "teams_analyzer_base_layer",
     deps = [":_code_root", ":_code_logic"],
+    visibility = ["//packages/biwenger_tools/web:__pkg__"],
 )
 
 # Local layer (with secrets baked in — only for local docker run)

--- a/packages/biwenger_tools/web/BUILD.bazel
+++ b/packages/biwenger_tools/web/BUILD.bazel
@@ -6,6 +6,8 @@ python_service(
     main = "app.py",
     repository = "europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/web",
     secrets = ["biwenger-tools-sa.json", ".env"],
+    deps = ["//packages/biwenger_tools/teams_analyzer:teams_analyzer_lib"],
+    extra_layers = ["//packages/biwenger_tools/teams_analyzer:teams_analyzer_base_layer"],
     extra_env = {
         "PORT": "8080",
         "PYTHONPATH": "/app",

--- a/packages/biwenger_tools/web/app.py
+++ b/packages/biwenger_tools/web/app.py
@@ -9,6 +9,7 @@ from packages.biwenger_tools.web import config, services
 from packages.biwenger_tools.web.routes.admin import bp as admin_bp
 from packages.biwenger_tools.web.routes.main import bp as main_bp
 from packages.biwenger_tools.web.routes.season import bp as season_bp
+from packages.biwenger_tools.web.routes.telegram import bp as telegram_bp
 
 _SEASON_RE = re.compile(r"^\d{2}-\d{2}$")
 
@@ -21,6 +22,7 @@ services.init_services()
 app.register_blueprint(main_bp)
 app.register_blueprint(season_bp)
 app.register_blueprint(admin_bp)
+app.register_blueprint(telegram_bp)
 
 
 @app.context_processor

--- a/packages/biwenger_tools/web/config.py
+++ b/packages/biwenger_tools/web/config.py
@@ -46,6 +46,11 @@ ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD")
 GIT_COMMIT = os.getenv("GIT_COMMIT", "local")
 DEPLOY_TIME = os.getenv("DEPLOY_TIME", "")
 
+# --- TELEGRAM (webhook + teams_analyzer calls) ---
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
+TELEGRAM_WEBHOOK_SECRET = os.getenv("TELEGRAM_WEBHOOK_SECRET")
+
 # --- CONFIGURACIÓN NO CRÍTICA (valores fijos) ---
 MESSAGES_PER_PAGE = 7
 

--- a/packages/biwenger_tools/web/routes/telegram.py
+++ b/packages/biwenger_tools/web/routes/telegram.py
@@ -1,0 +1,54 @@
+"""Telegram webhook handler — single-tenant bot for the Lloros league."""
+
+from flask import Blueprint, Response, abort, request
+
+from core.sdk.telegram import send_telegram_message
+from core.utils import get_logger
+from packages.biwenger_tools.teams_analyzer.teams_analyzer import main as run_analyzer
+from packages.biwenger_tools.web import config
+
+logger = get_logger(__name__)
+
+bp = Blueprint("telegram", __name__)
+
+_HELP_TEXT = (
+    "Available commands:\n"
+    "/analizar — run squad & market analysis\n"
+    "/help — show this message"
+)
+
+
+def _parse_command(text: str) -> str:
+    """Return the base command (strips @botname suffix), or '' if not a command."""
+    if not text.startswith("/"):
+        return ""
+    return text.split("@")[0].split()[0]
+
+
+@bp.route("/telegram/webhook", methods=["POST"])
+def webhook() -> Response:
+    token = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
+    if not config.TELEGRAM_WEBHOOK_SECRET or token != config.TELEGRAM_WEBHOOK_SECRET:
+        abort(401)
+
+    update = request.get_json(silent=True) or {}
+    message = update.get("message", {})
+    chat_id = str(message.get("chat", {}).get("id", ""))
+    text = (message.get("text") or "").strip()
+
+    if chat_id != str(config.TELEGRAM_CHAT_ID):
+        return "", 200
+
+    command = _parse_command(text)
+
+    if command == "/analizar":
+        logger.info("Telegram /analizar — starting analysis.")
+        run_analyzer()
+    elif command == "/help":
+        send_telegram_message(
+            config.TELEGRAM_BOT_TOKEN,
+            config.TELEGRAM_CHAT_ID,
+            _HELP_TEXT,
+        )
+
+    return "", 200

--- a/packages/biwenger_tools/web/tests/test_telegram_webhook.py
+++ b/packages/biwenger_tools/web/tests/test_telegram_webhook.py
@@ -1,0 +1,102 @@
+"""Tests for the Telegram webhook handler."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from packages.biwenger_tools.web.app import app
+from packages.biwenger_tools.web import services
+
+VALID_SECRET = "test-webhook-secret"
+VALID_CHAT_ID = "-4825518712"
+
+
+@pytest.fixture(autouse=True)
+def mock_services():
+    services.drive_service = MagicMock()
+    services.sheets_service = MagicMock()
+    yield
+    services.drive_service = None
+    services.sheets_service = None
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test_key"
+    with app.test_client() as c:
+        yield c
+
+
+def _post(client, body, secret=VALID_SECRET):
+    return client.post(
+        "/telegram/webhook",
+        json=body,
+        headers={"X-Telegram-Bot-Api-Secret-Token": secret},
+    )
+
+
+def _update(chat_id, text):
+    return {"message": {"chat": {"id": int(chat_id)}, "text": text}}
+
+
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_WEBHOOK_SECRET", VALID_SECRET)
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_CHAT_ID", VALID_CHAT_ID)
+def test_wrong_secret_returns_401(client):
+    resp = _post(client, _update(VALID_CHAT_ID, "/analizar"), secret="bad-secret")
+    assert resp.status_code == 401
+
+
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_WEBHOOK_SECRET", VALID_SECRET)
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_CHAT_ID", VALID_CHAT_ID)
+@patch("packages.biwenger_tools.web.routes.telegram.run_analyzer")
+def test_wrong_chat_id_ignored(mock_analyzer, client):
+    resp = _post(client, _update("-9999999", "/analizar"))
+    assert resp.status_code == 200
+    assert resp.data == b""
+    mock_analyzer.assert_not_called()
+
+
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_WEBHOOK_SECRET", VALID_SECRET)
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_CHAT_ID", VALID_CHAT_ID)
+@patch("packages.biwenger_tools.web.routes.telegram.run_analyzer")
+def test_analizar_triggers_analyzer(mock_analyzer, client):
+    resp = _post(client, _update(VALID_CHAT_ID, "/analizar"))
+    assert resp.status_code == 200
+    mock_analyzer.assert_called_once()
+
+
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_WEBHOOK_SECRET", VALID_SECRET)
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_CHAT_ID", VALID_CHAT_ID)
+@patch("packages.biwenger_tools.web.routes.telegram.run_analyzer")
+def test_analizar_with_botname_suffix(mock_analyzer, client):
+    resp = _post(client, _update(VALID_CHAT_ID, "/analizar@LlorosBot"))
+    assert resp.status_code == 200
+    mock_analyzer.assert_called_once()
+
+
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_WEBHOOK_SECRET", VALID_SECRET)
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_CHAT_ID", VALID_CHAT_ID)
+@patch("packages.biwenger_tools.web.routes.telegram.send_telegram_message")
+def test_help_sends_message(mock_send, client):
+    resp = _post(client, _update(VALID_CHAT_ID, "/help"))
+    assert resp.status_code == 200
+    mock_send.assert_called_once()
+    assert "/analizar" in mock_send.call_args[0][2]
+
+
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_WEBHOOK_SECRET", VALID_SECRET)
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_CHAT_ID", VALID_CHAT_ID)
+@patch("packages.biwenger_tools.web.routes.telegram.run_analyzer")
+def test_unknown_command_ignored(mock_analyzer, client):
+    resp = _post(client, _update(VALID_CHAT_ID, "/alinear"))
+    assert resp.status_code == 200
+    mock_analyzer.assert_not_called()
+
+
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_WEBHOOK_SECRET", VALID_SECRET)
+@patch("packages.biwenger_tools.web.routes.telegram.config.TELEGRAM_CHAT_ID", VALID_CHAT_ID)
+@patch("packages.biwenger_tools.web.routes.telegram.run_analyzer")
+def test_plain_text_ignored(mock_analyzer, client):
+    resp = _post(client, _update(VALID_CHAT_ID, "hello"))
+    assert resp.status_code == 200
+    mock_analyzer.assert_not_called()

--- a/tools/bazel/python_service.bzl
+++ b/tools/bazel/python_service.bzl
@@ -13,6 +13,7 @@ def python_service(
         secrets = [],
         srcs = None,
         extra_env = {},
+        extra_layers = [],
         enable_tests = True):
     """
     Macro genérica para servicios Python con OCI images.
@@ -116,7 +117,7 @@ def python_service(
         tars = [
             ":" + name + "_core_layer",
             ":" + name + "_code_with_secrets_layer",
-        ],
+        ] + extra_layers,
         env = dict(
             {
                 "PORT": "8080",
@@ -143,7 +144,7 @@ def python_service(
         tars = [
             ":" + name + "_core_layer",
             ":" + name + "_code_layer",
-        ],
+        ] + extra_layers,
         env = dict(
             {
                 "PORT": "8080",


### PR DESCRIPTION
## Summary

- **New endpoint** `POST /telegram/webhook` in the Flask web app (Phase B of the analyzer plan).
- Validates `X-Telegram-Bot-Api-Secret-Token` header → 401 if wrong.
- Single-tenant: messages from any chat other than `TELEGRAM_CHAT_ID` are silently ignored (Telegram requires 2xx to stop retrying).
- `/analizar` → calls `teams_analyzer.main()` synchronously (~10-15s, well within 300s Cloud Run timeout).
- `/help` → static command list via Telegram message.
- All other text silently ignored.

**Infrastructure already applied:**
- `telegram-webhook-secret-regional` created in Secret Manager.
- Web Cloud Run service updated with `BIWENGER_EMAIL`, `BIWENGER_PASSWORD`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `TELEGRAM_WEBHOOK_SECRET` via `--update-secrets`.

**After merge — one manual step:** register the webhook with Telegram:
\`\`\`bash
TOKEN=$(gcloud secrets versions access latest --secret=telegram-bot-token-regional --project=biwenger-tools)
SECRET=$(gcloud secrets versions access latest --secret=telegram-webhook-secret-regional --project=biwenger-tools)
curl -X POST "https://api.telegram.org/bot${TOKEN}/setWebhook" \
     -d "url=https://biwenger-summary-319945089838.europe-southwest1.run.app/telegram/webhook" \
     -d "secret_token=${SECRET}" \
     -d "allowed_updates=[\"message\"]"
\`\`\`

## Test plan

- [ ] 24/24 web tests pass (7 new telegram tests)
- [ ] CI green after merge
- [ ] Web image deploys with teams_analyzer layer included
- [ ] Register webhook (manual step above) and send `/analizar` from the chat
- [ ] Send `/analizar` from a different chat → no response