### PR TITLE
feat(teams-analyzer): CSV format, multi-mode dispatch, /myTeam command

### DIFF
--- a/core/sdk/telegram.py
+++ b/core/sdk/telegram.py
@@ -1,3 +1,5 @@
+import io
+
 import requests
 
 from core.utils import get_logger
@@ -5,6 +7,7 @@ from core.utils import get_logger
 logger = get_logger(__name__)
 
 TELEGRAM_SEND_MESSAGE_URL = "https://api.telegram.org/bot{token}/sendMessage"
+TELEGRAM_SEND_DOCUMENT_URL = "https://api.telegram.org/bot{token}/sendDocument"
 
 
 def send_telegram_message(
@@ -40,3 +43,27 @@ def send_telegram_message(
         logger.info("Telegram message sent.", extra={"chars": len(text)})
     except Exception as e:
         logger.error("Failed to send Telegram message.", extra={"error": str(e)})
+
+
+def send_telegram_document(
+    bot_token: str,
+    chat_id: str,
+    filename: str,
+    data: bytes,
+    caption: str = "",
+) -> None:
+    """Sends a file (CSV, PDF, …) to a Telegram chat via sendDocument."""
+    url = TELEGRAM_SEND_DOCUMENT_URL.format(token=bot_token)
+    try:
+        response = requests.post(
+            url,
+            data={"chat_id": chat_id, "caption": caption, "parse_mode": "HTML"},
+            files={"document": (filename, io.BytesIO(data), "text/csv")},
+            timeout=30,
+        )
+        response.raise_for_status()
+        logger.info("Telegram document sent.", extra={"filename": filename})
+    except Exception as e:
+        logger.error(
+            "Failed to send Telegram document.", extra={"error": str(e)}
+        )

--- a/packages/biwenger_tools/teams_analyzer/config.py
+++ b/packages/biwenger_tools/teams_analyzer/config.py
@@ -27,3 +27,9 @@ USER_SQUAD_URL = biwenger_sdk.manager_squad_url("{manager_id}")
 JP_AUTH_TOKEN = "lks9k2k$iJK"
 JP_COMPETITION = 1  # LaLiga
 JP_SCORE_TYPE = 2  # SofaScore (sistema usado por el Automanager)
+
+# --- MODO DE ANÁLISIS ---
+# "daily"   → mi equipo + mercado (cron diario)
+# "all"     → todos los equipos + mercado (/analizar)
+# "my_team" → solo mi equipo (/myTeam)
+ANALYSIS_MODE = os.getenv("ANALYSIS_MODE", "daily")

--- a/packages/biwenger_tools/teams_analyzer/teams_analyzer.py
+++ b/packages/biwenger_tools/teams_analyzer/teams_analyzer.py
@@ -1,11 +1,9 @@
 """Orquestador del analizador de equipos.
 
-Flujo:
-1. Health-check de la API JP (token / disponibilidad)
-2. Descarga jugadores JP (una llamada HTTP)
-3. Login Biwenger + descarga: catálogo de jugadores, mánagers, mercado, squads
-4. Cruza por nombre normalizado (Biwenger ↔ JP)
-5. Envía resumen a Telegram en varios mensajes
+Modos (ANALYSIS_MODE env var):
+  daily   — mi equipo + mercado como CSV (cron diario)
+  all     — todos los equipos + mercado como CSV (/analizar)
+  my_team — solo mi equipo como CSV (/myTeam)
 """
 
 import time
@@ -16,17 +14,20 @@ from packages.biwenger_tools.teams_analyzer.logic.player_matching import (
     build_jp_index,
     find_player_match,
 )
-from packages.biwenger_tools.teams_analyzer.telegram_formatter import build_all_messages
+from packages.biwenger_tools.teams_analyzer.telegram_formatter import (
+    build_all_teams_csv,
+    build_market_csv,
+    build_team_csv,
+)
 from core.sdk.biwenger import BiwengerClient
 from core.sdk.jp import check_api_health, fetch_all_players
-from core.sdk.telegram import send_telegram_message
+from core.sdk.telegram import send_telegram_document
 from core.utils import get_logger
 
 logger = get_logger(__name__)
 
 
 def _build_row(biwenger_player: dict, jp_index: dict) -> dict:
-    """Construye una fila lista para el formateador a partir del player Biwenger."""
     name = biwenger_player.get("name", "N/A")
     return {
         "name": name,
@@ -36,9 +37,39 @@ def _build_row(biwenger_player: dict, jp_index: dict) -> dict:
     }
 
 
+def _build_market_rows(market_players: list, biwenger_players: dict, jp_index: dict) -> list:
+    rows = []
+    for sale in market_players:
+        if sale.get("user") is not None:
+            continue
+        bw_player = biwenger_players.get(sale.get("player", {}).get("id"))
+        if not bw_player:
+            continue
+        rows.append(_build_row(bw_player, jp_index))
+    return rows
+
+
+def _build_squad_rows(squad: list, biwenger_players: dict, jp_index: dict) -> list:
+    rows = []
+    for player_data in squad:
+        bw_player = biwenger_players.get(player_data.get("id"))
+        if not bw_player:
+            continue
+        rows.append(_build_row(bw_player, jp_index))
+    return rows
+
+
+def _send_csv(token: str, chat_id: str, data: bytes, caption: str, filename: str) -> None:
+    send_telegram_document(token, chat_id, filename, data, caption)
+    time.sleep(0.4)
+
+
 def main():
     start_time = time.time()
-    logger.info("Script started.", extra={"timestamp": datetime.now().isoformat()})
+    logger.info(
+        "Script started.",
+        extra={"timestamp": datetime.now().isoformat(), "mode": config.ANALYSIS_MODE},
+    )
 
     try:
         check_api_health(
@@ -62,69 +93,73 @@ def main():
             config.LEAGUE_ID,
         )
 
-        biwenger_players = biwenger.get_all_players_data_map(
-            config.ALL_PLAYERS_DATA_URL
-        )
-        managers = biwenger.get_league_users(config.LEAGUE_DATA_URL)
-        market_players = biwenger.get_market_players(config.MARKET_URL)
-
-        my_team: list[dict] = []
-        rivals: dict[str, list[dict]] = {}
-
-        my_user_id = biwenger.user_id
-
-        for manager_id, manager_name in managers.items():
-            squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, manager_id)
-            logger.info(
-                "Squad fetched.", extra={"manager": manager_name, "size": len(squad)}
-            )
-            time.sleep(0.5)
-
-            rows = []
-            for player_data in squad:
-                bw_player = biwenger_players.get(player_data.get("id"))
-                if not bw_player:
-                    continue
-                rows.append(_build_row(bw_player, jp_index))
-
-            if manager_id == my_user_id:
-                my_team = rows
-            else:
-                rivals[manager_name] = rows
-
-        market_rows: list[dict] = []
-        for sale in market_players:
-            if sale.get("user") is not None:
-                continue
-            bw_player = biwenger_players.get(sale.get("player", {}).get("id"))
-            if not bw_player:
-                continue
-            market_rows.append(_build_row(bw_player, jp_index))
-
-        logger.info(
-            "Rows built.",
-            extra={
-                "my_team": len(my_team),
-                "rivals": sum(len(v) for v in rivals.values()),
-                "market": len(market_rows),
-            },
-        )
-
-        messages = build_all_messages(my_team, market_rows, rivals)
+        biwenger_players = biwenger.get_all_players_data_map(config.ALL_PLAYERS_DATA_URL)
 
         if not (config.TELEGRAM_BOT_TOKEN and config.TELEGRAM_CHAT_ID):
             logger.warning("Telegram credentials missing — skipping send.")
             return
 
-        for msg in messages:
-            send_telegram_message(
-                config.TELEGRAM_BOT_TOKEN,
-                config.TELEGRAM_CHAT_ID,
-                msg,
-            )
-            time.sleep(0.4)  # avoid hitting Telegram rate limits
+        token = config.TELEGRAM_BOT_TOKEN
+        chat_id = config.TELEGRAM_CHAT_ID
+        mode = config.ANALYSIS_MODE
 
-        logger.info("Telegram messages sent.", extra={"count": len(messages)})
+        if mode == "all":
+            managers = biwenger.get_league_users(config.LEAGUE_DATA_URL)
+            my_team: list[dict] = []
+            rivals: dict[str, list[dict]] = {}
+
+            for manager_id, manager_name in managers.items():
+                squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, manager_id)
+                logger.info(
+                    "Squad fetched.",
+                    extra={"manager": manager_name, "size": len(squad)},
+                )
+                rows = _build_squad_rows(squad, biwenger_players, jp_index)
+                if manager_id == biwenger.user_id:
+                    my_team = rows
+                else:
+                    rivals[manager_name] = rows
+                time.sleep(0.5)
+
+            for data, caption, filename in build_all_teams_csv(my_team, rivals):
+                _send_csv(token, chat_id, data, caption, filename)
+
+            market_players = biwenger.get_market_players(config.MARKET_URL)
+            market_rows = _build_market_rows(market_players, biwenger_players, jp_index)
+            data, caption, filename = build_market_csv(market_rows)
+            _send_csv(token, chat_id, data, caption, filename)
+
+            logger.info(
+                "All-teams analysis sent.",
+                extra={"teams": 1 + len(rivals), "market": len(market_rows)},
+            )
+
+        elif mode == "my_team":
+            my_squad = biwenger.get_manager_squad(
+                config.USER_SQUAD_URL, biwenger.user_id
+            )
+            my_team = _build_squad_rows(my_squad, biwenger_players, jp_index)
+            data, caption, filename = build_team_csv(my_team)
+            _send_csv(token, chat_id, data, caption, filename)
+            logger.info("My-team analysis sent.", extra={"size": len(my_team)})
+
+        else:  # "daily" (default)
+            my_squad = biwenger.get_manager_squad(
+                config.USER_SQUAD_URL, biwenger.user_id
+            )
+            my_team = _build_squad_rows(my_squad, biwenger_players, jp_index)
+            data, caption, filename = build_team_csv(my_team)
+            _send_csv(token, chat_id, data, caption, filename)
+
+            market_players = biwenger.get_market_players(config.MARKET_URL)
+            market_rows = _build_market_rows(market_players, biwenger_players, jp_index)
+            data, caption, filename = build_market_csv(market_rows)
+            _send_csv(token, chat_id, data, caption, filename)
+
+            logger.info(
+                "Daily analysis sent.",
+                extra={"my_team": len(my_team), "market": len(market_rows)},
+            )
 
     except Exception:
         logger.exception("Unexpected error in teams analyzer.")

--- a/packages/biwenger_tools/teams_analyzer/telegram_formatter.py
+++ b/packages/biwenger_tools/teams_analyzer/telegram_formatter.py
@@ -1,5 +1,8 @@
-"""Formatea los mensajes que se envían a Telegram."""
+"""Formatea los mensajes que se envían a Telegram (texto y CSV)."""
 
+import csv
+import io
+import re
 from html import escape
 
 from core.sdk.jp import get_predict_rate
@@ -186,10 +189,172 @@ def build_all_messages(
     return messages
 
 
+_CSV_COLUMNS = [
+    "Nombre",
+    "Pos",
+    "Precio",
+    "SF",
+    "AS",
+    "Avg",
+    "Racha",
+    "Juega",
+    "Estado",
+    "Variacion",
+]
+
+
+def _variacion_str(inc) -> str:
+    if inc is None or inc == 0:
+        return "0"
+    sign = "+" if inc > 0 else "-"
+    abs_val = abs(inc)
+    if abs_val >= 1_000_000:
+        return f"{sign}{abs_val / 1_000_000:.1f}M"
+    return f"{sign}{abs_val // 1_000}K"
+
+
+def _juega_str(jp_player: dict | None) -> str:
+    if jp_player is None:
+        return "sin datos"
+    status = jp_player.get("status", "ok")
+    if status == "injured":
+        return "lesionado"
+    if status == "suspended":
+        return "sancionado"
+    if status == "doubt":
+        return "duda"
+    next_match = jp_player.get("nextMatch") or {}
+    if next_match.get("status") == "break":
+        return "sin partido"
+    if next_match.get("playerInLineup") is False:
+        return "no convocado"
+    venue = "casa" if next_match.get("isLocal") else "fuera"
+    return venue
+
+
+def _csv_player_row(row: dict) -> dict:
+    jp = row.get("jp_player")
+    name = row.get("name", "")
+    pos = _short_pos(row.get("position_id"))
+    price = _price_millions(row.get("price", 0))
+
+    if jp is None:
+        return dict(
+            zip(
+                _CSV_COLUMNS,
+                [name, pos, price, "-", "-", "-", "-", "sin datos", "desconocido", "0"],
+            )
+        )
+
+    def fmt(v):
+        return str(v) if v is not None else "-"
+
+    sf = get_predict_rate(jp, SCORE_SF)
+    as_ = get_predict_rate(jp, SCORE_AS)
+    avg = get_predict_rate(jp, SCORE_AVG)
+
+    return {
+        "Nombre": name,
+        "Pos": pos,
+        "Precio": price,
+        "SF": fmt(sf),
+        "AS": fmt(as_),
+        "Avg": fmt(avg),
+        "Racha": str(jp.get("streak", 0)),
+        "Juega": _juega_str(jp),
+        "Estado": jp.get("status", "ok"),
+        "Variacion": _variacion_str(jp.get("priceIncrement")),
+    }
+
+
+def _rows_to_csv_bytes(
+    rows: list[dict], extra_col: str | None = None
+) -> bytes:
+    buf = io.StringIO()
+    cols = ([extra_col] if extra_col else []) + _CSV_COLUMNS
+    writer = csv.DictWriter(buf, fieldnames=cols)
+    writer.writeheader()
+    for r in rows:
+        csv_row = _csv_player_row(r)
+        if extra_col:
+            csv_row[extra_col] = r.get(extra_col, "")
+        writer.writerow(csv_row)
+    return buf.getvalue().encode("utf-8-sig")
+
+
+def _count_status(rows: list[dict]) -> tuple[int, int, int, int]:
+    """Returns (green, yellow, red, white) counts."""
+    g = y = r = w = 0
+    for row in rows:
+        e = _status_emoji(row.get("jp_player"))
+        if e == "🟢":
+            g += 1
+        elif e == "🟡":
+            y += 1
+        elif e == "🔴":
+            r += 1
+        else:
+            w += 1
+    return g, y, r, w
+
+
+def _safe_filename(name: str) -> str:
+    slug = re.sub(r"[^\w]", "_", name.lower())
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    return f"{slug}.csv"
+
+
+def build_team_csv(
+    rows: list[dict], team_name: str = "Mi equipo"
+) -> tuple[bytes, str, str]:
+    """Build a CSV for one team.
+
+    Returns (csv_bytes, caption_html, filename).
+    """
+    sorted_rows = sorted(rows, key=_sort_key_sf_desc, reverse=True)
+    g, y, r, _ = _count_status(sorted_rows)
+    caption = (
+        f"🛡️ <b>{escape(team_name)}</b> — {len(sorted_rows)} jug.\n"
+        f"🟢 {g} · 🟡 {y} · 🔴 {r}"
+    )
+    filename = _safe_filename(team_name) if team_name != "Mi equipo" else "mi_equipo.csv"
+    return _rows_to_csv_bytes(sorted_rows), caption, filename
+
+
+def build_market_csv(
+    rows: list[dict], top_n: int = 10
+) -> tuple[bytes, str, str]:
+    """Build a CSV for the market top-N.
+
+    Returns (csv_bytes, caption_html, filename).
+    """
+    sorted_rows = sorted(rows, key=_sort_key_sf_desc, reverse=True)[:top_n]
+    caption = f"🛒 <b>Mercado</b> — top {len(sorted_rows)} por SF"
+    return _rows_to_csv_bytes(sorted_rows), caption, "mercado.csv"
+
+
+def build_all_teams_csv(
+    my_team: list[dict],
+    rivals: dict[str, list[dict]],
+) -> list[tuple[bytes, str, str]]:
+    """One CSV per team (mi equipo first, then rivals).
+
+    Returns list of (csv_bytes, caption_html, filename).
+    """
+    results = []
+    results.append(build_team_csv(my_team, "Mi equipo"))
+    for manager_name, rows in rivals.items():
+        results.append(build_team_csv(rows, manager_name))
+    return results
+
+
 __all__ = [
     "format_player_row",
     "build_my_team_message",
     "build_market_message",
     "build_rival_messages",
     "build_all_messages",
+    "build_team_csv",
+    "build_market_csv",
+    "build_all_teams_csv",
 ]

--- a/packages/biwenger_tools/teams_analyzer/tests/test_team_analyzer.py
+++ b/packages/biwenger_tools/teams_analyzer/tests/test_team_analyzer.py
@@ -16,6 +16,10 @@ def mock_config_module():
             "packages.biwenger_tools.teams_analyzer.config.TELEGRAM_CHAT_ID",
             "mock_chat_id",
         ),
+        patch(
+            "packages.biwenger_tools.teams_analyzer.config.ANALYSIS_MODE",
+            "all",
+        ),
     ):
         yield
 
@@ -34,7 +38,7 @@ def mock_all_dependencies():
         ) as mock_health,
         patch(
             "packages.biwenger_tools.teams_analyzer.teams_analyzer."
-            "send_telegram_message"
+            "send_telegram_document"
         ) as mock_send,
         patch("packages.biwenger_tools.teams_analyzer.teams_analyzer.time.sleep"),
     ):
@@ -97,6 +101,10 @@ def mock_all_dependencies():
         }
 
 
+def _sent_captions(mock_send):
+    return [call.args[4] for call in mock_send.call_args_list]
+
+
 def test_main_success(mock_all_dependencies):
     main()
 
@@ -106,14 +114,13 @@ def test_main_success(mock_all_dependencies):
     mock_all_dependencies["biwenger"].get_league_users.assert_called_once()
     mock_all_dependencies["biwenger"].get_market_players.assert_called_once()
 
-    # Manager A es el usuario actual -> "MI EQUIPO"; Manager B -> rival.
-    # Mensajes esperados: mi equipo, mercado, manager B
+    # Mode "all": mi equipo CSV + Manager B CSV + mercado CSV = 3 documents
     assert mock_all_dependencies["send"].call_count == 3
 
-    sent_texts = [call.args[2] for call in mock_all_dependencies["send"].call_args_list]
-    assert any("MI EQUIPO" in t for t in sent_texts)
-    assert any("MERCADO" in t for t in sent_texts)
-    assert any("Manager B" in t for t in sent_texts)
+    captions = _sent_captions(mock_all_dependencies["send"])
+    assert any("Mi equipo" in c for c in captions)
+    assert any("Mercado" in c for c in captions)
+    assert any("Manager B" in c for c in captions)
 
 
 def test_main_skips_send_when_no_telegram_creds(mock_all_dependencies):
@@ -127,24 +134,19 @@ def test_main_skips_send_when_no_telegram_creds(mock_all_dependencies):
 def test_main_aborts_silently_when_jp_health_fails(mock_all_dependencies):
     """If the JP token rotated or the API is down, the orchestrator must NOT
     fall through to fetching/sending — it would push a stale or empty digest.
-
-    The exception is caught by the top-level try/except (the script logs it
-    and exits cleanly), so we verify side-effects rather than re-raise.
     """
     mock_all_dependencies["health"].side_effect = RuntimeError("token rotated")
 
     main()
 
-    # Nothing past the health-check should run
     mock_all_dependencies["fetch_jp"].assert_not_called()
     mock_all_dependencies["biwenger"].get_all_players_data_map.assert_not_called()
     mock_all_dependencies["send"].assert_not_called()
 
 
 def test_main_aborts_silently_when_jp_fetch_fails(mock_all_dependencies):
-    """If JP responds to the health-check but the full fetch fails (network
-    blip, partial outage), we still don't want to call Biwenger and ship
-    half-data to Telegram."""
+    """If JP responds to the health-check but the full fetch fails, we still
+    don't want to call Biwenger and ship half-data to Telegram."""
     mock_all_dependencies["fetch_jp"].side_effect = RuntimeError("connection reset")
 
     main()
@@ -154,16 +156,12 @@ def test_main_aborts_silently_when_jp_fetch_fails(mock_all_dependencies):
 
 
 def test_main_with_empty_squad_still_sends_market(mock_all_dependencies):
-    """An empty squad shouldn't crash the run — we still want the market and
-    rivals digest. Verifies the orchestrator doesn't assume non-empty rows."""
+    """An empty squad shouldn't crash — market and rivals digest still go out."""
     mock_all_dependencies["biwenger"].get_manager_squad.side_effect = [[], []]
 
     main()
 
-    # 3 messages: "mi equipo" (empty), "mercado", and 1 rival (Manager B, also empty).
-    # We don't gate on count — the formatter handles empty rows. Just verify
-    # send was called and didn't blow up.
     assert mock_all_dependencies["send"].call_count >= 2
-    sent_texts = [call.args[2] for call in mock_all_dependencies["send"].call_args_list]
-    assert any("MI EQUIPO" in t for t in sent_texts)
-    assert any("MERCADO" in t for t in sent_texts)
+    captions = _sent_captions(mock_all_dependencies["send"])
+    assert any("Mi equipo" in c for c in captions)
+    assert any("Mercado" in c for c in captions)

--- a/packages/biwenger_tools/teams_analyzer/tests/test_telegram_formatter.py
+++ b/packages/biwenger_tools/teams_analyzer/tests/test_telegram_formatter.py
@@ -1,8 +1,14 @@
+import csv
+import io
+
 from packages.biwenger_tools.teams_analyzer.telegram_formatter import (
     build_all_messages,
-    build_my_team_message,
+    build_all_teams_csv,
+    build_market_csv,
     build_market_message,
+    build_my_team_message,
     build_rival_messages,
+    build_team_csv,
     format_player_row,
 )
 
@@ -126,6 +132,79 @@ def test_rivals_split_when_too_long():
     assert len(msgs) >= 2
     for m in msgs:
         assert len(m) <= 4096
+
+
+# --- CSV builders ---
+
+
+def _row(name="Test", pos=3, price=5_000_000, rate_sf=300):
+    return {
+        "name": name, "position_id": pos, "price": price,
+        "jp_player": _jp(rate_sf=rate_sf),
+    }
+
+
+def _parse_csv(data: bytes) -> list[dict]:
+    text = data.decode("utf-8-sig")
+    return list(csv.DictReader(io.StringIO(text)))
+
+
+def test_build_team_csv_returns_bytes_and_caption_and_filename():
+    rows = [_row("Vini Jr")]
+    data, caption, filename = build_team_csv(rows, "Mi equipo")
+    assert isinstance(data, bytes)
+    assert "Mi equipo" in caption
+    assert filename == "mi_equipo.csv"
+
+
+def test_build_team_csv_caption_contains_status_counts():
+    rows = [_row(rate_sf=400), _row(rate_sf=150), _row(rate_sf=50)]
+    _, caption, _ = build_team_csv(rows, "Mi equipo")
+    assert "🟢" in caption and "🟡" in caption and "🔴" in caption
+
+
+def test_build_team_csv_rival_filename_slugified():
+    rows = [_row()]
+    _, _, filename = build_team_csv(rows, "Manager Pérez")
+    assert filename.endswith(".csv")
+    assert " " not in filename
+
+
+def test_build_team_csv_contains_player_data():
+    rows = [_row("Bellingham", pos=3, price=20_000_000, rate_sf=400)]
+    data, _, _ = build_team_csv(rows)
+    parsed = _parse_csv(data)
+    assert len(parsed) == 1
+    assert parsed[0]["Nombre"] == "Bellingham"
+    assert parsed[0]["Pos"] == "MED"
+    assert parsed[0]["Precio"] == "20M"
+    assert parsed[0]["SF"] == "400"
+
+
+def test_build_market_csv_caps_rows():
+    rows = [_row(f"P{i}", rate_sf=i * 10) for i in range(20)]
+    data, caption, filename = build_market_csv(rows, top_n=5)
+    parsed = _parse_csv(data)
+    assert len(parsed) == 5
+    assert "top 5" in caption
+    assert filename == "mercado.csv"
+
+
+def test_build_market_csv_sorted_by_sf_desc():
+    rows = [_row("Low", rate_sf=100), _row("High", rate_sf=500)]
+    data, _, _ = build_market_csv(rows, top_n=10)
+    parsed = _parse_csv(data)
+    assert parsed[0]["Nombre"] == "High"
+    assert parsed[1]["Nombre"] == "Low"
+
+
+def test_build_all_teams_csv_order_and_count():
+    my_team = [_row("Me")]
+    rivals = {"Rival A": [_row("A1")], "Rival B": [_row("B1")]}
+    results = build_all_teams_csv(my_team, rivals)
+    assert len(results) == 3
+    _, first_caption, _ = results[0]
+    assert "Mi equipo" in first_caption
 
 
 def test_build_all_messages_returns_my_team_market_then_rivals():

--- a/packages/biwenger_tools/telegram_bot/app.py
+++ b/packages/biwenger_tools/telegram_bot/app.py
@@ -14,7 +14,8 @@ app = Flask(__name__)
 
 _HELP_TEXT = (
     "<b>Biwenger Bot</b>\n\n"
-    "/analizar — Lanza un análisis inmediato del equipo\n"
+    "/analizar — Análisis completo (todos los equipos)\n"
+    "/myTeam — Análisis solo de mi equipo\n"
     "/help — Muestra este mensaje"
 )
 
@@ -39,11 +40,20 @@ def webhook():
         return "", 200
 
     if text.startswith("/analizar"):
-        logger.info("Webhook: /analizar received — triggering job")
+        logger.info("Webhook: /analizar received — triggering job (all)")
         job_trigger.trigger_analyzer_job(
             config.GCP_PROJECT_ID,
             config.CLOUD_RUN_REGION,
             config.CLOUD_RUN_JOB_NAME,
+            mode="all",
+        )
+    elif text.startswith("/myTeam"):
+        logger.info("Webhook: /myTeam received — triggering job (my_team)")
+        job_trigger.trigger_analyzer_job(
+            config.GCP_PROJECT_ID,
+            config.CLOUD_RUN_REGION,
+            config.CLOUD_RUN_JOB_NAME,
+            mode="my_team",
         )
     elif text.startswith("/help"):
         logger.info("Webhook: /help received")

--- a/packages/biwenger_tools/telegram_bot/job_trigger.py
+++ b/packages/biwenger_tools/telegram_bot/job_trigger.py
@@ -7,7 +7,9 @@ from core.utils import get_logger
 logger = get_logger(__name__)
 
 
-def trigger_analyzer_job(project: str, region: str, job_name: str) -> None:
+def trigger_analyzer_job(
+    project: str, region: str, job_name: str, mode: str = "daily"
+) -> None:
     creds, _ = google.auth.default(
         scopes=["https://www.googleapis.com/auth/cloud-platform"]
     )
@@ -16,6 +18,17 @@ def trigger_analyzer_job(project: str, region: str, job_name: str) -> None:
         f"https://{region}-run.googleapis.com/apis/run.googleapis.com/v1"
         f"/namespaces/{project}/jobs/{job_name}:run"
     )
-    resp = http_requests.post(url, headers={"Authorization": f"Bearer {creds.token}"})
+    body = {
+        "overrides": {
+            "containerOverrides": [
+                {"env": [{"name": "ANALYSIS_MODE", "value": mode}]}
+            ]
+        }
+    }
+    resp = http_requests.post(
+        url,
+        json=body,
+        headers={"Authorization": f"Bearer {creds.token}"},
+    )
     resp.raise_for_status()
-    logger.info("Cloud Run Job triggered", extra={"job": job_name})
+    logger.info("Cloud Run Job triggered", extra={"job": job_name, "mode": mode})

--- a/packages/biwenger_tools/telegram_bot/tests/test_telegram_bot.py
+++ b/packages/biwenger_tools/telegram_bot/tests/test_telegram_bot.py
@@ -79,7 +79,20 @@ def test_analizar_triggers_job_once(client):
     ) as mock_trigger:
         resp = _post(client, _update(_VALID_CHAT, "/analizar"))
     assert resp.status_code == 200
-    mock_trigger.assert_called_once_with("test-project", "us-central1", "test-job")
+    mock_trigger.assert_called_once_with(
+        "test-project", "us-central1", "test-job", mode="all"
+    )
+
+
+def test_myteam_triggers_job_with_mode(client):
+    with patch(
+        "packages.biwenger_tools.telegram_bot.app.job_trigger.trigger_analyzer_job"
+    ) as mock_trigger:
+        resp = _post(client, _update(_VALID_CHAT, "/myTeam"))
+    assert resp.status_code == 200
+    mock_trigger.assert_called_once_with(
+        "test-project", "us-central1", "test-job", mode="my_team"
+    )
 
 
 def test_help_sends_message(client):


### PR DESCRIPTION
## Summary

- **CSV format**: `teams_analyzer` now sends one CSV file per team via `sendDocument` (utf-8-sig for Excel/Numbers) instead of plain text messages. Caption shows player count and status emoji breakdown.
- **Multi-mode**: `ANALYSIS_MODE` env var controls what gets sent — `daily` (my team + market), `all` (all squads + market), `my_team` (my team only).
- **`/myTeam` command**: new Telegram command that triggers the analyzer in `my_team` mode (fast — no league-wide fetch).
- **`/analizar` updated**: now triggers in `all` mode, sending one CSV per manager.
- **Cloud Run Jobs mode injection**: `job_trigger` passes `ANALYSIS_MODE` as a container env override so each command maps to the right behavior without a separate job definition.

## Test plan

- [ ] All 5 test targets pass: `bazel test //core:core_tests //packages/biwenger_tools/...`
- [ ] Send a `/myTeam` to the bot and verify a single CSV arrives
- [ ] Send a `/analizar` and verify N+1 CSVs arrive (one per manager + market)
- [ ] Verify the daily cron (mode=daily) still sends two CSVs (my team + market)