### PR TITLE
feat(teams-analyzer): Clausulable + Cláusula columns from Biwenger API

### DIFF
--- a/core/sdk/biwenger.py
+++ b/core/sdk/biwenger.py
@@ -38,7 +38,7 @@ def clausulazos_url(league_id: Union[str, int]) -> str:
 
 
 def manager_squad_url(manager_id: Union[str, int]) -> str:
-    return f"{BIWENGER_API_BASE}/user/{manager_id}?fields=players(id,owner)"
+    return f"{BIWENGER_API_BASE}/user/{manager_id}?fields=players(id,owner(*))"
 
 
 class BiwengerClient:

--- a/packages/biwenger_tools/teams_analyzer/config.py
+++ b/packages/biwenger_tools/teams_analyzer/config.py
@@ -22,7 +22,6 @@ MARKET_URL = biwenger_sdk.MARKET_URL
 ALL_PLAYERS_DATA_URL = biwenger_sdk.ALL_PLAYERS_DATA_URL
 LEAGUE_DATA_URL = biwenger_sdk.league_standings_url(LEAGUE_ID)
 USER_SQUAD_URL = biwenger_sdk.manager_squad_url("{manager_id}")
-CLAUSULAZOS_URL = biwenger_sdk.clausulazos_url(LEAGUE_ID)
 
 # --- JORNADA PERFECTA (API privada) ---
 JP_AUTH_TOKEN = "lks9k2k$iJK"

--- a/packages/biwenger_tools/teams_analyzer/config.py
+++ b/packages/biwenger_tools/teams_analyzer/config.py
@@ -22,6 +22,7 @@ MARKET_URL = biwenger_sdk.MARKET_URL
 ALL_PLAYERS_DATA_URL = biwenger_sdk.ALL_PLAYERS_DATA_URL
 LEAGUE_DATA_URL = biwenger_sdk.league_standings_url(LEAGUE_ID)
 USER_SQUAD_URL = biwenger_sdk.manager_squad_url("{manager_id}")
+CLAUSULAZOS_URL = biwenger_sdk.clausulazos_url(LEAGUE_ID)
 
 # --- JORNADA PERFECTA (API privada) ---
 JP_AUTH_TOKEN = "lks9k2k$iJK"

--- a/packages/biwenger_tools/teams_analyzer/teams_analyzer.py
+++ b/packages/biwenger_tools/teams_analyzer/teams_analyzer.py
@@ -6,6 +6,7 @@ Modos (ANALYSIS_MODE env var):
   my_team — solo mi equipo como CSV (/myTeam)
 """
 
+import math
 import time
 from datetime import datetime
 
@@ -25,6 +26,32 @@ from core.sdk.telegram import send_telegram_document
 from core.utils import get_logger
 
 logger = get_logger(__name__)
+
+_TRANSFER_LOCK_SECS = 14 * 86400
+
+
+def _build_transfer_map(entries: list) -> dict:
+    """Returns {player_id: unix_ts} — most recent transfer timestamp per player."""
+    transfer_map: dict = {}
+    for entry in entries:
+        content = entry.get("content") or {}
+        player = content.get("player") or {}
+        player_id = player.get("id")
+        ts = entry.get("date")
+        if player_id and ts:
+            if player_id not in transfer_map or ts > transfer_map[player_id]:
+                transfer_map[player_id] = ts
+    return transfer_map
+
+
+def _clausulable_str(transfer_ts) -> str:
+    if transfer_ts is None:
+        return "Sí"
+    elapsed = time.time() - transfer_ts
+    remaining = math.ceil((_TRANSFER_LOCK_SECS - elapsed) / 86400)
+    if remaining <= 0:
+        return "Sí"
+    return f"No ({remaining}d)"
 
 
 def _build_row(biwenger_player: dict, jp_index: dict) -> dict:
@@ -51,13 +78,22 @@ def _build_market_rows(
     return rows
 
 
-def _build_squad_rows(squad: list, biwenger_players: dict, jp_index: dict) -> list:
+def _build_squad_rows(
+    squad: list,
+    biwenger_players: dict,
+    jp_index: dict,
+    transfer_map: dict | None = None,
+) -> list:
     rows = []
     for player_data in squad:
         bw_player = biwenger_players.get(player_data.get("id"))
         if not bw_player:
             continue
-        rows.append(_build_row(bw_player, jp_index))
+        row = _build_row(bw_player, jp_index)
+        if transfer_map is not None:
+            ts = transfer_map.get(bw_player.get("id"))
+            row["Clausulable"] = _clausulable_str(ts)
+        rows.append(row)
     return rows
 
 
@@ -111,6 +147,13 @@ def main():
 
         if mode == "all":
             managers = biwenger.get_league_users(config.LEAGUE_DATA_URL)
+
+            clausulazos_raw = biwenger.get_clausulazos(
+                config.CLAUSULAZOS_URL + "&limit=100&offset=0"
+            )
+            transfer_map = _build_transfer_map(clausulazos_raw.get("data", []))
+            logger.info("Transfer map built.", extra={"entries": len(transfer_map)})
+
             my_team: list[dict] = []
             rivals: dict[str, list[dict]] = {}
 
@@ -120,11 +163,12 @@ def main():
                     "Squad fetched.",
                     extra={"manager": manager_name, "size": len(squad)},
                 )
-                rows = _build_squad_rows(squad, biwenger_players, jp_index)
                 if manager_id == biwenger.user_id:
-                    my_team = rows
+                    my_team = _build_squad_rows(squad, biwenger_players, jp_index)
                 else:
-                    rivals[manager_name] = rows
+                    rivals[manager_name] = _build_squad_rows(
+                        squad, biwenger_players, jp_index, transfer_map
+                    )
                 time.sleep(0.5)
 
             for data, caption, filename in build_all_teams_csv(my_team, rivals):

--- a/packages/biwenger_tools/teams_analyzer/teams_analyzer.py
+++ b/packages/biwenger_tools/teams_analyzer/teams_analyzer.py
@@ -27,31 +27,20 @@ from core.utils import get_logger
 
 logger = get_logger(__name__)
 
-_TRANSFER_LOCK_SECS = 14 * 86400
 
-
-def _build_transfer_map(entries: list) -> dict:
-    """Returns {player_id: unix_ts} — most recent transfer timestamp per player."""
-    transfer_map: dict = {}
-    for entry in entries:
-        content = entry.get("content") or {}
-        player = content.get("player") or {}
-        player_id = player.get("id")
-        ts = entry.get("date")
-        if player_id and ts:
-            if player_id not in transfer_map or ts > transfer_map[player_id]:
-                transfer_map[player_id] = ts
-    return transfer_map
-
-
-def _clausulable_str(transfer_ts) -> str:
-    if transfer_ts is None:
+def _clausulable_str(locked_until) -> str:
+    if locked_until is None:
         return "Sí"
-    elapsed = time.time() - transfer_ts
-    remaining = math.ceil((_TRANSFER_LOCK_SECS - elapsed) / 86400)
+    remaining = math.ceil((locked_until - time.time()) / 86400)
     if remaining <= 0:
         return "Sí"
     return f"No ({remaining}d)"
+
+
+def _clause_str(clause) -> str:
+    if not clause:
+        return "-"
+    return f"{round(int(clause) / 1_000_000)}M"
 
 
 def _build_row(biwenger_player: dict, jp_index: dict) -> dict:
@@ -82,7 +71,7 @@ def _build_squad_rows(
     squad: list,
     biwenger_players: dict,
     jp_index: dict,
-    transfer_map: dict | None = None,
+    include_clause: bool = False,
 ) -> list:
     rows = []
     for player_data in squad:
@@ -90,9 +79,10 @@ def _build_squad_rows(
         if not bw_player:
             continue
         row = _build_row(bw_player, jp_index)
-        if transfer_map is not None:
-            ts = transfer_map.get(bw_player.get("id"))
-            row["Clausulable"] = _clausulable_str(ts)
+        if include_clause:
+            owner = player_data.get("owner") or {}
+            row["Clausulable"] = _clausulable_str(owner.get("clauseLockedUntil"))
+            row["Cláusula"] = _clause_str(owner.get("clause"))
         rows.append(row)
     return rows
 
@@ -147,13 +137,6 @@ def main():
 
         if mode == "all":
             managers = biwenger.get_league_users(config.LEAGUE_DATA_URL)
-
-            clausulazos_raw = biwenger.get_clausulazos(
-                config.CLAUSULAZOS_URL + "&limit=100&offset=0"
-            )
-            transfer_map = _build_transfer_map(clausulazos_raw.get("data", []))
-            logger.info("Transfer map built.", extra={"entries": len(transfer_map)})
-
             my_team: list[dict] = []
             rivals: dict[str, list[dict]] = {}
 
@@ -167,7 +150,7 @@ def main():
                     my_team = _build_squad_rows(squad, biwenger_players, jp_index)
                 else:
                     rivals[manager_name] = _build_squad_rows(
-                        squad, biwenger_players, jp_index, transfer_map
+                        squad, biwenger_players, jp_index, include_clause=True
                     )
                 time.sleep(0.5)
 

--- a/packages/biwenger_tools/teams_analyzer/telegram_formatter.py
+++ b/packages/biwenger_tools/teams_analyzer/telegram_formatter.py
@@ -303,11 +303,14 @@ def _safe_filename(name: str) -> str:
 
 
 def build_team_csv(
-    rows: list[dict], team_name: str = "Mi equipo"
+    rows: list[dict],
+    team_name: str = "Mi equipo",
+    include_clausulable: bool = False,
 ) -> tuple[bytes, str, str]:
     """Build a CSV for one team.
 
     Returns (csv_bytes, caption_html, filename).
+    include_clausulable adds a leading "Clausulable" column (for rival teams).
     """
     sorted_rows = sorted(rows, key=_sort_key_sf_desc, reverse=True)
     g, y, r, _ = _count_status(sorted_rows)
@@ -318,7 +321,8 @@ def build_team_csv(
     filename = (
         "mi_equipo.csv" if team_name == "Mi equipo" else _safe_filename(team_name)
     )
-    return _rows_to_csv_bytes(sorted_rows), caption, filename
+    extra_col = "Clausulable" if include_clausulable else None
+    return _rows_to_csv_bytes(sorted_rows, extra_col=extra_col), caption, filename
 
 
 def build_market_csv(rows: list[dict], top_n: int = 10) -> tuple[bytes, str, str]:
@@ -342,7 +346,7 @@ def build_all_teams_csv(
     results = []
     results.append(build_team_csv(my_team, "Mi equipo"))
     for manager_name, rows in rivals.items():
-        results.append(build_team_csv(rows, manager_name))
+        results.append(build_team_csv(rows, manager_name, include_clausulable=True))
     return results
 
 

--- a/packages/biwenger_tools/teams_analyzer/telegram_formatter.py
+++ b/packages/biwenger_tools/teams_analyzer/telegram_formatter.py
@@ -267,15 +267,15 @@ def _csv_player_row(row: dict) -> dict:
     }
 
 
-def _rows_to_csv_bytes(rows: list[dict], extra_col: str | None = None) -> bytes:
+def _rows_to_csv_bytes(rows: list[dict], extra_cols: list[str] | None = None) -> bytes:
     buf = io.StringIO()
-    cols = ([extra_col] if extra_col else []) + _CSV_COLUMNS
+    cols = (extra_cols or []) + _CSV_COLUMNS
     writer = csv.DictWriter(buf, fieldnames=cols)
     writer.writeheader()
     for r in rows:
         csv_row = _csv_player_row(r)
-        if extra_col:
-            csv_row[extra_col] = r.get(extra_col, "")
+        for col in extra_cols or []:
+            csv_row[col] = r.get(col, "")
         writer.writerow(csv_row)
     return buf.getvalue().encode("utf-8-sig")
 
@@ -310,7 +310,7 @@ def build_team_csv(
     """Build a CSV for one team.
 
     Returns (csv_bytes, caption_html, filename).
-    include_clausulable adds a leading "Clausulable" column (for rival teams).
+    include_clausulable adds leading Clausulable + Cláusula columns (rivals).
     """
     sorted_rows = sorted(rows, key=_sort_key_sf_desc, reverse=True)
     g, y, r, _ = _count_status(sorted_rows)
@@ -321,8 +321,8 @@ def build_team_csv(
     filename = (
         "mi_equipo.csv" if team_name == "Mi equipo" else _safe_filename(team_name)
     )
-    extra_col = "Clausulable" if include_clausulable else None
-    return _rows_to_csv_bytes(sorted_rows, extra_col=extra_col), caption, filename
+    extra_cols = ["Clausulable", "Cláusula"] if include_clausulable else None
+    return _rows_to_csv_bytes(sorted_rows, extra_cols=extra_cols), caption, filename
 
 
 def build_market_csv(rows: list[dict], top_n: int = 10) -> tuple[bytes, str, str]:

--- a/packages/biwenger_tools/teams_analyzer/tests/test_team_analyzer.py
+++ b/packages/biwenger_tools/teams_analyzer/tests/test_team_analyzer.py
@@ -43,7 +43,7 @@ def mock_all_dependencies():
         patch("packages.biwenger_tools.teams_analyzer.teams_analyzer.time.sleep"),
         patch(
             "packages.biwenger_tools.teams_analyzer.teams_analyzer.time.time",
-            return_value=1_700_000_000,
+            return_value=1_800_000_000,
         ),
     ):
         mock_biwenger = MagicMock()
@@ -59,22 +59,22 @@ def mock_all_dependencies():
             123: "Manager A",
             456: "Manager B",
         }
+        # Player A: no clause lock; Player B: locked for 9 more days
         mock_biwenger.get_manager_squad.side_effect = [
-            [{"id": 1}],
-            [{"id": 2}],
+            [{"id": 1, "owner": {"clause": 1_530_000}}],
+            [
+                {
+                    "id": 2,
+                    "owner": {
+                        "clause": 1_836_000,
+                        "clauseLockedUntil": 1_800_000_000 + 9 * 86400,
+                    },
+                }
+            ],
         ]
         mock_biwenger.get_market_players.return_value = [
             {"player": {"id": 1}, "user": None, "price": 0},
         ]
-        # clausulazos: Player B transferred 5 days ago (still locked)
-        mock_biwenger.get_clausulazos.return_value = {
-            "data": [
-                {
-                    "date": 1_700_000_000 - 5 * 86400,
-                    "content": {"player": {"id": 2}},
-                }
-            ]
-        }
 
         mock_fetch_jp.return_value = [
             {

--- a/packages/biwenger_tools/teams_analyzer/tests/test_team_analyzer.py
+++ b/packages/biwenger_tools/teams_analyzer/tests/test_team_analyzer.py
@@ -41,6 +41,10 @@ def mock_all_dependencies():
             "send_telegram_document"
         ) as mock_send,
         patch("packages.biwenger_tools.teams_analyzer.teams_analyzer.time.sleep"),
+        patch(
+            "packages.biwenger_tools.teams_analyzer.teams_analyzer.time.time",
+            return_value=1_700_000_000,
+        ),
     ):
         mock_biwenger = MagicMock()
         mock_biwenger.user_id = 123  # mánager actual = manager A
@@ -62,6 +66,15 @@ def mock_all_dependencies():
         mock_biwenger.get_market_players.return_value = [
             {"player": {"id": 1}, "user": None, "price": 0},
         ]
+        # clausulazos: Player B transferred 5 days ago (still locked)
+        mock_biwenger.get_clausulazos.return_value = {
+            "data": [
+                {
+                    "date": 1_700_000_000 - 5 * 86400,
+                    "content": {"player": {"id": 2}},
+                }
+            ]
+        }
 
         mock_fetch_jp.return_value = [
             {

--- a/packages/biwenger_tools/teams_analyzer/tests/test_telegram_formatter.py
+++ b/packages/biwenger_tools/teams_analyzer/tests/test_telegram_formatter.py
@@ -209,16 +209,20 @@ def test_build_all_teams_csv_order_and_count():
     assert "Mi equipo" in first_caption
 
 
-def test_rival_csv_has_clausulable_column():
+def test_rival_csv_has_clausulable_and_clausula_columns():
     rival_rows = [
-        {**_row("Locked"), "Clausulable": "No (3d)"},
-        {**_row("Free"), "Clausulable": "Sí"},
+        {**_row("Locked"), "Clausulable": "No (9d)", "Cláusula": "32M"},
+        {**_row("Free"), "Clausulable": "Sí", "Cláusula": "8M"},
     ]
     data, _, _ = build_team_csv(rival_rows, "Rival", include_clausulable=True)
     parsed = _parse_csv(data)
     assert "Clausulable" in parsed[0]
-    assert any(r["Clausulable"] == "No (3d)" for r in parsed)
-    assert any(r["Clausulable"] == "Sí" for r in parsed)
+    assert "Cláusula" in parsed[0]
+    locked = next(r for r in parsed if r["Nombre"] == "Locked")
+    assert locked["Clausulable"] == "No (9d)"
+    assert locked["Cláusula"] == "32M"
+    free = next(r for r in parsed if r["Nombre"] == "Free")
+    assert free["Clausulable"] == "Sí"
 
 
 def test_my_team_csv_has_no_clausulable_column():
@@ -226,16 +230,18 @@ def test_my_team_csv_has_no_clausulable_column():
     data, _, _ = build_team_csv(rows, "Mi equipo")
     parsed = _parse_csv(data)
     assert "Clausulable" not in parsed[0]
+    assert "Cláusula" not in parsed[0]
 
 
 def test_build_all_teams_csv_rivals_include_clausulable():
     my_team = [_row("Me")]
-    rival_rows = [{**_row("R"), "Clausulable": "Sí"}]
+    rival_rows = [{**_row("R"), "Clausulable": "Sí", "Cláusula": "10M"}]
     results = build_all_teams_csv(my_team, {"Rival": rival_rows})
     my_data, _, _ = results[0]
     rival_data, _, _ = results[1]
     assert "Clausulable" not in _parse_csv(my_data)[0]
     assert "Clausulable" in _parse_csv(rival_data)[0]
+    assert "Cláusula" in _parse_csv(rival_data)[0]
 
 
 def test_build_all_messages_returns_my_team_market_then_rivals():

--- a/packages/biwenger_tools/teams_analyzer/tests/test_telegram_formatter.py
+++ b/packages/biwenger_tools/teams_analyzer/tests/test_telegram_formatter.py
@@ -209,6 +209,35 @@ def test_build_all_teams_csv_order_and_count():
     assert "Mi equipo" in first_caption
 
 
+def test_rival_csv_has_clausulable_column():
+    rival_rows = [
+        {**_row("Locked"), "Clausulable": "No (3d)"},
+        {**_row("Free"), "Clausulable": "Sí"},
+    ]
+    data, _, _ = build_team_csv(rival_rows, "Rival", include_clausulable=True)
+    parsed = _parse_csv(data)
+    assert "Clausulable" in parsed[0]
+    assert any(r["Clausulable"] == "No (3d)" for r in parsed)
+    assert any(r["Clausulable"] == "Sí" for r in parsed)
+
+
+def test_my_team_csv_has_no_clausulable_column():
+    rows = [_row("Me")]
+    data, _, _ = build_team_csv(rows, "Mi equipo")
+    parsed = _parse_csv(data)
+    assert "Clausulable" not in parsed[0]
+
+
+def test_build_all_teams_csv_rivals_include_clausulable():
+    my_team = [_row("Me")]
+    rival_rows = [{**_row("R"), "Clausulable": "Sí"}]
+    results = build_all_teams_csv(my_team, {"Rival": rival_rows})
+    my_data, _, _ = results[0]
+    rival_data, _, _ = results[1]
+    assert "Clausulable" not in _parse_csv(my_data)[0]
+    assert "Clausulable" in _parse_csv(rival_data)[0]
+
+
 def test_build_all_messages_returns_my_team_market_then_rivals():
     msgs = build_all_messages(
         my_team=[


### PR DESCRIPTION
## Summary

Reads clause data directly from `owner.clauseLockedUntil` and `owner.clause` in the Biwenger squad endpoint — no extra API call needed.

- Changed `manager_squad_url` to request `fields=players(id,owner(*))` instead of just `owner`
- `owner.clauseLockedUntil` — Unix timestamp until clause is locked (`None` = available now)
- `owner.clause` — exact clause amount in euros

Rival team CSVs now have two leading columns:
- **Clausulable**: `Sí` or `No (9d)` — can you buy via clause right now?
- **Cláusula**: `32M` — the exact clause price

My team and market CSVs are unaffected.

## Test plan

- [ ] CI passes
- [ ] Trigger `/analizar` — open a rival CSV, verify `Clausulable` and `Cláusula` columns are present
- [ ] Player transferred < 14 days ago (e.g. Rüdiger) should show `No (Xd)` with clause amount