### PR TITLE
fix(lint): wrap long lines in lineup.py and test_lineup.py

### DIFF
--- a/packages/biwenger_tools/teams_analyzer/logic/lineup.py
+++ b/packages/biwenger_tools/teams_analyzer/logic/lineup.py
@@ -116,7 +116,7 @@ def pick_lineup(squad_rows: list) -> dict | None:
 
         starter_ids = {r["bw_id"] for r, _ in assignment}
         bench_pool = [r for r in available if r["bw_id"] not in starter_ids]
-        # Biwenger reserve slots are positional: slot1=GK, slot2=DEF, slot3=MID, slot4=FWD
+        # Biwenger reserve slots are positional: GK→DEF→MID→FWD
         used_ids: set = set()
         reserves = []
         for slot_pos in (GK, DEF, MID, FWD):
@@ -197,7 +197,11 @@ def format_lineup_message(result: dict) -> str:
             lines.append(f"{pos_name[pos_id]} {escape(row['name'])} (SF:{sf}){cap}")
 
     slot_label = {GK: "POR", DEF: "DEF", MID: "MED", FWD: "DEL"}
-    filled = [(slot_label[pos], r) for pos, r in zip((GK, DEF, MID, FWD), reserves) if r]
+    filled = [
+        (slot_label[pos], r)
+        for pos, r in zip((GK, DEF, MID, FWD), reserves)
+        if r
+    ]
     if filled:
         lines.append("\n<b>Suplentes:</b>")
         for label, r in filled:

--- a/packages/biwenger_tools/teams_analyzer/tests/test_lineup.py
+++ b/packages/biwenger_tools/teams_analyzer/tests/test_lineup.py
@@ -193,7 +193,7 @@ def test_captain_falls_back_to_cheapest_when_no_known_cheap():
 
 
 def test_captain_excludes_zero_price_players():
-    # price=0 means unknown MV — must not be selected as captain when a known-cheap exists
+    # price=0 means unknown MV — excluded even if best SF
     starters = [
         _player(1, GK, sf=600, price=0),       # unknown price, best SF
         _player(2, DEF, sf=300, price=2_000_000),  # cheap, known


### PR DESCRIPTION
## Summary

- Wrap 3 lines exceeding the 88-char flake8 limit introduced by PR #12.
- No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)