### PR TITLE
refactor(core): shared Telegram webhook helpers — parse_command, extract_webhook_update, validate_webhook_secret

### DIFF
--- a/core/sdk/telegram.py
+++ b/core/sdk/telegram.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import requests
 
 from core.utils import get_logger
@@ -91,3 +93,31 @@ def set_commands_menu_button(bot_token: str) -> None:
         logger.info("Menu button set to 'commands'.")
     except Exception as e:
         logger.error("Failed to set menu button.", extra={"error": str(e)})
+
+
+def parse_command(text: str) -> str:
+    """Extract the bare command from a Telegram message text.
+
+    '/analizar@bot arg' → '/analizar'
+    '/HELP' → '/help'
+    '' → ''
+    """
+    return text.lower().split()[0].split("@")[0] if text.strip() else ""
+
+
+def extract_webhook_update(request: Any) -> tuple[str, str]:
+    """Extract (chat_id, text) from a Flask webhook POST request body.
+
+    Returns ('', '') for empty or malformed bodies.
+    """
+    body = request.get_json(silent=True) or {}
+    message = body.get("message", {})
+    chat_id = str(message.get("chat", {}).get("id", ""))
+    text = (message.get("text") or "").strip()
+    return chat_id, text
+
+
+def validate_webhook_secret(request: Any, expected: str) -> bool:
+    """Return True if the X-Telegram-Bot-Api-Secret-Token header matches."""
+    received = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
+    return received == expected

--- a/core/tests/test_telegram_notifier.py
+++ b/core/tests/test_telegram_notifier.py
@@ -1,6 +1,14 @@
+from unittest.mock import MagicMock
+
 import requests_mock
 
-from core.sdk.telegram import TELEGRAM_SEND_MESSAGE_URL, send_telegram_message
+from core.sdk.telegram import (
+    TELEGRAM_SEND_MESSAGE_URL,
+    extract_webhook_update,
+    parse_command,
+    send_telegram_message,
+    validate_webhook_secret,
+)
 
 TEST_BOT_TOKEN = "test_bot_token"
 TEST_CHAT_ID = "123456789"
@@ -46,3 +54,85 @@ def test_send_telegram_message_logs_error_on_api_failure(caplog):
         assert any(
             "Failed to send Telegram message" in r.message for r in caplog.records
         )
+
+
+# --- parse_command ---
+
+
+def test_parse_command_strips_botname():
+    assert parse_command("/analizar@biwenger_bot") == "/analizar"
+
+
+def test_parse_command_lowercases():
+    assert parse_command("/HELP") == "/help"
+
+
+def test_parse_command_strips_arguments():
+    assert parse_command("/myteam foo bar") == "/myteam"
+
+
+def test_parse_command_empty_string():
+    assert parse_command("") == ""
+
+
+def test_parse_command_whitespace_only():
+    assert parse_command("   ") == ""
+
+
+# --- validate_webhook_secret ---
+
+
+def _mock_request(secret: str) -> MagicMock:
+    req = MagicMock()
+    req.headers.get = lambda key, default="": (
+        secret if key == "X-Telegram-Bot-Api-Secret-Token" else default
+    )
+    return req
+
+
+def test_validate_webhook_secret_match():
+    assert validate_webhook_secret(_mock_request("abc123"), "abc123") is True
+
+
+def test_validate_webhook_secret_mismatch():
+    assert validate_webhook_secret(_mock_request("wrong"), "abc123") is False
+
+
+def test_validate_webhook_secret_empty_header():
+    assert validate_webhook_secret(_mock_request(""), "abc123") is False
+
+
+# --- extract_webhook_update ---
+
+
+def _mock_json_request(body: dict) -> MagicMock:
+    req = MagicMock()
+    req.get_json = MagicMock(return_value=body)
+    return req
+
+
+def test_extract_webhook_update_normal():
+    req = _mock_json_request({"message": {"chat": {"id": 42}, "text": "/help"}})
+    chat_id, text = extract_webhook_update(req)
+    assert chat_id == "42"
+    assert text == "/help"
+
+
+def test_extract_webhook_update_empty_body():
+    req = MagicMock()
+    req.get_json = MagicMock(return_value=None)
+    chat_id, text = extract_webhook_update(req)
+    assert chat_id == ""
+    assert text == ""
+
+
+def test_extract_webhook_update_strips_text_whitespace():
+    req = _mock_json_request({"message": {"chat": {"id": 1}, "text": "  /random  "}})
+    _, text = extract_webhook_update(req)
+    assert text == "/random"
+
+
+def test_extract_webhook_update_no_text_key():
+    req = _mock_json_request({"message": {"chat": {"id": 1}}})
+    _, text = extract_webhook_update(req)
+    assert text == ""

--- a/packages/biwenger_tools/telegram_bot/app.py
+++ b/packages/biwenger_tools/telegram_bot/app.py
@@ -4,7 +4,12 @@ import os
 
 from flask import Flask, request
 
-from core.sdk.telegram import send_telegram_message
+from core.sdk.telegram import (
+    extract_webhook_update,
+    parse_command,
+    send_telegram_message,
+    validate_webhook_secret,
+)
 from core.utils import get_logger
 from packages.biwenger_tools.telegram_bot import config, job_trigger
 
@@ -29,26 +34,13 @@ _JOB_MODES = {
 }
 
 
-def _parse_command(text: str) -> str:
-    """Extract bare command from text, stripping @botname and arguments.
-
-    '/analizar@biwenger_tools_bot' → '/analizar'
-    '/myteam foo' → '/myteam'
-    """
-    return text.lower().split()[0].split("@")[0] if text.strip() else ""
-
-
 @app.route("/telegram/webhook", methods=["POST"])
 def webhook():
-    secret = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
-    if secret != config.TELEGRAM_WEBHOOK_SECRET:
+    if not validate_webhook_secret(request, config.TELEGRAM_WEBHOOK_SECRET):
         logger.warning("Webhook: invalid secret token")
         return "", 401
 
-    body = request.get_json(silent=True) or {}
-    message = body.get("message", {})
-    chat_id = str(message.get("chat", {}).get("id", ""))
-    text = (message.get("text") or "").strip()
+    chat_id, text = extract_webhook_update(request)
 
     if chat_id != config.TELEGRAM_CHAT_ID:
         logger.info(
@@ -57,7 +49,7 @@ def webhook():
         )
         return "", 200
 
-    cmd = _parse_command(text)
+    cmd = parse_command(text)
 
     if cmd in _JOB_MODES:
         mode = _JOB_MODES[cmd]

--- a/packages/biwenger_tools/telegram_bot/config.py
+++ b/packages/biwenger_tools/telegram_bot/config.py
@@ -4,9 +4,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
-TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "")
-TELEGRAM_WEBHOOK_SECRET = os.getenv("TELEGRAM_WEBHOOK_SECRET", "")
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "").strip()
+TELEGRAM_WEBHOOK_SECRET = os.getenv("TELEGRAM_WEBHOOK_SECRET", "").strip()
 
 GCP_PROJECT_ID = os.getenv("GCP_PROJECT_ID", "biwenger-tools")
 CLOUD_RUN_REGION = os.getenv("CLOUD_RUN_REGION", "europe-southwest1")

--- a/packages/chucknorris_bot/bot/app.py
+++ b/packages/chucknorris_bot/bot/app.py
@@ -5,7 +5,12 @@ import os
 import requests
 from flask import Flask, render_template, request
 
-from core.sdk.telegram import send_telegram_message
+from core.sdk.telegram import (
+    extract_webhook_update,
+    parse_command,
+    send_telegram_message,
+    validate_webhook_secret,
+)
 from core.utils import get_logger
 from packages.chucknorris_bot.bot import config
 
@@ -42,10 +47,6 @@ def _fetch_joke(category: str | None = None) -> str:
         return "Chuck Norris broke the internet. Try again."
 
 
-def _parse_command(text: str) -> str:
-    return text.lower().split()[0].split("@")[0] if text.strip() else ""
-
-
 @app.route("/")
 def index():
     return render_template("index.html")
@@ -53,20 +54,15 @@ def index():
 
 @app.route("/telegram/webhook", methods=["POST"])
 def webhook():
-    secret = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
-    if secret != config.TELEGRAM_WEBHOOK_SECRET:
+    if not validate_webhook_secret(request, config.TELEGRAM_WEBHOOK_SECRET):
         logger.warning("Webhook: invalid secret token")
         return "", 401
 
-    body = request.get_json(silent=True) or {}
-    message = body.get("message", {})
-    chat_id = str(message.get("chat", {}).get("id", ""))
-    text = (message.get("text") or "").strip()
-
+    chat_id, text = extract_webhook_update(request)
     if not chat_id or not text:
         return "", 200
 
-    cmd = _parse_command(text)
+    cmd = parse_command(text)
 
     if cmd in ("/start", "/help"):
         send_telegram_message(

--- a/packages/chucknorris_bot/bot/tests/test_app.py
+++ b/packages/chucknorris_bot/bot/tests/test_app.py
@@ -4,7 +4,8 @@ import pytest
 from unittest.mock import patch
 
 import packages.chucknorris_bot.bot.config as cfg
-from packages.chucknorris_bot.bot.app import app, _fetch_joke, _parse_command
+from core.sdk.telegram import parse_command
+from packages.chucknorris_bot.bot.app import app, _fetch_joke
 
 _VALID_SECRET = "test-secret"
 
@@ -122,19 +123,19 @@ def test_message_without_text_is_ignored(client):
     mock_send.assert_not_called()
 
 
-# --- _parse_command ---
+# --- parse_command (from core) ---
 
 
 def test_parse_command_strips_botname():
-    assert _parse_command("/random@mybot") == "/random"
+    assert parse_command("/random@mybot") == "/random"
 
 
 def test_parse_command_lowercase():
-    assert _parse_command("/HELP") == "/help"
+    assert parse_command("/HELP") == "/help"
 
 
 def test_parse_command_empty():
-    assert _parse_command("") == ""
+    assert parse_command("") == ""
 
 
 # --- _fetch_joke ---


### PR DESCRIPTION
## Summary

* Both bots (`telegram_bot`, `chucknorris_bot`) had identical code for parsing commands, extracting the webhook body, and validating the secret header. Extracted to `core/sdk/telegram.py` so any future bot gets these for free with a single import.
* `telegram_bot/config.py` was missing `.strip()` on token/secret env vars (chucknorris_bot had already fixed this) — aligned.
* 12 new tests in `core/tests/test_telegram_notifier.py` covering the three new functions.

**New core functions:**
- `parse_command(text)` — strips `@botname`, lowercases, handles empty
- `extract_webhook_update(request)` → `(chat_id, text)`
- `validate_webhook_secret(request, expected)` → `bool`

## Test plan

- [x] `bazel test //core:core_tests` — 57 passed (12 new)
- [x] `bazel test //packages/biwenger_tools/telegram_bot:telegram_bot_tests` — 13 passed
- [x] `bazel test //packages/chucknorris_bot/bot:bot_tests` — 19 passed
- [x] flake8 + black — clean