### PR TITLE
feat(ci): wire chucknorris_bot into deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
       - "packages/biwenger_tools/scraper_job/**"
       - "packages/biwenger_tools/teams_analyzer/**"
       - "packages/biwenger_tools/telegram_bot/**"
+      - "packages/chucknorris_bot/**"
       - "tools/**"
       - ".github/workflows/deploy.yml"
 
@@ -55,6 +56,7 @@ jobs:
       scraper: ${{ steps.filter.outputs.scraper }}
       teams_analyzer: ${{ steps.filter.outputs.teams_analyzer }}
       telegram_bot: ${{ steps.filter.outputs.telegram_bot }}
+      chucknorris_bot: ${{ steps.filter.outputs.chucknorris_bot }}
     steps:
       - uses: actions/checkout@v6
 
@@ -78,6 +80,10 @@ jobs:
               - 'core/**'
               - 'tools/**'
               - 'packages/biwenger_tools/telegram_bot/**'
+            chucknorris_bot:
+              - 'core/**'
+              - 'tools/**'
+              - 'packages/chucknorris_bot/**'
 
   # -------------------------------------------------------
   # 1. Run all tests before any deployment
@@ -103,6 +109,7 @@ jobs:
             //packages/biwenger_tools/scraper_job:scraper_job_tests \
             //packages/biwenger_tools/teams_analyzer:teams_analyzer_tests \
             //packages/biwenger_tools/telegram_bot:telegram_bot_tests \
+            //packages/chucknorris_bot/bot:bot_tests \
             --test_output=streamed --test_arg=-v
 
   # -------------------------------------------------------
@@ -295,12 +302,59 @@ jobs:
           CLOUD_RUN_JOB_NAME=biwenger-teams-analyzer"
 
   # -------------------------------------------------------
+  # 2e. Build and deploy Chuck Norris bot Cloud Run Service
+  # -------------------------------------------------------
+  deploy-chucknorris-bot:
+    name: Deploy Chuck Norris bot service
+    needs: [detect-changes, test]
+    if: needs.detect-changes.outputs.chucknorris_bot == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Configure Docker auth for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
+
+      - name: Set up Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+
+      - name: Build and push Chuck Norris bot image
+        run: |
+          bazel run //packages/chucknorris_bot/bot:push_image_to_gcp \
+            --platforms=//platforms:linux_amd64
+
+      - name: Deploy Chuck Norris bot to Cloud Run
+        run: |
+          gcloud run deploy chucknorris-bot \
+            --image ${{ env.REGISTRY }}/chucknorris_bot \
+            --platform managed \
+            --region ${{ env.REGION }} \
+            --project ${{ env.PROJECT_ID }} \
+            --allow-unauthenticated \
+            --memory=256Mi \
+            --cpu=1 \
+            --update-secrets="\
+          TELEGRAM_BOT_TOKEN=chucknorris-bot-token-regional:latest,\
+          TELEGRAM_WEBHOOK_SECRET=chucknorris-bot-webhook-secret-regional:latest"
+
+  # -------------------------------------------------------
   # 3. Clean up old images once any deploy succeeds
   # -------------------------------------------------------
   cleanup:
     name: Clean up old images
-    needs: [deploy-web, deploy-scraper, deploy-teams-analyzer, deploy-telegram-bot]
-    if: always() && (needs.deploy-web.result == 'success' || needs.deploy-scraper.result == 'success' || needs.deploy-teams-analyzer.result == 'success' || needs.deploy-telegram-bot.result == 'success')
+    needs: [deploy-web, deploy-scraper, deploy-teams-analyzer, deploy-telegram-bot, deploy-chucknorris-bot]
+    if: always() && (needs.deploy-web.result == 'success' || needs.deploy-scraper.result == 'success' || needs.deploy-teams-analyzer.result == 'success' || needs.deploy-telegram-bot.result == 'success' || needs.deploy-chucknorris-bot.result == 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Adds `packages/chucknorris_bot/**` to the `paths:` trigger so CI fires on bot changes
- Adds `chucknorris_bot` output + filter to `detect-changes` (mirrors `telegram_bot` pattern)
- Adds `//packages/chucknorris_bot/bot:bot_tests` to the `test` job
- New `deploy-chucknorris-bot` job: builds OCI image, deploys to Cloud Run Service `chucknorris-bot`, pulls secrets `chucknorris-bot-token-regional` and `chucknorris-bot-webhook-secret-regional`
- Adds `deploy-chucknorris-bot` to `cleanup.needs` and `cleanup.if` so old images are pruned after a successful deploy

## Test plan

- [ ] CI triggers on a push that touches `packages/chucknorris_bot/`
- [ ] `bot_tests` pass in the `test` job
- [ ] `deploy-chucknorris-bot` deploys successfully to Cloud Run
- [ ] `cleanup` runs after deploy