### PR TITLE
chore: upgrade Python 3.12 → 3.13

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install lint tools
         # Pinned to match versions resolved in requirements_lock.txt;

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,15 +13,15 @@ bazel_dep(name = "platforms", version = "1.1.0")
 # --- TOOLCHAINS Y DEPENDENCIAS DE PYTHON ---
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
-    python_version = "3.12",
+    python_version = "3.13",
 )
-use_repo(python, python_toolchain = "python_3_12")
+use_repo(python, python_toolchain = "python_3_13")
 
 # Se utiliza la extensión pip para gestionar las dependencias de Python
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "pypi",
-    python_version = "3.12",
+    python_version = "3.13",
     requirements_lock = "//:requirements_lock.txt",
 )
 use_repo(pip, "pypi")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,7 +32,7 @@ oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 # Imagen base CON TODAS las dependencias preinstaladas (para producción)
 oci.pull(
     name = "python_with_deps",
-    digest = "sha256:a4e1848751ff5f326a2ad10df2c559241e9750907164cf020165aec706432ae5",
+    digest = "sha256:5553373fe4697cd936f56eb9ead8d289d8184aa58e4455d94d23a3bb0a75aeac",
     image = "europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/python-base",
     platforms = [
         "linux/amd64",

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -6,7 +6,7 @@
 # Si añades/quitas una dep en cualquier requirements.txt, regenera el lock
 # y actualiza esta lista (ver docs/operations.md).
 
-FROM python:3.12-slim@sha256:4386a385d81dba9f72ed72a6fe4237755d7f5440c84b417650f38336bbc43117
+FROM python:3.13-slim@sha256:0ee2df98db454606ca92bb7a79d47ff7dc9cc0c8d5901e32eb71e6b5203377b2
 
 RUN pip install --no-cache-dir \
     beautifulsoup4==4.14.3 \

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10,8 +10,8 @@
 - [x] **GitHub Actions secrets** — todos añadidos en el repo
 - [x] **Primer deploy via CI** — disparado tras los primeros pushes a `master`
 - [x] **Eliminar GitHub Secrets obsoletos** — `COMUNICADOS_CSV_URL`, `PALMARES_CSV_URL`, `PARTICIPACION_CSV_URL` borrados (2026-05-04).
-- [ ] **Auditar y rotar SA key** si la del repo es la real (~30min)
-- [ ] **Mover IDs de Drive/Sheets a Secret Manager / env** — actualmente hardcodeados en `packages/biwenger_tools/web/BUILD.bazel:13-19`
+- [x] **Auditar y rotar SA key** — SA key está gitignoreada, nunca se subió. No hay riesgo (2026-05-10).
+- [ ] **Mover IDs de Drive/Sheets a Secret Manager / env** — actualmente hardcodeados en `packages/biwenger_tools/web/BUILD.bazel:13-19` (mueren con la migración Firestore)
 
 ## Técnico
 
@@ -31,9 +31,11 @@
 - [x] **Auto-alineación `/alinear`** — `logic/lineup.py`, greedy sobre 12 formaciones, multi-posición vía `altPositions`, capitán < 3M. `BiwengerClient.set_lineup()` en core.
 - [ ] **Sección VAR en web** — revisar y conectar trigger manual del AI scraper o cron job
 - [ ] **Nuevo proyecto Google para fotos**
+- [x] **Chuck Norris bot** — @ChuckNorrisJokesBot desplegado en Cloud Run, en CI (PR #17, 2026-05-10).
 
 ## Arquitectura (medio plazo)
 
 - [x] **Domain models aplicados** — `LeagueMessage`, `Participation`, `Clausulazo`, `JusticeEntry` con `from_csv_row`/`to_csv_row` ya se usan en scraper (escritura) y web (lectura). El call site del CSV-as-DB queda contenido en una capa: facilita la futura migración a Firestore.
 - [ ] **Migración CSV → Firestore** — los modelos de dominio están listos para que el cambio sea localizado en lecturas/escrituras GCP en lugar de tocar todos los call sites. Sin urgencia, ver project_pitch.md para narrativa.
-- [ ] **Bumps de dependencias** — ver Fase D en `.claude/plans/next_phases.md`. Prioridad: `rules_python` 0.40→2.0 + `platforms` 0.0.10→1.1 (warnings en cada build), luego GH Actions, luego Python libs.
+- [x] **Bumps de dependencias (Phase D)** — todo al día a 2026-05-10. rules_python 2.0, platforms 1.1, GH Actions en major actual, libs Python todas en latest.
+- [ ] **Upgrade Python 3.12 → 3.13** — 3.12 en security-only desde oct 2025. Ver rama `chore/python-313-upgrade` (en curso).


### PR DESCRIPTION
## Summary

- Python 3.12 moved to **security-only** in October 2025 (no more bug fixes). Python 3.13 is the current bugfix-supported release.
- \`MODULE.bazel\`: toolchain + pip_parse updated to \`python_version = "3.13"\`
- \`docker/Dockerfile.base\`: new \`python:3.13-slim\` digest (amd64+arm64)
- \`.github/workflows/deploy.yml\`: lint step uses \`python-version: "3.13"\`
- \`requirements_lock.txt\`: unchanged — all pinned libs already support 3.13
- Rebuilt \`python-base\` image and pushed to Artifact Registry; \`MODULE.bazel\` updated with new multi-arch digest

## Test plan

- [x] 6/6 Bazel test targets pass locally under the new toolchain config
- [x] Lint (flake8 + black) clean
- [ ] CI green on merge