### PR TITLE
feat(web): clausulazos summary + filters on mercado page

### DIFF
--- a/packages/biwenger_tools/web/routes/season.py
+++ b/packages/biwenger_tools/web/routes/season.py
@@ -2,6 +2,7 @@
 
 import ssl
 from dataclasses import asdict
+from datetime import datetime
 from typing import Optional
 
 from flask import Blueprint, Response, g, jsonify, render_template, request
@@ -213,9 +214,28 @@ def mercado(season: str) -> str:
         )
         logger.exception("Error loading mercado.", extra={"season": g.season})
 
+    clausulazos_summary = None
+    if clausulazos:
+        def _parse_fecha(f: str) -> datetime:
+            for fmt in ("%d/%m/%Y", "%Y-%m-%d", "%d-%m-%Y"):
+                try:
+                    return datetime.strptime(f, fmt)
+                except ValueError:
+                    continue
+            return datetime.min
+
+        clausulazos_by_date = sorted(clausulazos, key=lambda c: _parse_fecha(c.fecha), reverse=True)
+        clausulazos_summary = {
+            "total": len(clausulazos),
+            "total_eur": sum(c.precio for c in clausulazos),
+            "max_clausulazo": max(clausulazos, key=lambda c: c.precio),
+            "ultimo": clausulazos_by_date[0],
+        }
+
     return render_template(
         "mercado.html",
         clausulazos=clausulazos,
+        clausulazos_summary=clausulazos_summary,
         tabla_justicia=tabla_justicia,
         error=error,
         active_page="mercado",

--- a/packages/biwenger_tools/web/routes/season.py
+++ b/packages/biwenger_tools/web/routes/season.py
@@ -224,7 +224,9 @@ def mercado(season: str) -> str:
                     continue
             return datetime.min
 
-        clausulazos_by_date = sorted(clausulazos, key=lambda c: _parse_fecha(c.fecha), reverse=True)
+        clausulazos_by_date = sorted(
+            clausulazos, key=lambda c: _parse_fecha(c.fecha), reverse=True
+        )
         clausulazos_summary = {
             "total": len(clausulazos),
             "total_eur": sum(c.precio for c in clausulazos),

--- a/packages/biwenger_tools/web/templates/mercado.html
+++ b/packages/biwenger_tools/web/templates/mercado.html
@@ -48,10 +48,75 @@
 <!-- Clausulazos -->
 <div>
     <h2 class="font-header text-2xl font-bold text-gray-800 mb-4">💸 Historial de Clausulazos</h2>
+    {% if clausulazos_summary %}
+    <!-- Resumen -->
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+        <div class="card p-4 rounded-xl text-center">
+            <p class="text-xs text-gray-500 uppercase tracking-wide">📊 Total</p>
+            <p class="text-2xl font-bold text-gray-800 mt-1">{{ clausulazos_summary.total }}</p>
+        </div>
+        <div class="card p-4 rounded-xl text-center">
+            <p class="text-xs text-gray-500 uppercase tracking-wide">💰 Movido</p>
+            <p class="text-xl font-bold text-green-700 mt-1">
+                {{ "{:,.0f}".format(clausulazos_summary.total_eur / 1000000).replace(",", ".") }} M €
+            </p>
+        </div>
+        <div class="card p-4 rounded-xl text-center">
+            <p class="text-xs text-gray-500 uppercase tracking-wide">🏆 Mayor gasto</p>
+            {% if clausulazos_summary.max_clausulazo %}
+            <p class="text-xl font-bold text-green-700 mt-1">
+                {{ "{:,.0f}".format(clausulazos_summary.max_clausulazo.precio).replace(",", ".") }} €
+            </p>
+            <p class="text-sm font-semibold text-gray-800 mt-0.5">{{ clausulazos_summary.max_clausulazo.equipo_comprador }}</p>
+            <p class="text-xs text-gray-500 mt-0.5">{{ clausulazos_summary.max_clausulazo.jugador }}</p>
+            {% endif %}
+        </div>
+        <div class="card p-4 rounded-xl text-center">
+            <p class="text-xs text-gray-500 uppercase tracking-wide">📅 Último</p>
+            {% if clausulazos_summary.ultimo %}
+            <p class="text-sm font-bold text-gray-800 mt-1">{{ clausulazos_summary.ultimo.fecha }}</p>
+            <p class="text-xs text-gray-500 mt-0.5">{{ clausulazos_summary.ultimo.jugador }}</p>
+            {% endif %}
+        </div>
+    </div>
+    <!-- Filtros -->
+    <div class="card p-4 rounded-xl mb-4">
+        <div class="flex flex-wrap items-center gap-3">
+            <input id="filter-player" type="text" placeholder="🔍 Jugador..."
+                   oninput="applyFilters()"
+                   class="flex-1 min-w-[140px] border border-gray-200 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-green-300">
+            <select id="filter-vendedor" onchange="applyFilters()"
+                    class="border border-gray-200 rounded-lg px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-green-300">
+                <option value="">Todos los vendedores</option>
+                {% for team in clausulazos | map(attribute='equipo_vendedor') | unique | sort %}
+                <option value="{{ team }}">{{ team }}</option>
+                {% endfor %}
+            </select>
+            <select id="filter-comprador" onchange="applyFilters()"
+                    class="border border-gray-200 rounded-lg px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-green-300">
+                <option value="">Todos los compradores</option>
+                {% for team in clausulazos | map(attribute='equipo_comprador') | unique | sort %}
+                <option value="{{ team }}">{{ team }}</option>
+                {% endfor %}
+            </select>
+            <button onclick="clearFilters()"
+                    class="px-3 py-1.5 text-sm rounded-lg bg-gray-100 text-gray-600 hover:bg-gray-200 transition">
+                Limpiar
+            </button>
+            <span id="filter-counter" class="text-sm text-gray-500 ml-auto">
+                {{ clausulazos | length }} de {{ clausulazos | length }}
+            </span>
+        </div>
+    </div>
+    {% endif %}
     {% if clausulazos %}
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" id="clausulazos-grid">
             {% for c in clausulazos %}
-            <div class="card rounded-xl shadow-md p-5 flex flex-col items-center text-center border-t-2 border-green-500">
+            <div class="card rounded-xl shadow-md p-5 flex flex-col items-center text-center border-t-2 border-green-500"
+                 data-clausulazo
+                 data-jugador="{{ c.jugador }}"
+                 data-vendedor="{{ c.equipo_vendedor }}"
+                 data-comprador="{{ c.equipo_comprador }}">
                 <p class="text-xs text-gray-400 mb-2">{{ c.fecha }}</p>
                 <h3 class="text-lg font-bold text-gray-900 mb-3">{{ c.jugador }}</h3>
                 <div class="flex items-center justify-center gap-2 text-sm text-gray-600 mb-3 w-full">
@@ -196,5 +261,36 @@ function renderTabla(mode) {
 function setTablaMode(mode) { renderTabla(mode); }
 
 if (tablaData.length > 0) renderTabla('ataques');
+
+// --- Clausulazos filters ---
+function applyFilters() {
+    const player = document.getElementById('filter-player').value.toLowerCase();
+    const vendedor = document.getElementById('filter-vendedor').value;
+    const comprador = document.getElementById('filter-comprador').value;
+    const cards = document.querySelectorAll('[data-clausulazo]');
+    let visible = 0;
+    cards.forEach(card => {
+        const j = card.dataset.jugador.toLowerCase();
+        const v = card.dataset.vendedor;
+        const c = card.dataset.comprador;
+        const match = (!player || j.includes(player))
+                   && (!vendedor || v === vendedor)
+                   && (!comprador || c === comprador);
+        card.style.display = match ? '' : 'none';
+        if (match) visible++;
+    });
+    const counter = document.getElementById('filter-counter');
+    if (counter) counter.textContent = visible + ' de ' + cards.length;
+}
+
+function clearFilters() {
+    const player = document.getElementById('filter-player');
+    const vendedor = document.getElementById('filter-vendedor');
+    const comprador = document.getElementById('filter-comprador');
+    if (player) player.value = '';
+    if (vendedor) vendedor.value = '';
+    if (comprador) comprador.value = '';
+    applyFilters();
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary

Adds two new UI elements to the `/mercado` page above the clausulazos grid:

**1. Summary row (4 mini-cards)**
- Total clausulazos count
- Total € moved (in millions)
- Biggest transfer: price + buyer team + player name
- Most recent transfer: date + player

**2. Filter panel**
- Text input: filter by player name (case-insensitive substring)
- Dropdown: filter by seller team
- Dropdown: filter by buyer team
- "Limpiar" button resets all filters
- Counter "X de N visibles" updates live

All filtering is client-side JS — no API calls. The summary and filters only appear when `clausulazos` is non-empty; empty state ("No hay clausulazos") is unchanged.

## Implementation
- `routes/season.py`: calculates `clausulazos_summary` dict in Python (most-expensive, most-recent sorted by date)
- `mercado.html`: adds summary cards, filter panel, `data-clausulazo/data-jugador/data-vendedor/data-comprador` attributes on each card, and `applyFilters()`/`clearFilters()` JS functions
- Design follows `DESIGN.md` tokens (card, rounded-xl, green-700 accent)
- Mobile: summary uses `grid-cols-2 sm:grid-cols-4`

## Test plan
- [ ] Summary shows correct totals
- [ ] Filter by player name works (case-insensitive)
- [ ] Filter by vendedor dropdown works
- [ ] Filter by comprador dropdown works
- [ ] Filters combine correctly
- [ ] "Limpiar" resets all filters and shows all cards
- [ ] Counter updates correctly
- [ ] Empty state (no clausulazos) shows no summary/filters — just the existing message
- [ ] Mobile layout doesn't break (Chrome DevTools responsive)