### PR TITLE
chore: consolidate Secret Manager secrets into per-domain JSON

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -207,7 +207,8 @@ jobs:
             --image ${{ env.REGISTRY }}/scraper_job \
             --region ${{ env.REGION }} \
             --project ${{ env.PROJECT_ID }} \
-            --update-env-vars TEMPORADA_ACTUAL=${{ env.TEMPORADA_ACTUAL }}
+            --update-env-vars TEMPORADA_ACTUAL=${{ env.TEMPORADA_ACTUAL }} \
+            --update-secrets="BIWENGER_CREDENTIALS_JSON=biwenger-credentials-regional:latest"
 
   # -------------------------------------------------------
   # 2c. Build and update teams_analyzer Cloud Run Job (only if teams_analyzer changed)
@@ -292,10 +293,7 @@ jobs:
             --allow-unauthenticated \
             --memory=256Mi \
             --cpu=1 \
-            --update-secrets="\
-          TELEGRAM_BOT_TOKEN=telegram-bot-token-regional:latest,\
-          TELEGRAM_CHAT_ID=telegram-chat-id-regional:latest,\
-          TELEGRAM_WEBHOOK_SECRET=telegram-webhook-secret-regional:latest" \
+            --update-secrets="TELEGRAM_BOT_CONFIG_JSON=telegram-bot-config-regional:latest" \
             --set-env-vars="\
           GCP_PROJECT_ID=${{ env.PROJECT_ID }},\
           CLOUD_RUN_REGION=${{ env.REGION }},\
@@ -344,9 +342,7 @@ jobs:
             --allow-unauthenticated \
             --memory=256Mi \
             --cpu=1 \
-            --update-secrets="\
-          TELEGRAM_BOT_TOKEN=chucknorris-bot-token-regional:latest,\
-          TELEGRAM_WEBHOOK_SECRET=chucknorris-bot-webhook-secret-regional:latest"
+            --update-secrets="CHUCKNORRIS_BOT_CONFIG_JSON=chucknorris-bot-config-regional:latest"
 
   # -------------------------------------------------------
   # 3. Clean up old images once any deploy succeeds

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -99,6 +99,8 @@ Commands for running each component.
 
     URL: https://biwenger-summary-pjpqofuevq-no.a.run.app/25-26/
 
+    > **Note:** The footer shows "local" when deploying from a local machine because the `GIT_COMMIT` env var is not set (defaults to `"local"`). CI injects the real value automatically via `${GITHUB_SHA::7}`. This is expected behaviour — it does not indicate a failed deploy.
+
 ### 2\. Scraper Job
 
   * **Run locally:**
@@ -144,9 +146,7 @@ Commands for running each component.
               --image europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/scraper_job \
               --region europe-southwest1 \
               --set-secrets="/gdrive_sa/biwenger-tools-sa.json=biwenger-tools-sa-regional:latest" \
-              --set-secrets="/biwenger_email/biwenger-email=biwenger-email-regional:latest" \
-              --set-secrets="/biwenger_password/biwenger-password=biwenger-password-regional:latest" \
-              --set-secrets="/gdrive_folder_id/gdrive-folder-id=gdrive-folder-id-regional:latest"
+              --update-secrets="BIWENGER_CREDENTIALS_JSON=biwenger-credentials-regional:latest"
         ```
       * **Update the Job (when changing the image or secrets):**
         ```bash

--- a/packages/biwenger_tools/scraper_job/config.py
+++ b/packages/biwenger_tools/scraper_job/config.py
@@ -25,7 +25,9 @@ TEMPORADA_ACTUAL = os.getenv("TEMPORADA_ACTUAL", "25-26")
 _BIWENGER_CREDS = _load_json_secret("BIWENGER_CREDENTIALS_JSON")
 BIWENGER_EMAIL = _BIWENGER_CREDS.get("email") or os.getenv("BIWENGER_EMAIL")
 BIWENGER_PASSWORD = _BIWENGER_CREDS.get("password") or os.getenv("BIWENGER_PASSWORD")
-GDRIVE_FOLDER_ID = _BIWENGER_CREDS.get("gdrive_folder_id") or os.getenv("GDRIVE_FOLDER_ID")
+GDRIVE_FOLDER_ID = (
+    _BIWENGER_CREDS.get("gdrive_folder_id") or os.getenv("GDRIVE_FOLDER_ID")
+)
 
 # --- CONFIGURACIÓN NO CRÍTICA (valores fijos) ---
 LEAGUE_ID = "340703"

--- a/packages/biwenger_tools/scraper_job/config.py
+++ b/packages/biwenger_tools/scraper_job/config.py
@@ -1,3 +1,4 @@
+import json
 import os
 from dotenv import load_dotenv
 
@@ -6,15 +7,25 @@ from core.sdk import biwenger as biwenger_sdk
 # Carga las variables del archivo .env para el desarrollo local
 load_dotenv()
 
+
+def _load_json_secret(env_var: str) -> dict:
+    raw = os.getenv(env_var, "{}")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
 # --- CONFIGURACIÓN DE TEMPORADA ---
 # Para cambiar de temporada: actualizar TEMPORADA_ACTUAL en deploy.yml (env global)
 # o via: gcloud run jobs update ... --update-env-vars TEMPORADA_ACTUAL=26-27
 TEMPORADA_ACTUAL = os.getenv("TEMPORADA_ACTUAL", "25-26")
 
 # --- CONFIGURACIÓN CRÍTICA (leída desde el entorno) ---
-BIWENGER_EMAIL = os.getenv("BIWENGER_EMAIL")
-BIWENGER_PASSWORD = os.getenv("BIWENGER_PASSWORD")
-GDRIVE_FOLDER_ID = os.getenv("GDRIVE_FOLDER_ID")
+_BIWENGER_CREDS = _load_json_secret("BIWENGER_CREDENTIALS_JSON")
+BIWENGER_EMAIL = _BIWENGER_CREDS.get("email") or os.getenv("BIWENGER_EMAIL")
+BIWENGER_PASSWORD = _BIWENGER_CREDS.get("password") or os.getenv("BIWENGER_PASSWORD")
+GDRIVE_FOLDER_ID = _BIWENGER_CREDS.get("gdrive_folder_id") or os.getenv("GDRIVE_FOLDER_ID")
 
 # --- CONFIGURACIÓN NO CRÍTICA (valores fijos) ---
 LEAGUE_ID = "340703"
@@ -32,8 +43,5 @@ BOARD_MESSAGES_URL = biwenger_sdk.league_board_url(LEAGUE_ID)
 CLAUSULAZOS_FILENAME_BASE = "clausulazos"
 TABLA_JUSTICIA_FILENAME_BASE = "tabla_justicia"
 
-# Rutas donde Cloud Run montará los secretos como archivos
-BIWENGER_EMAIL_PATH = "/biwenger_email/biwenger-email"
-BIWENGER_PASSWORD_PATH = "/biwenger_password/biwenger-password"
-GDRIVE_FOLDER_ID_PATH = "/gdrive_folder_id/gdrive-folder-id"
+# Ruta donde Cloud Run monta la Service Account key como archivo (no cambia)
 SERVICE_ACCOUNT_PATH = "/gdrive_sa/biwenger-tools-sa.json"

--- a/packages/biwenger_tools/scraper_job/get_messages.py
+++ b/packages/biwenger_tools/scraper_job/get_messages.py
@@ -18,7 +18,7 @@ from core.sdk.gcp import (
     get_google_service,
     upload_csv_to_drive,
 )
-from core.utils import get_logger, read_secret_from_file
+from core.utils import get_logger
 from packages.biwenger_tools.scraper_job import config
 from packages.biwenger_tools.scraper_job.logic.processing import (
     build_tabla_justicia,
@@ -34,12 +34,10 @@ MADRID_TZ = ZoneInfo("Europe/Madrid")
 
 
 def _read_credentials(cfg) -> tuple[str, str, str]:
-    """Read Biwenger and Drive credentials from secrets or environment variables."""
-    email = read_secret_from_file(cfg.BIWENGER_EMAIL_PATH) or cfg.BIWENGER_EMAIL
-    password = (
-        read_secret_from_file(cfg.BIWENGER_PASSWORD_PATH) or cfg.BIWENGER_PASSWORD
-    )
-    folder_id = read_secret_from_file(cfg.GDRIVE_FOLDER_ID_PATH) or cfg.GDRIVE_FOLDER_ID
+    """Read Biwenger and Drive credentials from environment variables."""
+    email = cfg.BIWENGER_EMAIL
+    password = cfg.BIWENGER_PASSWORD
+    folder_id = cfg.GDRIVE_FOLDER_ID
     if not all([email, password, folder_id]):
         raise ValueError("No se pudieron leer todas las credenciales necesarias.")
     return email, password, folder_id

--- a/packages/biwenger_tools/scraper_job/tests/test_get_messages.py
+++ b/packages/biwenger_tools/scraper_job/tests/test_get_messages.py
@@ -13,8 +13,24 @@ def mock_external_deps():
     """Fixture para mockear servicios externos como Drive y Biwenger."""
     # Las rutas de los patches se actualizan
     with patch(
-        "packages.biwenger_tools.scraper_job.get_messages.read_secret_from_file",
-        return_value="mock_secret",
+        "packages.biwenger_tools.scraper_job.get_messages.config",
+        **{
+            "BIWENGER_EMAIL": "test@example.com",
+            "BIWENGER_PASSWORD": "test_password",
+            "GDRIVE_FOLDER_ID": "mock_folder_id",
+            "SERVICE_ACCOUNT_PATH": "/fake/sa.json",
+            "SCOPES": [],
+            "TEMPORADA_ACTUAL": "25-26",
+            "CLAUSULAZOS_FILENAME_BASE": "clausulazos",
+            "TABLA_JUSTICIA_FILENAME_BASE": "tabla_justicia",
+            "LOGIN_URL": "https://fake-login",
+            "ACCOUNT_URL": "https://fake-account",
+            "ALL_PLAYERS_DATA_URL": "https://fake-players",
+            "LEAGUE_USERS_URL": "https://fake-users",
+            "CLAUSULAZOS_URL": "https://fake-clausulazos",
+            "BOARD_MESSAGES_URL": "https://fake-board",
+            "LEAGUE_ID": "340703",
+        },
     ), patch(
         "packages.biwenger_tools.scraper_job.get_messages.get_google_service"
     ) as mock_gservice, patch(

--- a/packages/biwenger_tools/telegram_bot/config.py
+++ b/packages/biwenger_tools/telegram_bot/config.py
@@ -1,12 +1,24 @@
+import json
 import os
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
-TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
-TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "").strip()
-TELEGRAM_WEBHOOK_SECRET = os.getenv("TELEGRAM_WEBHOOK_SECRET", "").strip()
+
+def _load_json_secret(env_var: str) -> dict:
+    raw = os.getenv(env_var, "{}")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
+_TELEGRAM_CFG = _load_json_secret("TELEGRAM_BOT_CONFIG_JSON")
+
+TELEGRAM_BOT_TOKEN = (_TELEGRAM_CFG.get("bot_token") or os.getenv("TELEGRAM_BOT_TOKEN", "")).strip()
+TELEGRAM_CHAT_ID = (_TELEGRAM_CFG.get("chat_id") or os.getenv("TELEGRAM_CHAT_ID", "")).strip()
+TELEGRAM_WEBHOOK_SECRET = (_TELEGRAM_CFG.get("webhook_secret") or os.getenv("TELEGRAM_WEBHOOK_SECRET", "")).strip()
 
 GCP_PROJECT_ID = os.getenv("GCP_PROJECT_ID", "biwenger-tools")
 CLOUD_RUN_REGION = os.getenv("CLOUD_RUN_REGION", "europe-southwest1")

--- a/packages/biwenger_tools/telegram_bot/config.py
+++ b/packages/biwenger_tools/telegram_bot/config.py
@@ -16,9 +16,15 @@ def _load_json_secret(env_var: str) -> dict:
 
 _TELEGRAM_CFG = _load_json_secret("TELEGRAM_BOT_CONFIG_JSON")
 
-TELEGRAM_BOT_TOKEN = (_TELEGRAM_CFG.get("bot_token") or os.getenv("TELEGRAM_BOT_TOKEN", "")).strip()
-TELEGRAM_CHAT_ID = (_TELEGRAM_CFG.get("chat_id") or os.getenv("TELEGRAM_CHAT_ID", "")).strip()
-TELEGRAM_WEBHOOK_SECRET = (_TELEGRAM_CFG.get("webhook_secret") or os.getenv("TELEGRAM_WEBHOOK_SECRET", "")).strip()
+TELEGRAM_BOT_TOKEN = (
+    _TELEGRAM_CFG.get("bot_token") or os.getenv("TELEGRAM_BOT_TOKEN", "")
+).strip()
+TELEGRAM_CHAT_ID = (
+    _TELEGRAM_CFG.get("chat_id") or os.getenv("TELEGRAM_CHAT_ID", "")
+).strip()
+TELEGRAM_WEBHOOK_SECRET = (
+    _TELEGRAM_CFG.get("webhook_secret") or os.getenv("TELEGRAM_WEBHOOK_SECRET", "")
+).strip()
 
 GCP_PROJECT_ID = os.getenv("GCP_PROJECT_ID", "biwenger-tools")
 CLOUD_RUN_REGION = os.getenv("CLOUD_RUN_REGION", "europe-southwest1")

--- a/packages/chucknorris_bot/bot/config.py
+++ b/packages/chucknorris_bot/bot/config.py
@@ -1,8 +1,20 @@
+import json
 import os
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
-TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
-TELEGRAM_WEBHOOK_SECRET = os.getenv("TELEGRAM_WEBHOOK_SECRET", "").strip()
+
+def _load_json_secret(env_var: str) -> dict:
+    raw = os.getenv(env_var, "{}")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
+_CHUCKNORRIS_CFG = _load_json_secret("CHUCKNORRIS_BOT_CONFIG_JSON")
+
+TELEGRAM_BOT_TOKEN = (_CHUCKNORRIS_CFG.get("bot_token") or os.getenv("TELEGRAM_BOT_TOKEN", "")).strip()
+TELEGRAM_WEBHOOK_SECRET = (_CHUCKNORRIS_CFG.get("webhook_secret") or os.getenv("TELEGRAM_WEBHOOK_SECRET", "")).strip()

--- a/packages/chucknorris_bot/bot/config.py
+++ b/packages/chucknorris_bot/bot/config.py
@@ -16,5 +16,9 @@ def _load_json_secret(env_var: str) -> dict:
 
 _CHUCKNORRIS_CFG = _load_json_secret("CHUCKNORRIS_BOT_CONFIG_JSON")
 
-TELEGRAM_BOT_TOKEN = (_CHUCKNORRIS_CFG.get("bot_token") or os.getenv("TELEGRAM_BOT_TOKEN", "")).strip()
-TELEGRAM_WEBHOOK_SECRET = (_CHUCKNORRIS_CFG.get("webhook_secret") or os.getenv("TELEGRAM_WEBHOOK_SECRET", "")).strip()
+TELEGRAM_BOT_TOKEN = (
+    _CHUCKNORRIS_CFG.get("bot_token") or os.getenv("TELEGRAM_BOT_TOKEN", "")
+).strip()
+TELEGRAM_WEBHOOK_SECRET = (
+    _CHUCKNORRIS_CFG.get("webhook_secret") or os.getenv("TELEGRAM_WEBHOOK_SECRET", "")
+).strip()


### PR DESCRIPTION
## Summary

Consolidates 8 individual GCP secrets → 3 per-domain JSON secrets, leaving the SA key unchanged.

| Secret nuevo | Contenido JSON | Sustituye a |
|---|---|---|
| `biwenger-credentials-regional` | `{"email": "...", "password": "...", "gdrive_folder_id": "..."}` | `biwenger-email-regional`, `biwenger-password-regional`, `gdrive-folder-id-regional` |
| `telegram-bot-config-regional` | `{"bot_token": "...", "chat_id": "...", "webhook_secret": "..."}` | `telegram-bot-token-regional`, `telegram-chat-id-regional`, `telegram-webhook-secret-regional` |
| `chucknorris-bot-config-regional` | `{"bot_token": "...", "webhook_secret": "..."}` | `chucknorris-bot-token-regional`, `chucknorris-bot-webhook-secret-regional` |
| `biwenger-tools-sa-regional` | SA key JSON — **no cambia** | (sin cambio) |

Result: **9 secrets → 4 secrets**

## Code changes
- `telegram_bot/config.py`, `chucknorris_bot/bot/config.py`, `scraper_job/config.py` — `_load_json_secret()` helper; individual getenv calls now fall back to the old vars (backward compat for local .env)
- `scraper_job/get_messages.py` — `_read_credentials()` now reads from config attrs (env vars) instead of mounted files
- `scraper_job/tests/test_get_messages.py` — updated mock to patch config directly
- `deploy.yml` — telegram/chucknorris secrets consolidated; scraper job update now passes `BIWENGER_CREDENTIALS_JSON`
- `docs/operations.md` — updated `gcloud run jobs create` command

## ⚠️ Before merging: manual steps required

The new secrets must exist in GCP before this PR can be deployed. Run these commands (you need `secretmanager.secrets.create` permission):

```bash
# 1. Read current values
EMAIL=$(gcloud secrets versions access latest --secret=biwenger-email-regional)
PASSWORD=$(gcloud secrets versions access latest --secret=biwenger-password-regional)
FOLDER=$(gcloud secrets versions access latest --secret=gdrive-folder-id-regional)

# 2. Create biwenger-credentials-regional
echo "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\",\"gdrive_folder_id\":\"$FOLDER\"}" | \
  gcloud secrets create biwenger-credentials-regional \
    --replication-policy="user-managed" --locations=europe-southwest1 --data-file=-

# 3. Read telegram values
BOT_TOKEN=$(gcloud secrets versions access latest --secret=telegram-bot-token-regional)
CHAT_ID=$(gcloud secrets versions access latest --secret=telegram-chat-id-regional)
WEBHOOK=$(gcloud secrets versions access latest --secret=telegram-webhook-secret-regional)

# 4. Create telegram-bot-config-regional
echo "{\"bot_token\":\"$BOT_TOKEN\",\"chat_id\":\"$CHAT_ID\",\"webhook_secret\":\"$WEBHOOK\"}" | \
  gcloud secrets create telegram-bot-config-regional \
    --replication-policy="user-managed" --locations=europe-southwest1 --data-file=-

# 5. Read chucknorris values
CN_TOKEN=$(gcloud secrets versions access latest --secret=chucknorris-bot-token-regional)
CN_WEBHOOK=$(gcloud secrets versions access latest --secret=chucknorris-bot-webhook-secret-regional)

# 6. Create chucknorris-bot-config-regional
echo "{\"bot_token\":\"$CN_TOKEN\",\"webhook_secret\":\"$CN_WEBHOOK\"}" | \
  gcloud secrets create chucknorris-bot-config-regional \
    --replication-policy="user-managed" --locations=europe-southwest1 --data-file=-
```

Also update your local `.env` files:
- Replace `BIWENGER_EMAIL=...`, `BIWENGER_PASSWORD=...`, `GDRIVE_FOLDER_ID=...` with `BIWENGER_CREDENTIALS_JSON={"email":"...","password":"...","gdrive_folder_id":"..."}`
- Replace `TELEGRAM_BOT_TOKEN=...`, `TELEGRAM_CHAT_ID=...`, `TELEGRAM_WEBHOOK_SECRET=...` with `TELEGRAM_BOT_CONFIG_JSON={"bot_token":"...","chat_id":"...","webhook_secret":"..."}`

## Post-merge checklist (after validating in prod for 2+ days)
- [ ] Delete `biwenger-email-regional`
- [ ] Delete `biwenger-password-regional`
- [ ] Delete `gdrive-folder-id-regional`
- [ ] Delete `telegram-bot-token-regional`
- [ ] Delete `telegram-chat-id-regional`
- [ ] Delete `telegram-webhook-secret-regional`
- [ ] Delete `chucknorris-bot-token-regional`
- [ ] Delete `chucknorris-bot-webhook-secret-regional`