### PR TITLE
fix: apply black formatting to season.py

### DIFF
--- a/packages/biwenger_tools/web/routes/season.py
+++ b/packages/biwenger_tools/web/routes/season.py
@@ -216,6 +216,7 @@ def mercado(season: str) -> str:
 
     clausulazos_summary = None
     if clausulazos:
+
         def _parse_fecha(f: str) -> datetime:
             for fmt in ("%d/%m/%Y", "%Y-%m-%d", "%d-%m-%Y"):
                 try:


### PR DESCRIPTION
Black formatting check failed on master after merging PR #24. This applies the required formatting to `packages/biwenger_tools/web/routes/season.py`.