### PR TITLE
docs: update next_phases, translate DESIGN.md to English, clear TODO notes

### DIFF
--- a/.claude/plans/next_phases.md
+++ b/.claude/plans/next_phases.md
@@ -4,47 +4,53 @@ This file is the entry point for any session continuing work in this repo.
 Reads in 3 minutes; tells you what's done, what's next, and which decisions
 are already taken.
 
-## State on 2026-05-10
+## State on 2026-05-13
 
-- **`master`**: clean. PRs #15–#20 merged.
+- **`master`**: clean. PRs #21–#27 merged. CI green.
 - **JP API**: alive, token unchanged.
 - **All packages in CI**: web, scraper_job, teams_analyzer, telegram_bot, chucknorris_bot.
 - **Python**: 3.13 (PR #18).
-- **Deuda técnica**: prácticamente cero. No hay work pendiente urgente.
+- **Open PR**: #25 — secrets consolidation (requires manual GCP secret creation before merging).
 
-## What shipped this sprint
+## What shipped this sprint (2026-05-13)
 
-### Chuck Norris Bot ✅ (PR #17)
-- `packages/chucknorris_bot/bot` — Python/Flask rewrite del bot original de 2015 (Node.js/Heroku).
-- Cloud Run Service `chucknorris-bot`, europe-southwest1, proyecto biwenger-tools.
-- Bot: @ChuckNorrisJokesBot. Landing page dark-mode. CI wired.
+### Skills layout standardisation ✅ (PR #21)
+- Shell scripts moved into `scripts/` subdirs within each skill folder.
+- Affected: `check-deps/`, `rpi-common/` (shared by rpi-plan, rpi-implement, rpi-research).
 
-### Python 3.13 ✅ (PR #18)
-- Toolchain, Dockerfile.base (nueva imagen pushed), deploy.yml, digest MODULE.bazel actualizados.
+### check-gcp-costs.sh v2 ✅ (PRs #23, #26, #27)
+- Full rewrite covering Storage, Artifact Registry, Cloud Run Services/Jobs,
+  Secret Manager, Cloud Scheduler, Logging.
+- Summary table with OK/WARN/OVER status and free-tier percentages.
+- bash 3.2 compatible (macOS default shell — no `declare -A`).
 
-### VAR panel — scraper on-demand ✅ (PR #19)
-- `POST /admin/run-scraper` lanza `biwenger-scraper-data` Cloud Run Job vía ADC (roles/run.developer ya en la SA).
-- Panel rediseñado: 4 cards (header, scraper controls, ficheros, sistema).
-- SA: `biwenger-tools-sa@biwenger-tools.iam.gserviceaccount.com`, gitignoreada, no rotación necesaria.
+### season-rollover skill update ✅ (PR #22)
+- Documents that teams_analyzer/telegram_bot/chucknorris_bot don't use TEMPORADA_ACTUAL.
+- Added Step 2b: auto-generate palmarés CSV via `fetch_palmares.py`.
+- New script: `.claude/skills/season-rollover/scripts/fetch_palmares.py`.
 
-### Web UI 2.0 ✅ (PR #20)
-- Sticky nav con hamburger en móvil. Season selector como pill en desktop.
-- Nueva sección `/mercado` (Clausulazos + Tabla de Justicia, split de Salseo).
-- Salseo simplificado a 2 tabs (Crónicas + Datos). Búsqueda con botón ✕ y contador.
-- Participación: columna Total, medallas 🥇🥈🥉, barra de progreso, cards en móvil.
-- Tabla de Justicia: filas expandibles (click = desglose quién atacó a quién).
-- Lloros Awards: auto-carga primera tab. Reglamento: acordeón. Palmarés: badge dorado campeón.
-- VAR link en footer siempre visible. 23 tests, lint limpio, CI verde.
+### Mercado summary + filters ✅ (PR #24)
+- Summary cards: total clausulazos, € movido, mayor gasto (buyer+player), último.
+- Filter panel: text search + buyer/seller dropdowns + clear button + counter.
+- Client-side JS, no extra requests.
 
 ---
 
 ## Pending work
 
-### 1. Firestore migration (~16h, $0/mes) — DEFERRED
-La única tarea grande pendiente. Deferred indefinidamente por el usuario (2026-05-10).
-Domain models en `core/domain/models.py` ya mapean directo a Firestore.
+### 1. Secrets consolidation — PR #25 (blocked on manual GCP step)
+Before merging #25, create the 4 consolidated secrets in GCP Secret Manager:
+- `biwenger-credentials-regional` — JSON: `{"email": "...", "password": "...", "gdrive_folder_id": "..."}`
+- `telegram-bot-config-regional` — JSON: `{"token": "...", "chat_id": "...", "webhook_secret": "..."}`
+- `chucknorris-bot-config-regional` — JSON: `{"token": "...", "webhook_secret": "..."}`
 
-Estructura de colecciones decidida:
+Once created: merge PR #25, then delete the 9 old individual secrets.
+
+### 2. Firestore migration (~16h, $0/mes) — DEFERRED
+Deferred indefinitely by the user (2026-05-10).
+Domain models in `core/domain/models.py` already map directly to Firestore.
+
+Agreed collection structure:
 ```
 comunicados/{season}/messages/{id_hash}
 clausulazos/{season}/transfers/{auto_id}
@@ -53,34 +59,39 @@ participacion/{season}/authors/{autor}
 palmares/{auto_id}
 ```
 
-Orden de ataque cuando se retome:
+Attack order when resumed:
 1. `core/sdk/firestore.py` — CRUD helpers, ADC auth
-2. `scraper_job` — escribir a Firestore en vez de CSV → Drive
-3. `web` — leer de Firestore en vez de Drive CSVs
-4. Borrar secrets `gdrive-folder-id-regional` y `biwenger-tools-sa-regional`
+2. `scraper_job` — write to Firestore instead of CSV → Drive
+3. `web` — read from Firestore instead of Drive CSVs
+4. Delete secrets `gdrive-folder-id-regional` and `biwenger-tools-sa-regional`
 
-### 2. Nuevo proyecto Google para fotos (sin urgencia)
-Mencionado como TODO pero sin spec. Sin blockers técnicos.
+### 3. Opus doc review (future)
+Pass Opus over all MDs, docs, READMEs, diagrams across the repo.
+No urgency — user-initiated when ready.
+
+### 4. New GCP project for photos (no spec yet)
+Mentioned as TODO, no blockers. Waiting for spec.
 
 ---
 
 ## Closed / won't do
 
-- **Auditar y rotar SA key** — gitignoreada, nunca subida. No hay riesgo.
-- **Mover IDs de Drive/Sheets a Secret Manager** — mueren con Firestore.
-- **Phase D dependencies** — todo al día (2026-05-10).
+- **Audit and rotate SA key** — gitignored, never pushed. No risk.
+- **Move Drive/Sheets IDs to Secret Manager** — dies with Firestore migration.
+- **Phase D dependencies** — up to date (2026-05-10).
 
 ---
 
 ## Decisions already taken (don't reopen)
 
-- Telegram bot → Cloud Run Service dedicado, no el Flask web.
-- Output (teams, market) → PNG via `sendPhoto`. No texto/CSV.
-- Auto-lineup capitán → precio < 3M estricto, mayor SF. Fallback: más barato con precio conocido.
-- Chuck Norris bot → mismo proyecto GCP (`biwenger-tools`). Secrets regionales.
-- Webhook helpers → `core/sdk/telegram.py`, no duplicados por bot.
-- Firestore migration → deferred; stack CSV/Drive permanece hasta que se retome explícitamente.
-- Web UI → Tailwind CDN + vanilla JS, sin frameworks. Misma paleta verde #38a169.
+- Telegram bot → dedicated Cloud Run Service, not the Flask web.
+- Output (teams, market) → PNG via `sendPhoto`. No text/CSV.
+- Auto-lineup captain → price < 3M strict, highest SF. Fallback: cheapest with known price.
+- Chuck Norris bot → same GCP project (`biwenger-tools`). Regional secrets.
+- Webhook helpers → `core/sdk/telegram.py`, not duplicated per bot.
+- Firestore migration → deferred; CSV/Drive stack stays until explicitly resumed.
+- Web UI → Tailwind CDN + vanilla JS, no frameworks. Same green palette #38a169.
+- `.claude/plans/` → git-tracked (plans reference code paths, lifecycle cleanup on merge).
 
 ---
 
@@ -90,7 +101,7 @@ Mencionado como TODO pero sin spec. Sin blockers técnicos.
 2. `git checkout master && git pull --ff-only`
 3. Read `CLAUDE.md` (root) + `.claude/CLAUDE.md`.
 4. Read this file.
-5. No hay "next action" urgente — preguntar al usuario qué quiere hacer.
+5. Check open PRs: `gh pr list --state open`.
 
 ```bash
 # Full test sweep

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -38,3 +38,15 @@
 - [ ] **Migración CSV → Firestore** — los modelos de dominio están listos para que el cambio sea localizado en lecturas/escrituras GCP en lugar de tocar todos los call sites. Sin urgencia, ver project_pitch.md para narrativa.
 - [x] **Bumps de dependencias (Phase D)** — todo al día a 2026-05-10. rules_python 2.0, platforms 1.1, GH Actions en major actual, libs Python todas en latest.
 - [x] **Upgrade Python 3.12 → 3.13** — hecho en PR #18 (2026-05-10). Toolchain, Dockerfile.base y MODULE.bazel actualizados.
+
+
+
+
+
+- revisar costes: /Users/jorge/Projects/lillorepo/scripts/check-gcp-costs.sh es una version temprana no esta adaptada a los ultimos cambios
+- secretos con json para tener menos, revisa todos los secretos actuales y veamos si podemos implementar algo rollo guardar un json secreto por proyecto y con varias clave valor separadas ((por evitar el limite de secretos antes de corbarte))
+- arquitectura skills: que si tienen script tengan una carpeta scripts o si tienen referencia references
+- skill nueva temporada revisar -> /Users/jorge/Projects/lillorepo/.claude/skills/season-rollover
+
+
+pasarle opus a revisar todo mds docs readmes diagramas... todo el repo!

--- a/packages/biwenger_tools/web/DESIGN.md
+++ b/packages/biwenger_tools/web/DESIGN.md
@@ -69,60 +69,121 @@ components:
 
 ## Overview
 
-Sport dashboard con personalidad — mezcla de marcador de fútbol y tablón de anuncios de una liga de amigos. El tono es desenfadado pero el layout es limpio. El verde acento remite al campo de juego; los grises oscuros aportan legibilidad sin resultar corporativos.
+Sport dashboard with personality — part football scoreboard, part private league noticeboard. Tone is informal but the layout is clean. The green accent references the pitch; dark greys give readability without feeling corporate.
 
-La app no es un producto comercial, es una intranet de liga privada. El diseño puede ser directo y denso en información; no hay que vender nada.
+This is not a commercial product — it's a private league intranet. The design can be dense and direct; there's nothing to sell.
 
 ## Colors
 
-El verde `#38a169` es el único color "vivo" de la paleta y debe usarse con criterio:
+`#38a169` is the only "live" colour in the palette and must be used sparingly:
 
-- **Primary (#2d3748):** Texto principal, titulares de contenido, iconos de UI.
-- **Secondary (#4a5568):** Texto secundario, labels, metadatos.
-- **Muted (#718096):** Fechas, pies de nota, contenido de menor jerarquía.
-- **Accent (#38a169):** Indicador de nav activo, botones de acción confirmada, números de página activos, highlights de autor. Único color "vivo" — no usar como decoración.
-- **Background (#f7fafc):** Base de página, levemente off-white para reducir fatiga visual frente a blanco puro.
-- **Surface (#ffffff):** Cards y paneles elevados sobre el fondo.
-- **Border (#e2e8f0):** Separadores y bordes de card — sutil, no prominente.
+- **Primary (#2d3748):** Main text, content headings, UI icons.
+- **Secondary (#4a5568):** Secondary text, labels, metadata.
+- **Muted (#718096):** Dates, footnotes, lower-hierarchy content.
+- **Accent (#38a169):** Active nav indicator, confirmed-action buttons, active page numbers, author highlights. The only live colour — don't use it as decoration.
+- **Background (#f7fafc):** Page base, slightly off-white to reduce eye fatigue vs. pure white.
+- **Surface (#ffffff):** Cards and panels elevated above the background.
+- **Border (#e2e8f0):** Dividers and card borders — subtle, not prominent.
 
 ## Typography
 
-Dos familias, roles bien separados:
+Two families, clearly separated roles:
 
-- **Oswald** para el logotipo `LLOROS LEAGUE` y títulos de sección con alto impacto. Siempre en peso 500 o 700, nunca por debajo. El tracking amplio (0.05em) en el heading principal refuerza el carácter deportivo.
-- **Roboto** para todo el cuerpo de texto: comunicados, tablas, formularios, metadatos. Legible en densidades de información alta.
+- **Oswald** for the `LLOROS LEAGUE` logotype and high-impact section headings. Always weight 500 or 700, never lighter. Wide tracking (0.05em) on the main heading reinforces the sport character.
+- **Roboto** for all body text: messages, tables, forms, metadata. Readable at high information density.
 
-No mezclar las dos familias en el mismo bloque de texto.
+Never mix both families in the same text block.
 
 ## Layout
 
-- **Max-width:** `max-w-4xl` (56rem) centrado — suficiente para tablas de datos sin resultar excesivamente ancho en desktop.
-- **Padding de página:** `p-4` en móvil, `p-8` en desktop.
-- La cabecera usa un layout de tres columnas en desktop (espaciador / título centrado / selector de temporada) que colapsa a centrado en móvil.
-- Las cards usan `shadow-md` en reposo y `shadow-lg` en hover para dar profundidad sin ser excesivas.
+- **Max-width:** `max-w-4xl` (56rem) centred — enough for data tables without becoming too wide on desktop.
+- **Page padding:** `p-4` on mobile, `p-8` on desktop.
+- Cards use `shadow-md` at rest and `shadow-lg` on hover for depth without excess.
 
 ## Components
 
 ### Card
 
-La unidad básica de contenido. Fondo blanco, borde sutil `#e2e8f0`, radio `rounded-xl` (12px), padding `p-6`. Todas las páginas de contenido usan cards como contenedor principal.
+The basic content unit. White background, subtle `#e2e8f0` border, `rounded-xl` radius (12px), `p-6` padding. All content pages use cards as their main container.
 
-### Nav
+### Sticky Nav (UI 2.0)
 
-Barra horizontal bajo el header. Los links inactivos son `#4a5568`; el activo usa `#2d3748` en negrita con un subrayado de 2px en `#38a169`. No usar color de fondo en el item activo — el subrayado es el indicador.
+`base.html` implements a sticky bar (`position: sticky; top: 0; z-index: 20`) with two layers:
+
+- **Mobile bar** (`md:hidden`): logo + hamburger button with two SVGs (menu / close) toggled via `classList.toggle('hidden')`. When open, shows a vertical link panel with season pills below.
+- **Desktop nav** (`hidden md:flex`, 48px tall): logo + `.nav-link` items + season pill dropdown. The active link uses `border-bottom: 2px solid #38a169`; inactive links use `border-bottom: 2px solid transparent` to prevent layout shift.
+
+Don't use background colour on the active item — the underline is the indicator. The season selector on desktop is a dropdown with `stopPropagation` and click-outside close.
 
 ### Search Input
 
-Input de ancho completo con `focus:ring-2 focus:ring-green-500`. El foco debe ser claramente visible.
+Full-width input with `focus:ring-2 focus:ring-green-500`. The focus ring must be clearly visible.
 
 ### Pagination
 
-Botones con borde, radio `rounded-md`. La página activa invierte colores: fondo `#38a169`, texto blanco.
+Bordered buttons, `rounded-md` radius. The active page inverts colours: `#38a169` background, white text.
+
+## JS Template Conventions
+
+Vanilla JS only — no frameworks. Standardised patterns for consistency across templates:
+
+### `originalHtml` — restore server-rendered content
+
+When an interaction (search, tab switch) replaces Jinja2-rendered content, store the original HTML on `DOMContentLoaded` and restore it on clear:
+
+```js
+const originalHtml = {};
+document.addEventListener('DOMContentLoaded', () => {
+    originalHtml.tab = document.getElementById('container').innerHTML;
+});
+function clearSearch() {
+    container.innerHTML = originalHtml.tab || '';
+}
+```
+
+Never reconstruct in JS what Jinja2 already rendered correctly.
+
+### Expandable table rows
+
+Add `data-row-idx` to each `<tr>` and use `insertAdjacentElement('afterend', detailTr)` to insert the detail row. Close any previously open detail before opening a new one (avoids multiple open rows at once).
+
+```js
+function toggleRowDetail(idx) {
+    document.querySelectorAll('[data-detail-row]').forEach(r => r.remove());
+    const anchor = document.querySelector(`[data-row-idx="${idx}"]`);
+    if (anchor) anchor.insertAdjacentElement('afterend', buildDetailTr());
+}
+```
+
+On mobile use a `<div id="card-detail-{i}">` toggled with `classList.toggle('hidden')` instead of inserting rows.
+
+### `AbortController` for fetch with timeout
+
+```js
+const controller = new AbortController();
+const tid = setTimeout(() => controller.abort(), 5000);
+const res = await fetch(url, { signal: controller.signal });
+clearTimeout(tid);
+```
+
+### Passing server data to JS
+
+Use `{{ data | tojson }}` in a `<script>` block at the top of the JS section. Never hardcode data in JS or make an extra fetch if Jinja2 already has the data available.
+
+```html
+<script>
+const DATA = {{ rows | tojson }};
+</script>
+```
+
+### Accordion
+
+Button with `data-target="section-id"` + collapsible div. First item open by default; the rest start with class `hidden`. The chevron uses `classList.toggle('rotate-180', isOpen)`.
 
 ## Do's and Don'ts
 
-- **Do:** Usar `accent` para un único elemento interactivo activo por contexto.
-- **Do:** Mantener la densidad de información alta — esta app la necesita.
-- **Don't:** Usar Oswald en peso < 500.
-- **Don't:** Añadir nuevos colores sin actualizar este archivo primero.
-- **Don't:** Usar sombras más pronunciadas que `shadow-lg` — el diseño es plano con sombra funcional.
+- **Do:** Use `accent` for a single active interactive element per context.
+- **Do:** Keep information density high — this app needs it.
+- **Don't:** Use Oswald at weight < 500.
+- **Don't:** Add new colours without updating this file first.
+- **Don't:** Use shadows heavier than `shadow-lg` — the design is flat with functional shadow.


### PR DESCRIPTION
## Summary

- `next_phases.md`: updated to reflect 2026-05-13 state — marks PRs #21–#27 as shipped, documents PR #25 (secrets) as the only pending item, adds Opus doc review and photos project as future items
- `multi_task_improvements.md`: deleted — all 5 tasks merged, plan is complete
- `DESIGN.md`: translated Spanish → English; added "Sticky Nav (UI 2.0)" and "JS Template Conventions" sections documenting patterns introduced in PR #20 and #24
- `TODO.md`: cleared in-session task notes (now tracked as PRs/plans)