### PR TITLE
fix(bots): rebuild chucknorris and telegram_bot images with JSON secret config

### DIFF
--- a/packages/biwenger_tools/telegram_bot/config.py
+++ b/packages/biwenger_tools/telegram_bot/config.py
@@ -14,6 +14,8 @@ def _load_json_secret(env_var: str) -> dict:
         return {}
 
 
+# Production: TELEGRAM_BOT_CONFIG_JSON = {"bot_token": "...", "chat_id": "...", "webhook_secret": "..."}
+# Local dev: individual env vars TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID / TELEGRAM_WEBHOOK_SECRET as fallback.
 _TELEGRAM_CFG = _load_json_secret("TELEGRAM_BOT_CONFIG_JSON")
 
 TELEGRAM_BOT_TOKEN = (

--- a/packages/chucknorris_bot/bot/config.py
+++ b/packages/chucknorris_bot/bot/config.py
@@ -14,6 +14,8 @@ def _load_json_secret(env_var: str) -> dict:
         return {}
 
 
+# Production: CHUCKNORRIS_BOT_CONFIG_JSON = {"bot_token": "...", "webhook_secret": "..."}
+# Local dev: individual env vars TELEGRAM_BOT_TOKEN / TELEGRAM_WEBHOOK_SECRET as fallback.
 _CHUCKNORRIS_CFG = _load_json_secret("CHUCKNORRIS_BOT_CONFIG_JSON")
 
 TELEGRAM_BOT_TOKEN = (


### PR DESCRIPTION
Images for both bots were never rebuilt after PR #25 (secrets consolidation) because that CI run failed at lint before reaching the deploy step.

The running images still have the old config.py that reads individual env vars (TELEGRAM_BOT_TOKEN, TELEGRAM_WEBHOOK_SECRET, etc.), which were removed from Cloud Run config as part of the consolidation. Result: bots start but have empty credentials → webhook validation fails with 401.

This PR adds comments documenting the secret structure, which touches the package files and forces the CI to rebuild both images with the correct JSON-secret config.