### PR TITLE
fix(bots): shorten config comments to pass flake8 E501

### DIFF
--- a/packages/biwenger_tools/telegram_bot/config.py
+++ b/packages/biwenger_tools/telegram_bot/config.py
@@ -14,8 +14,8 @@ def _load_json_secret(env_var: str) -> dict:
         return {}
 
 
-# Production: TELEGRAM_BOT_CONFIG_JSON = {"bot_token": "...", "chat_id": "...", "webhook_secret": "..."}
-# Local dev: individual env vars TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID / TELEGRAM_WEBHOOK_SECRET as fallback.
+# Production: TELEGRAM_BOT_CONFIG_JSON (keys: bot_token, chat_id, webhook_secret)
+# Local dev: TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID / TELEGRAM_WEBHOOK_SECRET fallback.
 _TELEGRAM_CFG = _load_json_secret("TELEGRAM_BOT_CONFIG_JSON")
 
 TELEGRAM_BOT_TOKEN = (

--- a/packages/chucknorris_bot/bot/config.py
+++ b/packages/chucknorris_bot/bot/config.py
@@ -14,8 +14,8 @@ def _load_json_secret(env_var: str) -> dict:
         return {}
 
 
-# Production: CHUCKNORRIS_BOT_CONFIG_JSON = {"bot_token": "...", "webhook_secret": "..."}
-# Local dev: individual env vars TELEGRAM_BOT_TOKEN / TELEGRAM_WEBHOOK_SECRET as fallback.
+# Production: CHUCKNORRIS_BOT_CONFIG_JSON (keys: bot_token, webhook_secret)
+# Local dev: TELEGRAM_BOT_TOKEN / TELEGRAM_WEBHOOK_SECRET fallback.
 _CHUCKNORRIS_CFG = _load_json_secret("CHUCKNORRIS_BOT_CONFIG_JSON")
 
 TELEGRAM_BOT_TOKEN = (


### PR DESCRIPTION
Fixes E501 in comments added in PR #32 (89–104 chars, limit is 88).