### PR TITLE
feat(skills): sync Google Cloud skills via local script

### DIFF
--- a/.claude/skills/GOOGLE-SKILLS-LICENSE.md
+++ b/.claude/skills/GOOGLE-SKILLS-LICENSE.md
@@ -1,0 +1,13 @@
+# Google Skills — License Notice
+
+The `google-*` skills in this directory are sourced from the official Google
+Agent Skills repository:
+
+  https://github.com/google/skills
+
+Licensed under the Apache License 2.0:
+
+  https://github.com/google/skills/blob/main/LICENSE
+
+They are synced via `scripts/sync-google-skills.sh`. Run that script to check
+for upstream changes or to install/remove skills.

--- a/.claude/skills/google-cloud-recipe-auth/SKILL.md
+++ b/.claude/skills/google-cloud-recipe-auth/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: google-cloud-recipe-auth
+description: Provides expert guidance on authenticating and authorizing to Google Cloud services and APIs, covering human users, service identities, Application Default Credentials (ADC), and best practices for secure access.
+---
+
+# Authenticating to Google Cloud
+
+[Authentication](https://docs.cloud.google.com/docs/authentication) is the
+process of proving **who you are**. In Google Cloud, you represent a
+**Principal** (an identity like a user or a service). This is the first step
+before [Authorization](https://docs.cloud.google.com/iam/docs/overview)
+(determining **what you can do**).
+
+## Authentication
+
+### Clarifying Questions for the Agent
+
+Before providing a specific solution, clarify the following with the user:
+
+1.  **Who or what is authenticating?** (A human developer, a local script, or an
+    application running in production?)
+2.  **Where is the code running?** (Local laptop, [Compute
+    Engine](https://docs.cloud.google.com/compute/docs),
+    [GKE](https://docs.cloud.google.com/kubernetes-engine/docs), [Cloud
+    Run](https://docs.cloud.google.com/run/docs), or another cloud like
+    AWS/Azure?)
+3.  **What is the target?** (A Google Cloud API like Storage/BigQuery, or a
+    custom application you built?)
+4.  **Are you using a high-level client library?** (e.g., Python, Go, Node.js
+    libraries usually handle ADC automatically.)
+
+---
+
+## Human Authentication
+
+For users to access Google Cloud, they need an identity that Google Cloud can
+recognize.
+
+### Types of User Identities
+
+Google Cloud supports several ways to configure identities for your internal
+workforce (developers, administrators, employees):
+
+*   **[Google-Managed
+    Accounts](https://docs.cloud.google.com/iam/docs/user-identities#google-accounts)**:
+    You can use Cloud Identity or Google Workspace to create managed user
+    accounts. These are called managed accounts because your organization
+    controls their lifecycle and configuration.
+*   **[Federation using Cloud Identity or Google
+    Workspace](https://docs.cloud.google.com/iam/docs/user-identities#synced-federation)**:
+    You can federate identities to allow users to use their existing identity
+    and credentials to sign in to Google services. Users authenticate against an
+    external identity provider (IdP), but you must keep accounts synchronized
+    into Google Cloud using tools like Google Cloud Directory Sync (GCDS) or an
+    external authoritative source like Active Directory or Microsoft Entra ID.
+*   **[Workforce Identity
+    Federation](https://docs.cloud.google.com/iam/docs/user-identities#workforce)**:
+    This lets you use an external IdP to authenticate and authorize a workforce
+    using IAM directly. Unlike standard federation, you do not need to
+    synchronize user identities from your existing IdP to Google Cloud
+    identities. It supports syncless, attribute-based single sign-on.
+
+### Methods of Access for Developers and Administrators
+
+Used for interacting with Google Cloud resources and APIs during development and
+management.
+
+*   **[Google Cloud Console](https://console.cloud.google.com/)**: The primary
+    web interface. You authenticate using your Google Account (Gmail or [Google
+    Workspace](https://workspace.google.com/)).
+*   **[gcloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk) (`gcloud
+    auth login`)**: Used to authenticate the CLI itself so you can run
+    management commands (e.g., `gcloud compute instances list`). It uses a
+    **Credential** (like an OAuth 2.0 refresh token) stored locally.
+*   **Local Development with [App Default Credentials
+    (ADC)](https://docs.cloud.google.com/docs/authentication/application-default-credentials)
+    (`gcloud auth application-default login`)**: This is different from CLI
+    auth. It creates a local JSON file that Google Cloud **Client Libraries**
+    (Python, Java, etc.) use to act as "you" when you run code on your laptop.
+*   **[Service Account
+    Impersonation](https://docs.cloud.google.com/docs/authentication/use-service-account-impersonation)**:
+    For security reasons, developers should avoid downloading Service Account
+    keys entirely. Instead, they should authenticate as humans (`gcloud auth
+    login`) and use Service Account Impersonation to run CLI commands or
+    generate short-lived credentials. This is a critical best practice for local
+    development and troubleshooting.
+
+### For End-Users and Customers
+
+Used when a human (who is not a developer) needs to access a web application
+you've deployed on Google Cloud. Note: These are distinct from workforce
+identities.
+
+*   **[Identity-Aware Proxy (IAP)](https://docs.cloud.google.com/iap/docs)**:
+    Acts as a central authorization layer for web applications. It intercepts
+    web requests and verifies the user's identity (via Google Workspace, Cloud
+    Identity, or external providers) before letting them reach the application.
+    It's often used to protect internal apps without a VPN, or secure customer
+    portals.
+*   **[Identity
+    Platform](https://docs.cloud.google.com/identity-platform/docs)**: A
+    Customer Identity and Access Management (CIAM) solution for adding consumer
+    sign-in (email/password, phone, social) directly into the code of your
+    custom-built applications.
+
+---
+
+## Service-to-Service Authentication
+
+When code runs in production, it should use a **Service Account** rather than a
+human user account.
+
+### Service Accounts and Service Agents
+
+*   **[Service
+    Account](https://docs.cloud.google.com/iam/docs/service-account-overview)**:
+    A special identity intended for non-human users. It's like a "robot
+    identity" with its own email address.
+*   **[Service Agent](https://docs.cloud.google.com/iam/docs/service-agents)**:
+    A service account managed by Google that allows a service (like Pub/Sub) to
+    access your resources on your behalf.
+
+### Best Practice: Attaching Service Accounts
+
+Instead of using **Service Account Keys** (dangerous JSON files), you should
+**attach** a custom service account to the Google Cloud resource. The resource's
+environment then provides a **Token** (a short-lived digital object) via a local
+metadata server.
+
+*   **[Compute
+    Engine](https://docs.cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances)**:
+    Assign a service account during VM creation.
+*   **[Cloud
+    Run](https://docs.cloud.google.com/run/docs/securing/service-identity)**:
+    Assign a service account in the service configuration.
+
+### Special Cases & Advanced Topics
+
+#### Kubernetes Engine (GKE)
+
+Use **[Workload Identity Federation for
+GKE](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)**
+to map Kubernetes identities to IAM principal identifiers. This grants specific
+Kubernetes workloads access to specific Google Cloud APIs. [Learn more
+here.](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#configure-authz-principals)
+
+#### External Workloads ([Workload Identity Federation](https://docs.cloud.google.com/iam/docs/workload-identity-federation))
+
+For code running **outside** Google Cloud (e.g., AWS, Azure, or on-prem), do not
+use keys. Instead, use Workload Identity Federation to exchange an external
+token (like an AWS IAM role) for a short-lived Google Cloud access token.
+
+#### [API Keys](https://docs.cloud.google.com/docs/authentication/api-keys)
+
+API keys are encrypted strings used for public data (e.g., Google Maps) or
+simplified access like **[Vertex AI Express
+Mode](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview)**,
+which allows fast testing of Gemini models without complex setup. Both humans
+and services (e.g., Cloud Run-based AI agent) can use API keys, for the services
+that support it.
+
+Note: API keys should be
+[restricted](https://docs.cloud.google.com/api-keys/docs/add-restrictions-api-keys)
+to specific APIs and projects to minimize security risks. Store API keys in a
+secrets manager like [Secret
+Manager](https://docs.cloud.google.com/secret-manager/docs) to prevent
+accidental exposure.
+
+#### OAuth 2.0 Access Scopes
+
+While IAM is the modern way to handle authorization, legacy Compute Engine VMs
+and GKE node pools still rely on **Access Scopes** alongside IAM. If a VM's
+scope is restricted, the attached service account will fail to make API calls
+even if it has the correct IAM permissions. Check this first if attached service
+accounts are failing unexpectedly.
+
+#### Short-Lived Credentials
+
+The underlying mechanism for impersonation and secure service-to-service
+communication is the **IAM Service Account Credentials API**. This API generates
+short-lived access tokens, OpenID Connect (OIDC) ID tokens, or self-signed JSON
+Web Tokens (JWTs) dynamically, removing the need for static credentials.
+
+---
+
+## Authorization
+
+After Authentication, Google Cloud uses **[Identity and Access Management
+(IAM)](https://docs.cloud.google.com/iam/docs/overview)** to determine what the
+authenticated principal can do.
+
+*   **Allow Policy**: A record that binds a **Principal** to a **Role** on a
+    **Resource**.
+*   **[Predefined
+    Roles](https://docs.cloud.google.com/iam/docs/understanding-roles)**:
+    Prebuilt roles like `roles/storage.objectViewer` or
+    `roles/bigquery.dataEditor`. **Always try to use these first.**
+*   **[Custom
+    Roles](https://docs.cloud.google.com/iam/docs/creating-custom-roles)**:
+    User-defined collections of specific permissions if predefined roles are too
+    broad.
+
+---
+
+## Examples
+
+### Human-to-Service (Local Python Development)
+
+1.  **Authn**: Run `gcloud auth application-default login` to create local
+    credentials (ADC).
+2.  **Authz**: Grant your email the `roles/storage.objectViewer` role on a
+    bucket.
+3.  **Code**: Use the Python `storage.Client()`. It automatically finds your
+    local credentials via ADC. *Note: ADC searches in a specific order—first
+    checking the `GOOGLE_APPLICATION_CREDENTIALS` environment variable, then the
+    local gcloud JSON file, and finally the attached service account metadata
+    server.*
+
+### Service-to-Service (Cloud Run to Cloud SQL)
+
+1.  **Authn**: Attach a custom Service Account to your Cloud Run service.
+2.  **Authz**: Grant that Service Account the `roles/cloudsql.client` role on
+    the project.
+3.  **Code**: The Cloud Run environment provides the token automatically to the
+    connection driver.
+
+### Calling a Custom Application ([OIDC](https://docs.cloud.google.com/docs/authentication/get-id-token))
+
+When calling a private Cloud Run service from another service, the caller
+generates a Google-signed **OpenID Connect (OIDC) ID Token** and passes it in
+the `Authorization: Bearer <TOKEN>` header.
+
+---
+
+## Validation Checklist
+
+-   [ ] Is the user running code locally? Suggest `gcloud auth
+    application-default login` or **Service Account Impersonation**.
+-   [ ] Is the user attempting to use Service Account keys locally? Strongly
+    discourage this and recommend impersonation.
+-   [ ] Is the user running in production? Recommend attaching a custom,
+    least-privilege service account, NOT using keys.
+-   [ ] Is the user relying on the Compute Engine Default Service Account?
+    Recommend creating a custom service account instead.
+-   [ ] Is the user running on another cloud? Recommend Workload Identity
+    Federation.
+-   [ ] Is the user calling a custom app? Recommend OIDC ID Tokens.
+-   [ ] Has the user restricted their API Keys? Check for appropriate [API Key
+    Restrictions](https://docs.cloud.google.com/docs/authentication/api-keys#adding-application-restrictions).
+
+## References
+
+-   [Authentication Overview](https://docs.cloud.google.com/docs/authentication)
+-   [User Identities](https://docs.cloud.google.com/iam/docs/user-identities)
+-   [Application Default Credentials](https://docs.cloud.google.com/docs/authentication/provide-credentials-adc)
+-   [Service Account Best Practices](https://docs.cloud.google.com/iam/docs/best-practices-service-accounts)
+
+

--- a/.claude/skills/google-cloud-run-basics/SKILL.md
+++ b/.claude/skills/google-cloud-run-basics/SKILL.md
@@ -1,0 +1,376 @@
+---
+name: cloud-run-basics
+description: >-
+  Manages Cloud Run services, jobs, and worker pools. Use when you need to deploy applications
+  responding to HTTP requests (services), run event-triggered or scheduled tasks (jobs),
+  or handle always-on pull-based background processing (worker pools).
+---
+
+# Cloud Run Basics
+
+Cloud Run is a fully managed application platform for running your code,
+function, or container on top of Google's highly scalable infrastructure. It
+abstracts away infrastructure management, providing three primary resource
+types:
+
+1.  **Services:** Responds to HTTP requests sent to a unique and stable
+    endpoint, using stateless instances that autoscale based on a variety of key
+    metrics, also responds to events and functions.
+2.  **Jobs:** Executes parallelizable tasks that are executed manually, or on a
+    schedule, and run to completion.
+3.  **Worker pools:** Handles always-on background workloads such as pull-based
+    workloads, for example, Kafka consumers, Pub/Sub pull queues, or RabbitMQ
+    consumers.
+
+## Prerequisites
+
+1.  Enable the Cloud Run Admin API and Cloud Build APIs:
+
+    ```bash
+    gcloud services enable run.googleapis.com cloudbuild.googleapis.com --quiet
+    ```
+
+1.  If you are under a domain restriction organization policy [restricting](https://docs.cloud.google.com/organization-policy/restrict-domains)
+   unauthenticated invocations for your project, you will need to access your
+    deployed service as described under [Testing private
+    services](https://docs.cloud.google.com/run/docs/triggering/https-request#testing-private).
+
+### Required roles
+
+You need the following roles to deploy your Cloud Run resource:
+
+*   Cloud Run Admin (`roles/run.admin`) on the project
+*   Cloud Run Source Developer (`roles/run.sourceDeveloper`) on the project
+*   Service Account User (`roles/iam.serviceAccountUser`) on the service
+    identity
+*   Logs Viewer (`roles/logging.viewer`) on the project
+
+Cloud Build automatically uses the Compute Engine default service account as the
+default Cloud Build service account to build your source code and Cloud Run
+resource, unless you override this behavior.
+
+For Cloud Build to build your sources, grant the Cloud Build service account the
+Cloud Run Builder (`roles/run.builder`) role on your project:
+
+```bash
+gcloud projects add-iam-policy-binding PROJECT_ID \
+    --member=serviceAccount:SERVICE_ACCOUNT_EMAIL_ADDRESS \
+    --role=roles/run.builder \
+    --quiet
+```
+
+Replace `PROJECT_ID` with your Google Cloud project ID and
+`SERVICE_ACCOUNT_EMAIL_ADDRESS` with the email address of the Cloud Build
+service account.
+
+## Deploy a Cloud Run service
+
+You can deploy your service to Cloud Run by using a container image or deploy
+directly from source code using a single Google Cloud CLI command.
+
+> **CRITICAL RULE:** Any deployed code MUST listen on 0.0.0.0 (not 127.0.0.1)
+> and use the injected $PORT environment variable (defaults to 8080), or it will
+> crash on boot.
+
+### Deploy a container image to Cloud Run
+
+Cloud Run imports your container image during deployment. Cloud Run keeps this
+copy of the container image as long as it is used by a serving revision.
+Container images are not pulled from their container repository when a new Cloud
+Run instance is started.
+
+### Supported container images
+
+You can directly use container images stored in the [Artifact
+Registry](https://docs.cloud.google.com/artifact-registry/docs/overview), or
+[Docker Hub](https://hub.docker.com/). Google recommends the use of Artifact
+Registry since Docker Hub images are
+[cached](https://docs.cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images)
+for up to one hour.
+
+You can use container images from other public or private registries (like JFrog
+Artifactory, Nexus, or GitHub Container Registry), by setting up an [Artifact
+Registry remote
+repository](https://docs.cloud.google.com/artifact-registry/docs/repositories/remote-repo).
+
+You should only consider [Docker Hub](https://hub.docker.com/) for deploying
+popular container images such as [Docker Official
+Images](https://docs.docker.com/docker-hub/official_images/) or [Docker
+Sponsored OSS images](https://docs.docker.com/docker-hub/dsos-program/). For
+higher availability, Google recommends deploying these Docker Hub images using
+an [Artifact Registry remote
+repository](https://docs.cloud.google.com/artifact-registry/docs/repositories/remote-repo).
+
+To deploy a container image, run the following command:
+
+```bash
+    gcloud run deploy SERVICE_NAME \
+        --image IMAGE_URL \
+        --region us-central1 \
+        --allow-unauthenticated \
+        --quiet
+```
+
+Replace the following:
+
+*   SERVICE_NAME: the name of the service you want to deploy to. Service names
+    must be 49 characters or less and must be unique per region and project. If
+    the service does not exist yet, this command creates the service during the
+    deployment. You can omit this parameter entirely, but you will be prompted
+    for the service name if you omit it.
+*   IMAGE_URL: a reference to the container image, for example,
+    `us-docker.pkg.dev/cloudrun/container/hello:latest`. If you use Artifact
+    Registry, the repository REPO_NAME must already be created. The URL follows
+    the format of `LOCATION-docker.pkg.dev/PROJECT_ID/REPO_NAME/PATH:TAG`. Note
+    that if you don't supply the `--image` flag, the deploy command will attempt
+    to deploy from source code.
+
+### Deploy from source code
+
+There are two different ways to deploy your service from source:
+
+*   Deploy from source with build (default): This option uses Google Cloud's
+    buildpacks and Cloud Build to automatically build container images from your
+    source code without having to install Docker on your machine or set up
+    buildpacks or Cloud Build. By default, Cloud Run uses the default machine
+    type provided by Cloud Build.
+
+    *   To deploy from source with automatic base image updates enabled, run the
+        following command:
+
+         ```bash
+         gcloud run deploy SERVICE_NAME --source . \
+         --base-image BASE_IMAGE \
+         --automatic-updates \
+         --quiet
+         ```
+
+        Cloud Run only supports automatic base images that use [Google Cloud's
+        buildpacks base
+        images](https://docs.cloud.google.com/docs/buildpacks/base-images).
+
+        *   To deploy from source using a Dockerfile, run the following command:
+
+         ```bash
+          gcloud run deploy SERVICE_NAME --source . --quiet
+         ```
+            When you provide a Dockerfile, Cloud Build runs it in the cloud, and
+            deploys the service.
+
+*   Deploy from source without build (Preview): This option deploys artifacts
+    directly to Cloud Run, bypassing the Cloud Build step. This allows for rapid
+    deployment times. To deploy from source without build, run the following
+    command:
+
+    ```bash
+    gcloud beta run deploy SERVICE_NAME \
+     --source APPLICATION_PATH \
+     --no-build \
+     --base-image=BASE_IMAGE \
+     --command=COMMAND \
+     --args=ARG \
+     --quiet
+    ```
+
+    Replace the following:
+
+    *   SERVICE_NAME: the name of your Cloud Run service.
+    *   APPLICATION_PATH: the location of your application on the local file
+        system.
+    *   BASE_IMAGE: the [runtime base image](https://docs.cloud.google.com/run/docs/configuring/services/runtime-base-images#how_to_obtain_base_images)
+    you want to use for your application. For example,
+        `us-central1-docker.pkg.dev/serverless-runtimes/google-24-full/runtimes/nodejs24`.
+        You can also deploy a pre-compiled binary without configuring additional
+        language-specific runtime components using the OS only base image, such
+    as `osonly24`.
+    *   COMMAND: the command that the container starts up with.
+    *   ARG: an argument you send to the container command. If you use multiple
+    arguments, specify each on its own line.
+
+    For examples on deploying from source without build, see [Examples of
+        deploying from source without
+        build](https://docs.cloud.google.com/run/docs/deploying-source-code#examples-without-build).
+
+## Create and execute a Cloud Run job
+
+To create a new job, run the following command:
+
+```bash
+gcloud run jobs create JOB_NAME --image IMAGE_URL OPTIONS --quiet
+```
+
+Alternatively, use the deploy command:
+
+```bash
+gcloud run jobs deploy JOB_NAME --image IMAGE_URL OPTIONS --quiet
+```
+
+Replace the following:
+
+*   JOB_NAME: the name of the job you want to create. If you omit this
+    parameter, you will be prompted for the job name when you run the command.
+*   IMAGE_URL: a reference to the container image—for example,
+    `us-docker.pkg.dev/cloudrun/container/job:latest`.
+
+*   Optionally, replace OPTIONS with any of the following flags:
+
+    *   `--tasks`: Accepts integers greater or equal to 1. Defaults to 1;
+        maximum is 10,000. Each task is provided the environment variables
+        `CLOUD_RUN_TASK_INDEX` with a value between 0 and the number of tasks
+        minus 1, along with `CLOUD_RUN_TASK_COUNT`, which is the number of
+        tasks.
+    *   `--max-retries`: The number of times a failed task is retried. Once any
+        task fails beyond this limit, the entire job is marked as failed. For
+        example, if set to 1, a failed task will be retried once, for a total of
+        two attempts. The default is 3. Accepts integers from 0 to 10.
+    *   `--task-timeout`: Accepts a duration like "2s". Defaults to 10 minutes;
+        maximum is 168 hours (7 days). For tasks using GPUs, the maximum
+        available timeout is 1 hour.
+    *   `--parallelism`: The maximum number of tasks that can execute in
+        parallel. By default, tasks will be started as quickly as possible in
+        parallel.
+    *   --execute-now: If set, immediately after the job is created, a job
+        execution is started. Equivalent to calling `gcloud run jobs create`
+        followed by `gcloud run jobs execute`.
+
+    In addition to these preceding options, you also specify more configuration
+    such as environment variables or memory limits.
+
+For a full list of available options when creating a job, refer to the [`gcloud
+run jobs
+create`](https://docs.cloud.google.com/sdk/gcloud/reference/run/jobs/create)
+command line documentation.
+
+Wait for the job creation to finish. You'll see a success message upon a
+successful completion.
+
+To execute an existing job, run the following command:
+
+```bash
+gcloud run jobs execute JOB_NAME --quiet
+```
+
+If you want the command to wait until the execution completes, run the following
+command:
+
+```bash
+gcloud run jobs execute JOB_NAME --wait --region=REGION --quiet
+```
+
+Replace the following:
+
+*   JOB_NAME: the name of the job.
+*   REGION: the region in which the resource can be found. For example,
+    `europe-west1`. Alternatively, set the `run/region` property.
+
+## Deploy a worker pool
+
+You can deploy a Cloud Run worker pool using container images or deploy directly
+from the source.
+
+### Deploy a container image
+
+You can specify a container image with a tag (for example,
+`us-docker.pkg.dev/my-project/container/my-image:latest`) or with an exact
+digest (for example,
+`us-docker.pkg.dev/my-project/container/my-image@sha256:41f34ab970ee...`).
+
+### Supported container images
+
+You can directly use container images stored in the [Artifact
+Registry](https://docs.cloud.google.com/artifact-registry/docs/overview), or
+[Docker Hub](https://hub.docker.com/). Google recommends the use of Artifact
+Registry since Docker Hub images are
+[cached](https://docs.cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images)
+for up to one hour.
+
+You can use container images from other public or private registries (like JFrog
+Artifactory, Nexus, or GitHub Container Registry), by setting up an [Artifact
+Registry remote
+repository](https://docs.cloud.google.com/artifact-registry/docs/repositories/remote-repo).
+
+You should only consider [Docker Hub](https://hub.docker.com/) for deploying
+popular container images such as [Docker Official
+Images](https://docs.docker.com/docker-hub/official_images/) or [Docker
+Sponsored OSS images](https://docs.docker.com/docker-hub/dsos-program/). For
+higher availability, Google recommends deploying these Docker Hub images using
+an [Artifact Registry remote
+repository](https://docs.cloud.google.com/artifact-registry/docs/repositories/remote-repo).
+
+To deploy a container image, run the following command:
+
+```bash
+gcloud run worker-pools deploy WORKER_POOL_NAME --image IMAGE_URL --quiet
+```
+
+Replace the following:
+
+*   WORKER_POOL_NAME: the name of the worker pool you want to deploy to. If the
+  worker pool does not exist yet, this command creates the worker pool during
+    the deployment. You can omit this parameter entirely, but you will be
+    prompted for the worker pool name if you omit it.
+
+*   IMAGE_URL: a reference to the container image that contains the worker pool,
+    such as `us-docker.pkg.dev/cloudrun/container/worker-pool:latest`. Note that
+    if you don't supply the `--image` flag, the deploy command attempts to
+    deploy from source code.
+
+Wait for the deployment to finish. Upon successful completion, Cloud Run
+displays a success message along with the revision information about the
+deployed worker pool.
+
+### Deploy a worker pool from source
+
+You can deploy a new worker pool or worker pool revision to Cloud Run directly
+from source code using a single gcloud CLI command, `gcloud run worker-pools`
+deploy with the `--source` flag.
+
+The deploy command defaults to source deployment if you don't supply the
+`--image` or `--source` flags.
+
+Behind the scenes, this command uses [Google Cloud's
+buildpacks](https://docs.cloud.google.com/docs/buildpacks/overview) and Cloud
+Build to automatically build container images from your source code without
+having to install Docker on your machine or set up buildpacks or Cloud Build. By
+default, Cloud Run uses the default machine type provided by Cloud Build.
+
+To deploy a worker pool from source, run the following command:
+
+```bash
+gcloud run worker-pools deploy WORKER_POOL_NAME --source . --quiet
+```
+
+Replace `WORKER_POOL_NAME` with the name you want for your worker pool.
+
+### What to do if a deployment fails:
+
+1.  **IAM/Permission Error:** Read
+    [iam-security.md](references/iam-security.md).
+2.  **Crash on Boot / Healthcheck failed:** Fetch the logs immediately using
+    `gcloud logging read "resource.labels.service_name=SERVICE_NAME" --limit=20`
+    to find the exact runtime error.
+3.  **Native Dependency Error (Node/Python):** If using `--no-build`, switch to
+    `--source .` (Buildpacks) to compile native extensions properly for Linux.
+
+## Reference Directory
+
+-   [Core Concepts](references/core-concepts.md): Services vs. Jobs vs.
+    Worker pools, resource model, and auto-scaling behavior for services.
+
+-   [CLI Usage](references/cli-usage.md): Essential `gcloud run` commands for
+    deployment and management.
+
+-   [Client Libraries](references/client-library-usage.md): Using Google
+    Cloud client libraries to interact with Cloud Run.
+
+-   [MCP Usage](references/mcp-usage.md): Using the Cloud Run remote MCP
+    server.
+
+-   [Infrastructure as Code](references/iac-usage.md): Terraform examples for
+    services, jobs, worker pools, and IAM bindings.
+
+-   [IAM & Security](references/iam-security.md): Roles, service identities,
+    and ingress/egress controls.
+
+*If you need product information not found in these references, use the
+    Developer Knowledge MCP server `search_documents` tool.*

--- a/.claude/skills/google-cloud-run-basics/references/cli-usage.md
+++ b/.claude/skills/google-cloud-run-basics/references/cli-usage.md
@@ -1,0 +1,119 @@
+# Cloud Run CLI
+
+Use the `gcloud run` command to manage your Cloud Run applications.
+
+## Basic Syntax
+
+```bash
+gcloud run [GROUP] [COMMAND] [FLAGS]
+```
+
+## Essential Commands
+
+### Cloud Run service
+
+-   **Deploy a service from an image:**
+
+    ```bash
+    gcloud run deploy my-service \
+        --image us-docker.pkg.dev/cloudrun/container/hello:latest \
+        --quiet
+    ```
+
+-   **Deploy from source code:**
+
+    ```bash
+    gcloud run deploy my-service --source . --quiet
+    ```
+
+-   **Deploy a Cloud Run function:** 
+
+    ```bash
+    gcloud run deploy my-service
+    --source . --function example-hello --base-image go126 --region us-central1 --quiet
+    ```
+
+-   **List services:**
+
+    ```bash
+    gcloud run services list --quiet
+    ```
+
+-   **Update traffic split:**
+
+    ```bash
+    gcloud run services update-traffic my-service --to-revisions=REV1=50,REV2=50 --quiet
+    ```
+
+### Cloud Run job
+
+-   **Create a job:**
+
+    ```bash
+    gcloud run jobs create my-job \
+      --image us-docker.pkg.dev/cloudrun/container/job:latest \
+      --quiet
+    ```
+
+-   **Execute a job:**
+
+    ```bash
+    gcloud run jobs execute my-job --quiet
+    ```
+
+-   **List jobs:** `gcloud run jobs list`
+
+-   **List job executions:**
+
+    ```bash
+    gcloud run executions list --job my-job
+    ```
+
+### Cloud Run worker pools
+
+-   **Deploy a worker pool from an image:**
+
+    ```bash
+    gcloud run worker-pools deploy my-workerpool \
+      --image us-docker.pkg.dev/cloudrun/container/worker-pool:latest \
+      --quiet
+    ```
+
+-   **Deploy from source code:**
+
+    ```bash
+    gcloud run worker-pools deploy my-workerpool --source . --quiet
+    ```
+
+-   **List worker pools:**
+
+    ```bash
+    gcloud run worker-pools list --region us-central1 --quiet
+    ```
+
+-   **Configure scaling (manual):**
+
+    ```bash
+    gcloud run worker-pools deploy my-workerpool --instances=5 \
+      --image us-docker.pkg.dev/cloudrun/container/worker-pool:latest \
+      --quiet
+    ```
+
+### Configuration and logs
+
+-   **View more details about a service:** `gcloud run services describe my-service`
+
+-   **View logs:**
+
+    ```bash
+    gcloud logging read "resource.type=cloud_run_revision AND \
+      resource.labels.service_name=my-service" \
+      --quiet
+    ```
+
+## Common Flags
+
+-   `--region`: The region where the service or job is located.
+-   `--allow-unauthenticated`: Makes the service publicly accessible.
+
+-   `--no-allow-unauthenticated`: Restricts access to authenticated users only.

--- a/.claude/skills/google-cloud-run-basics/references/client-library-usage.md
+++ b/.claude/skills/google-cloud-run-basics/references/client-library-usage.md
@@ -1,0 +1,146 @@
+# Cloud Run Client Libraries
+
+Google Cloud client libraries provide an idiomatic way to manage Cloud Run
+resources programmatically.
+
+## Getting Started
+
+Ensure you have the Google Cloud SDK installed and authenticated.
+[Install Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
+
+### Python
+
+- **Installation:**
+
+  ```bash
+  pip install --upgrade google-cloud-run
+  ```
+
+- **Usage Example:**
+
+  ```python
+  from google.cloud import run_v2
+  client = run_v2.ServicesClient()
+  request = run_v2.ListServicesRequest(
+    parent="projects/my-project/locations/us-central1"
+  )
+  page_result = client.list_services(request=request)
+  ```
+
+- [Python Reference](https://docs.cloud.google.com/python/docs/reference/run/latest)
+
+### Java
+
+- **Maven Dependency:**
+
+  ```xml
+  <dependencyManagement>
+  <dependencies>
+   <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>libraries-bom</artifactId>
+      <version>26.79.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+   </dependency>
+  </dependencies>
+  </dependencyManagement>
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-run</artifactId>
+  </dependency>
+  ```
+
+- **Usage Example:**
+
+  ```java
+  try (ServicesClient servicesClient = ServicesClient.create()) {
+    ListServicesRequest request = ListServicesRequest.newBuilder()
+        .setParent(LocationName.of("my-project", "us-central1").toString())
+        .build();
+    for (Service element : servicesClient.listServices(request).iterateAll()) {
+      System.out.println(element.getName());
+    }
+  }
+  ```
+
+- [Java Reference](https://docs.cloud.google.com/java/docs/reference/google-cloud-run/latest/overview)
+
+### Node.js (TypeScript)
+
+- **Installation:**
+
+  ```bash
+  npm install @google-cloud/run
+  ```
+
+- **Usage Example:**
+
+  ```typescript
+  import {ServicesClient} from '@google-cloud/run';
+  const client = new ServicesClient();
+  const [services] = await client.listServices({
+    parent: 'projects/my-project/locations/us-central1',
+  });
+  ```
+
+- [Node.js Reference](https://googleapis.dev/nodejs/run/latest/index.html)
+
+### Go
+
+- **Installation:**
+
+  ```bash
+  go get cloud.google.com/go/run/apiv2
+  ```
+
+- **Usage Example:**
+
+  ```go
+  package main
+
+  import (
+  	"context"
+  	"fmt"
+  	"log" // Import the log package
+
+  	run "cloud.google.com/go/run/apiv2"
+  	runpb "cloud.google.com/go/run/apiv2/runpb"
+  	"google.golang.org/api/iterator"
+  )
+
+  func main() {
+  	ctx := context.Background()
+  	client, err := run.NewServicesClient(ctx)
+  	if err != nil {
+  		// Log the error and exit if the client can't be created
+  		log.Fatalf("Failed to create Cloud Run Services client: %v", err)
+  	}
+  	defer client.Close()
+
+  	req := &runpb.ListServicesRequest{
+  		Parent: "projects/my-project/locations/us-central1", // Remember to replace my-project
+  	}
+  	it := client.ListServices(ctx, req)
+
+  	fmt.Println("Cloud Run Services:")
+  	for {
+  		resp, err := it.Next()
+  		if err == iterator.Done {
+  			break // Finished iterating successfully
+  		}
+  		if err != nil {
+  			// Log the error and exit if iteration fails
+  			log.Fatalf("Error iterating services: %v", err)
+  		}
+  		fmt.Println(resp.GetName())
+  	}
+  }
+  ```
+
+- [Go Reference](https://docs.cloud.google.com/go/docs/reference/cloud.google.com/go/run/latest)
+
+## Source Code Samples
+
+For more examples across languages, visit the
+[Cloud Run Code Samples](https://cloud.google.com/run/docs/samples).

--- a/.claude/skills/google-cloud-run-basics/references/core-concepts.md
+++ b/.claude/skills/google-cloud-run-basics/references/core-concepts.md
@@ -1,0 +1,134 @@
+# Cloud Run core concepts
+
+Cloud Run is a fully managed application platform for running your code,
+function, or container on top of Google's highly scalable infrastructure. On
+Cloud Run, your code can run as a service, job, or worker pool. All of these
+resource types are running sandboxed container instances in the same execution
+environment and can integrate with Google Cloud services.
+
+## Services vs. Jobs vs. Worker pools
+
+-   **Cloud Run services:** Used for code that handles requests or events (e.g.,
+    web apps, APIs). They provide an HTTPS endpoint and automatically scale
+    based on traffic.
+
+-   **Cloud Run jobs:** Used for code that performs a specific task and then
+    exits (e.g., data processing, database migrations). They can run a single
+    task or an array of parallel tasks.
+
+-   **Cloud Run worker pools:** Designed for continuous, non-HTTP, pull-based
+    background processing (e.g., Kafka consumers).
+
+## Resource model
+
+Cloud Run organizes resources as follows:
+
+1.  **Service** The top-level resource. You can deploy a service from a
+    container, repository, or source code.
+                    1.  **Revision:** An immutable snapshot of a service's
+                        configuration and container image. Each service
+                        deployment creates a new revision.
+                    1.  **Service instances:** The running container that
+                        processes requests. Each service revision receiving
+                        requests is automatically scaled to the number of
+                        instances needed to handle all these requests.
+                    1.  **Cloud Run functions**: Deploy functions as Cloud Run
+                        services. You can deploy single-purpose functions that
+                        respond to events emitted from your cloud infrastructure
+                        and services
+
+1.  **Job**: Executes one or more containers to completion. A job consists of
+    one or multiple independent tasks that are executed in parallel in a given
+    job execution.
+
+1.  **Worker pools**: If your code processes workloads from an external source
+    but not from an HTTP request, such as pulling work from a message queue, you
+    can deploy it to a Cloud Run worker pool .
+
+## Autoscaling for Cloud Run services
+
+Cloud Run services scale automatically based on:
+
+-   **Request concurrency:** The number of concurrent requests per instance.
+-   **CPU utilization:**: The average CPU utilization of existing instances over
+    a one minute window.
+-   **Scale to zero:** Cloud Run autoscales from one to zero instances only
+    after verifying that an instance is no longer processing requests. If you
+    use instance-based billing, Cloud Run instances are charged for the entire
+    lifecycle of instances, even when there are no incoming requests.
+
+## Container contract 
+
+Your container image can run code written in the programming language
+of your choice and use any base image, provided that it respects the
+constraints listed in the [Container runtime contract](https://docs.cloud.google.com/run/docs/container-contract).
+
+Executables in the container image must be compiled for
+Linux 64-bit. Cloud Run specifically supports the Linux x86_64 ABI format.
+
+Cloud Run accepts container images in the Docker Imag
+ Manifest V2, Schema 1, Schema 2, and OCI image formats. Cloud Run
+also accepts Zstd compressed container images.
+
+If deploying a multi-architecture image, the manifest list must include
+linux/amd64.
+
+For functions deployed with Cloud Run, you can use one of the
+Cloud Run runtime base images that are published by Google
+Cloud's buildpacks to receive automatic security and maintenance updates.
+For more information about the supported runtimes, see the [Runtime support schedule](https://docs.cloud.google.com/run/docs/runtime-support).
+
+### Container requirements
+
+When deploying containers to Cloud Run, the following requirements must be met:
+
+* Container deployed to services must listen for requests on the correct port
+* A Cloud Run service starts Cloud Run instances to handle incoming
+  requests. A Cloud Run instance always has one single ingress
+  container that listens for requests, and optionally one or more
+  sidecar containers. The following port configuration details
+  apply only to the ingress container, not to sidecars.
+* The ingress container within an instance must listen for
+  requests on `0.0.0.0` on the port to which requests are sent. Notably,
+  the ingress container should not listen on `127.0.0.1`. By default, request
+  are sent to 8080, but you can configure Cloud Run to send requests to the port of your choice.
+  Cloud Run injects the PORT environment variable into the ingress container.
+
+## VPC network connectivity
+
+Cloud Run services and jobs support Direct VPC egress. This means
+that they can send traffic to private resources within your
+configured VPC network, such as databases or internal services. Cloud Run
+services and jobs don't support Direct VPC ingress.
+Cloud Run worker pools support both Direct VPC egress and Direct VPC
+ingress. When you configure Direct VPC for your Cloud Run worker pool
+deployment, each worker instance receives a private IP address on the
+configured network and subnet. Only resources from your VPC network can
+connect to the worker pool private IP address endpoint. For more information
+about obtaining the private IP addresses of your worker pool instance, see
+[Retrieve the private IP addresses using the metadata server (MDS)](https://docs.cloud.google.com/run/docs/configuring/vpc-direct-vpc#mds-support).
+
+For Cloud Run worker pools with Direct VPC ingress, such as database
+connections or any other custom TCP-based protocol, the container must
+listen for TCP connections on the port exposed in your container image
+through the Dockerfile or specified by the PORT environment variable.
+
+## AI and GPU support
+
+Cloud Run supports hosting AI inference models. You can configure services with
+GPUs (e.g., NVIDIA RTX PRO 6000 Blackwell GPU, NVIDIA L4) to accelerate
+workloads like LLM inference using Gemma 3. For more information, see GPU
+support for
+[services](https://docs.cloud.google.com/run/docs/configuring/services/gpu),
+[jobs](https://docs.cloud.google.com/run/docs/configuring/jobs/gpu), and [worker
+pools](https://docs.cloud.google.com/run/docs/configuring/workerpools/gpu).
+
+## Pricing
+
+Cloud Run uses a pay-as-you-go model:
+
+-   **Request-based:** Charged for resources used during request processing.
+-   **Instance-based:** Charged for the entire lifetime of an instance.
+
+For the latest pricing, visit: [Cloud Run
+pricing](https://cloud.google.com/run/pricing).

--- a/.claude/skills/google-cloud-run-basics/references/iac-usage.md
+++ b/.claude/skills/google-cloud-run-basics/references/iac-usage.md
@@ -1,0 +1,76 @@
+# Cloud Run Infrastructure as Code
+
+Cloud Run resources can be provisioned and managed using Terraform and other IaC
+tools.
+
+## Terraform
+
+The Google Cloud Terraform provider supports Cloud Run services, jobs, and worker pools.
+
+### Cloud Run service example
+
+```terraform
+resource "google_cloud_run_v2_service" "default" {
+  name     = "cloudrun-service"
+  location = "us-central1"
+  deletion_protection = false
+  ingress  = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+}
+
+resource "google_cloud_run_v2_service_iam_member" "noauth" {
+  location = google_cloud_run_v2_service.default.location
+  name     = google_cloud_run_v2_service.default.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+```
+
+### Cloud Run job example
+
+```terraform
+resource "google_cloud_run_v2_job" "default" {
+  name     = "cloudrun-job"
+  location = "us-central1"
+
+  template {
+    template {
+      containers {
+        image = "us-docker.pkg.dev/cloudrun/container/job"
+      }
+    }
+  }
+}
+```
+
+### Cloud Run worker pool example
+
+```terraform
+resource "google_cloud_run_v2_worker_pool" "default" {
+  name     = "cloudrun-workerpool"
+  location = "us-central1"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/worker-pool:latest"
+    }
+  }
+}
+```
+
+### Reference dpcumentation
+
+- [Terraform Google Provider - Cloud Run v2 Service](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service)
+
+- [Terraform Google Provider - Cloud Run v2 Job](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job)
+- [Terraform Google Provider - Cloud Run v2 Worker pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_worker_pool)
+
+## YAML
+
+Cloud Run resources can also be defined using YAML. For more information, see
+[Cloud Run YAML reference](https://docs.cloud.google.com/run/docs/reference/yaml/v1).

--- a/.claude/skills/google-cloud-run-basics/references/iam-security.md
+++ b/.claude/skills/google-cloud-run-basics/references/iam-security.md
@@ -1,0 +1,102 @@
+# Cloud Run IAM & security
+
+Cloud Run uses Identity and Access Management (IAM) to secure your resources and control who can deploy or invoke them.
+
+## Predefined IAM Roles
+
+| Predefined Role | Usage |
+| :--- | :--- |
+| `roles/run.admin` | Full control over all Cloud Run resources. |
+| `roles/run.invoker` | Invoke Cloud Run services and execute Cloud Run jobs. |
+| `roles/run.developer` | Read and write access to services, jobs and worker pools; cannot
+  set IAM policies. |
+| `roles/run.viewer` | Read-only access to Cloud Run resources. |
+
+## Types of service accounts for service identity
+
+Cloud Run resources run as a specific service account (the service
+identity).
+
+- **User-managed service account (recommended)**: You manually create this
+  service account and determine the most minimal set of permissions that
+  the service account needs to access specific Google Cloud resources. The
+  user-managed service account follows the format of `SERVICE_ACCOUNT_NAME@PROJECT_ID.iam.gserviceaccount.com`.
+
+- **Compute Engine default service account:** Cloud Run automatically
+  provides the Compute Engine default service account as the default
+  service identity. The Compute Engine default service account
+  follows the format of `PROJECT_NUMBER-compute@developer.gserviceaccount.com`.
+
+## Best practices
+
+By default, the Compute Engine default service account is automatically
+created. If you don't specify a service account when the
+Cloud Run service or job is created, Cloud Run uses this service account.
+Depending on your organization policy configuration, the default
+service account might automatically be granted the Editor role on your
+project. We strongly recommend that you disable the automatic role
+grant by enforcing the `iam.automaticIamGrantsForDefaultServiceAccounts`
+organization policy constraint. If you created your organization after
+May 3, 2024, this constraint is enforced by default.
+
+Create a user-managed service account with minimal
+permissions for each Cloud Run resource.
+
+To allow a service to access another GCP resource (e.g.,
+Cloud SQL), grant the service's identity the appropriate IAM role on that
+resource.
+
+## Security controls
+
+- **Ingress Settings:** Control whether your service is reachable from the
+  internet (`all`), only from within the VPC (`internal`), or via a load
+  balancer (`internal-and-cloud-load-balancing`).
+
+- **VPC Egress:** Use a VPC connector or Direct VPC egress to allow Cloud Run to
+  access resources in your VPC.
+
+- **Binary Authorization:** Ensure only trusted container images are deployed.
+
+- **Secrets Management:** Use Secret Manager to securely pass sensitive
+  information (e.g., API keys, database passwords) to your containers as
+  environment variables or volumes.
+
+## Public access
+
+There are two ways to create a public Cloud Run service, you can either:
+
+* Disable the Cloud Run Invoker IAM check (recommended).
+* Assign the Cloud Run Invoker IAM role to the `allUsers` member type.
+
+For more information, see:
+[Cloud Run security overview](https://docs.cloud.google.com/run/docs/securing/managing-access#make-service-public).
+
+## Configure IAP to secure access
+
+By enabling IAP on Cloud Run directly, you can secure traffic with a single
+click from all ingress paths, including default `run.app` URLs and load
+balancers.
+
+When you integrate IAP with Cloud Run, you can manage user or group access in
+the following ways:
+
+* Inside the organization - configure access to users who are within the same
+  organization as your Cloud Run service
+
+* Outside the organization - configure access to users who are from
+  organizations different than your Cloud Run service
+
+* No organization - configure access in projects that are not part of any
+  Google organization
+
+Enabling IAP on a Cloud Run service can be as easy as deploying a new service with
+the following flags:
+
+```bash
+gcloud run deploy SERVICE_NAME \
+  --region=REGION \
+  --image=IMAGE_URL \
+  --no-allow-unauthenticated \
+  --iap \
+  --quiet
+```

--- a/.claude/skills/google-cloud-run-basics/references/mcp-usage.md
+++ b/.claude/skills/google-cloud-run-basics/references/mcp-usage.md
@@ -1,0 +1,43 @@
+# Cloud Run MCP Usage
+
+Cloud Run is supported by a remote Model Context Protocol (MCP) server that
+enables agents to deploy, manage, and monitor serverless applications.
+
+## MCP Tools for Cloud Run
+
+The Cloud Run MCP server typically includes tools for:
+
+- `get_service`: Get info about a Cloud Run service, such as its URI and
+  whether the deploy succeeded.
+- `list_services`: List Cloud Run services in a given Google Cloud project and
+  region.
+- `deploy_service_from_image`: Deploy a container image from Artifact Registry
+  or Docker Hub as a Cloud Run service.
+- `deploy_service_from_archive`: Deploy a Cloud Run service directly from a
+  self-contained source code archive (.tar.gz), skipping the container image
+  build step for faster deployment. The archive must include all dependencies.
+- `deploy_service_from_file_contents`: Deploys a Cloud Run service directly from
+  local source files. This method is suitable for scripting languages like Python
+  and Node.js, of which the source code can be embedded in the request. This is
+  ideal for quick tests and development feedback loops. You must include all
+  necessary dependencies within the source files because it skips the build step
+  for faster deployment.
+
+## Setup Instructions
+
+To connect to the Cloud Run MCP server:
+
+1.  Enable the Cloud Run API in your Google Cloud project.
+2.  Configure the agent's MCP connection using the Gemini CLI extension.
+3.  Follow the setup guide:
+    [Setting up Cloud Run MCP](https://docs.cloud.google.com/run/docs/reference/mcp).
+
+## Supported Operations
+
+Agents using the Cloud Run MCP can:
+
+- Automate the rollout of new revisions.
+- Troubleshoot failing deployments by inspecting logs and status.
+- Manage scheduled jobs and verify their execution history.
+
+Alternatively, use the [open source Cloud Run MCP server](https://github.com/GoogleCloudPlatform/cloud-run-mcp) which runs locally.

--- a/.claude/skills/google-cloud-waf-cost-optimization/SKILL.md
+++ b/.claude/skills/google-cloud-waf-cost-optimization/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: google-cloud-waf-cost-optimization
+description: Generates cost optimization guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify cost requirements and constraints, and provide actionable recommendations for build, deploy, and manage the workload cost-efficiently in Google Cloud.
+---
+
+# Google Cloud Well-Architected Framework skill for the Cost Optimization pillar
+
+## Overview
+
+The Cost Optimization pillar of the Google Cloud Well-Architected Framework
+provides a structured approach to optimize the costs of your cloud workloads
+while maximizing business value. Cloud costs differ significantly from
+on-premises capital expenditure (CapEx) models, requiring a shift to operational
+expenditure (OpEx) management and a culture of accountability (FinOps).
+
+## Core principles
+
+The recommendations in the cost optimization pillar of the Well-Architected
+Framework are aligned with the following core principles:
+
+-  **Align cloud spending with business value**: Ensure that your cloud
+   resources deliver measurable business value by aligning IT spending with
+   business objectives. Prioritize investments that directly contribute to
+   revenue, customer satisfaction, or operational efficiency. Grounding
+   document:
+   https://docs.cloud.google.com/architecture/framework/cost-optimization/align-cloud-spending-business-value
+
+-  **Foster a culture of cost awareness**: Ensure that people across your
+   organization consider the cost impact of their decisions and activities.
+   Provide teams with the visibility and information they need to make informed,
+   cost-conscious choices. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/cost-optimization/foster-culture-cost-awareness
+
+-  **Optimize resource usage**: Provision only the resources that you need and
+   pay only for what you consume. Select the most cost-effective resource types,
+   sizes, and locations that meet your technical and business requirements.
+   Grounding document:
+   https://docs.cloud.google.com/architecture/framework/cost-optimization/optimize-resource-usage
+
+-  **Optimize continuously**: Continuously monitor your cloud resource usage and
+   costs, and proactively make adjustments as needed to optimize your spending.
+   This iterative approach helps identify and address inefficiencies before they
+   become significant. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/cost-optimization/optimize-continuously
+
+## Relevant Google Cloud products
+
+The following are _examples_ of Google Cloud products and features that are
+relevant to cost optimization:
+
+- **Visibility and monitoring**:
+
+  - **Cloud Billing reports**: Native dashboards for visualizing spending and
+    trends.
+  - **BigQuery billing export**: Enables granular, custom analysis of billing
+    data using SQL and BI tools.
+  - **Looker Studio**: Used for creating detailed, shared cost dashboards and
+    reports.
+  - **Billing alerts and budgets**: Automated notifications when spending
+    reaches predefined thresholds.
+
+- **Automation and optimization tools**:
+
+  - **Recommender / Active Assist**: Automatically identifies idle resources,
+    rightsizing opportunities, and unused commitments.
+  - **Cloud Hub Optimization**: Integrates billing and resource utilization data
+    to help developers and application owners quickly identify their most
+    expensive, fluctuating, or underutilized cloud resources.
+  - **FinOps hub**: Presents active savings and optimization opportunities in
+    one dashboard.
+  - **Billing quotas**: Limits on resource consumption to prevent unexpected
+    cost spikes.
+
+- **Efficient infrastructure**:
+
+  - **Managed services and serverless services**: Services like Cloud Run, Cloud
+    Run functions, and GKE Autopilot reduce operational overhead and pay-per-use
+    scaling.
+  - **Compute Engine**: Use of Spot VMs for fault-tolerant workloads and
+    Committed Use Discounts (CUDs) for stable workloads.
+  - **Cloud Storage Lifecycle Policies**: Automatically moves data to lower-cost
+    storage classes (Nearline, Coldline, Archive) based on age or access.
+
+- **Organization and governance**:
+
+  - **Resource Manager**: Logical structure (Organizations, Folders, Projects)
+    for cost attribution.
+  - **Labels**: Metadata tags for categorizing and filtering costs by
+    environment, team, or application.
+  - **Organization Policy Service**: Enforces constraints (e.g., restricted
+    regions or machine types) to control costs.
+
+## Workload assessment questions
+
+Ask appropriate questions to understand the cost-related requirements and
+constraints of the workload and the user's organization. Choose questions from
+the following list:
+
+- How do you incorporate cost considerations into your cloud architecture design
+  process?
+- How do you foster a culture of cost awareness among your development teams?
+- How do you monitor and manage cloud costs across different projects or
+  departments?
+- What strategies do you use to optimize the cost of your compute resources?
+- How do you balance cost optimization with the need for agility and innovation?
+- How do you ensure that you are not over-provisioning cloud resources?
+- How do you use data and analytics to drive cost optimization decisions?
+- How do you optimize costs in different environments (e.g., development,
+  testing, production)?
+- How do you ensure that your cost optimization efforts are sustainable and
+  ongoing?
+- How do you measure the success of your cloud cost optimization initiatives?
+
+## Validation checklist
+
+Use the following checklist to evaluate the architecture's alignment with
+cost-optimization recommendations:
+
+- **Cost Attribution**: 100% of resources are labeled with key metadata
+  (e.g., `env`, `team`, `app`).
+- **Granular Visibility**: BigQuery billing export is enabled and used for
+  regular cost reviews.
+- **Budgets and Alerts**: Every project or business unit has defined budgets
+  and active alerts.
+- **Rightsizing**: Resources are regularly adjusted based on rightsizing
+  suggestions provided by Active Assist Recommender.
+- **Commitment Strategy**: Spend is reviewed monthly to optimize Committed
+  Use Discount coverage.
+- **Idle Resource Management**: Unused disks, IP addresses, and idle VMs are
+  identified and removed monthly.
+- **Managed Services**: Serverless options are preferred for new workloads
+  unless specific technical constraints exist.
+- **Storage Tiers**: Lifecycle policies are active for all major storage
+  buckets to minimize archival costs.

--- a/.claude/skills/google-cloud-waf-reliability/SKILL.md
+++ b/.claude/skills/google-cloud-waf-reliability/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: google-cloud-waf-reliability
+description: Generates reliability-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework. Use this skill to evaluate a workload, identify reliability requirements, and provide actionable recommendations for build, deploy, and manage the workload reliably in Google Cloud.
+---
+
+# Google Cloud Well-Architected Framework skill for the Reliability pillar
+
+## Overview
+
+The Reliability pillar of the Google Cloud Well-Architected Framework provides
+principles and recommendations to help you design, deploy, and manage reliable,
+resilient, and highly available workloads in Google Cloud. A reliable system
+consistently performs its intended functions under defined conditions, is
+resilient to failures, and recovers gracefully from disruptions, thereby
+minimizing downtime, enhancing user experience, and ensuring data integrity.
+
+## Core principles
+
+The recommendations in the reliability pillar of the Well-Architected Framework
+are aligned with the following core principles:
+
+-  **Define reliability based on user-experience goals**: Measurement of
+   reliability should reflect the actual experience of the system's users rather
+   than merely relying on infrastructure metrics. Focus on outcomes that matter
+   most to users. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/reliability/define-reliability-based-on-user-experience-goals
+
+-  **Set realistic targets for reliability**: Determine appropriate Service
+   Level Objectives (SLOs) that balance the cost and complexity of maximizing
+   availability against business requirements. Utilize error budgets to manage
+   feature velocity. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/reliability/set-targets
+
+-  **Build highly available systems through resource redundancy**: Eliminate
+   single points of failure by duplicating critical components across zones and
+   regions to maintain operations during localized outages. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/reliability/build-highly-available-systems
+
+-  **Take advantage of horizontal scalability**: Design system architectures to
+   scale horizontally (adding more instances) to seamlessly accommodate load
+   fluctuations and improve overall fault tolerance. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/reliability/horizontal-scalability
+
+-  **Detect potential failures by using observability**: Implement thorough
+   monitoring, logging, and alerting systems to proactively detect, diagnose,
+   and address anomalies before they cause user-facing issues. Grounding
+   document:
+   https://docs.cloud.google.com/architecture/framework/reliability/observability
+
+-  **Design for graceful degradation**: Architect systems to maintain critical
+   functionality, even if at reduced performance or with limited features, when
+   dependencies fail or the system experiences extreme stress. Grounding
+   document:
+   https://docs.cloud.google.com/architecture/framework/reliability/graceful-degradation
+
+-  **Perform testing for recovery from failures**: Build confidence in system
+   resilience by continuously simulating failures and verifying the
+   effectiveness of automated and manual recovery procedures. Grounding
+   document:
+   https://docs.cloud.google.com/architecture/framework/reliability/perform-testing-for-recovery-from-failures
+
+-  **Perform testing for recovery from data loss**: Regularly test backup and
+   restore protocols to ensure rapid recovery from data corruption or loss,
+   remaining within the defined Recovery Time Objective (RTO) and Recovery Point
+   Objective (RPO). Grounding document:
+   https://docs.cloud.google.com/architecture/framework/reliability/perform-testing-for-recovery-from-data-loss
+
+-  **Conduct thorough postmortems**: Foster a blameless culture by investigating
+   outages comprehensively to understand root causes, followed by implementing
+   measures that prevent recurrence. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/reliability/conduct-postmortems
+
+## Relevant Google Cloud products
+
+The following are _examples_ of Google Cloud products and features that are
+relevant to reliability:
+
+- **Compute**: Compute Engine Managed Instance Groups (MIGs), Google Kubernetes
+  Engine (GKE), Cloud Run
+- **Networking**: Cloud Load Balancing, Cloud CDN, Cloud DNS
+- **Storage and databases**: Cloud Storage (multi-region), Cloud SQL High
+  Availability, Spanner, Filestore, Firestore
+- **Operations**: Cloud Monitoring, Cloud Logging, Google Cloud Managed Service
+  for Prometheus
+- **Disaster recovery**: Backup and DR Service, Filestore backups
+
+## Workload assessment questions
+
+Ask appropriate questions to understand the reliability-related requirements and
+constraints of the workload and the user's organization. Choose questions from
+the following list:
+
+- How does your organization define and measure the reliability of your systems
+  in relation to user experience?
+- How does your organization approach setting reliability targets for your
+  services?
+- What is your organization's strategy for ensuring high availability through
+  resource redundancy?
+- How does your organization leverage horizontal scalability to maintain
+  performance and reliability?
+- How does your organization utilize observability (metrics, logs, traces) to
+  gain insights and detect potential failures?
+- How does your organization manage alerting based on observability data to
+  ensure timely responses to significant issues without causing alert fatigue?
+- What measures does your organization take to ensure systems can gracefully
+  degrade during high load or partial failures?
+- How frequently and comprehensively does your organization test for recovery
+  from system failures (e.g., regional failovers, release rollbacks)?
+- What is your organization's approach to testing for recovery from data loss?
+- How does your organization conduct and utilize postmortems after incidents?
+
+## Validation checklist
+
+Use the following checklist to evaluate the architecture's alignment with
+reliability recommendations:
+
+- User-focused SLIs and SLOs are explicitly defined and actively monitored.
+- The architecture avoids single points of failure through cross-zone or
+  cross-region redundancy.
+- Autoscaling is enabled to handle variable demand without manual intervention.
+- Application and infrastructure health checks are configured to trigger
+  automated failovers.
+- Regular backup schedules are in place, and restoration processes are routinely
+  tested.
+- The system architecture incorporates patterns like circuit breakers, retries
+  with exponential backoff, and rate limiting to support graceful degradation.
+- Game days or chaos engineering practices are regularly held to validate
+  failure recovery.
+- A formalized, blameless postmortem process exists to ensure organizational
+  learning from operational incidents.

--- a/.claude/skills/google-cloud-waf-security/SKILL.md
+++ b/.claude/skills/google-cloud-waf-security/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: google-cloud-waf-security
+description: Generates security-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify security requirements, and provide actionable recommendations for IAM, network security, data protection, and operational security.
+---
+
+# Google Cloud Well-Architected Framework skill for the Security pillar
+
+## Overview
+
+The security pillar of the Google Cloud Well-Architected Framework provides
+design principles and best practices for building a robust security posture by
+integrating security into every layer of the architecture for cloud workloads.
+It focuses on maintaining confidentiality and integrity of data and systems
+while ensuring compliance and privacy. It provides a structured approach to risk
+management, threat defense, and identity control, enabling you to operate cloud
+workloads securely and at scale.
+
+## Core principles
+
+The recommendations in the security pillar of the Well-Architected Framework are
+aligned with the following core principles:
+
+-  **Implement security by design**: Integrate cloud security and network
+   security considerations starting from the initial design phase of your
+   applications and infrastructure. Google Cloud provides architecture
+   blueprints and recommendations to help you apply this principle. Grounding
+   document:
+   https://docs.cloud.google.com/architecture/framework/security/implement-security-by-design
+
+-  **Implement zero trust**: Use a _never trust, always verify_ approach, where
+   access to resources is granted based on continuous verification of trust.
+   Google Cloud supports this principle through products like Chrome Enterprise
+   Premium and Identity-Aware Proxy (IAP). Grounding document:
+   https://docs.cloud.google.com/architecture/framework/security/implement-zero-trust
+
+-  **Implement shift-left security**: Implement security controls early in the
+   software development lifecycle. Avoid security defects before system changes
+   are made. Detect and fix security bugs early, fast, and reliably after the
+   system changes are committed. Google Cloud supports this principle through
+   products like Cloud Build, Binary Authorization, and Artifact Registry.
+   Grounding document:
+   https://docs.cloud.google.com/architecture/framework/security/implement-shift-left-security
+
+-  **Implement preemptive cyber defense**: Adopt a proactive approach to
+   security by implementing robust fundamental measures like threat
+   intelligence. This approach helps you build a foundation for more effective
+   threat detection and response. Google Cloud's approach to layered security
+   controls aligns with this principle. Google Cloud supports this principle
+   through products like Security Command Center, Google Threat Intelligence,
+   and Google SecOps. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/security/implement-preemptive-cyber-defense
+
+-  **Use AI securely and responsibly**: Develop and deploy AI systems in a
+   responsible and secure manner. The recommendations for this principle are
+   aligned with guidance in the AI and ML perspective of the Well-Architected
+   Framework and in Google's Secure AI Framework (SAIF). Grounding document:
+   https://docs.cloud.google.com/architecture/framework/security/use-ai-securely-and-responsibly
+
+-  **Use AI for security**: Use AI capabilities to improve your existing
+   security systems and processes through Gemini in Security and overall
+   platform-security capabilities. Use AI as a tool to increase the automation
+   of remedial work and ensure security hygiene to make other systems more
+   secure. Google Cloud supports this principle through products like Google
+   Threat Intelligence and Google SecOps. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/security/use-ai-for-security
+
+-  **Meet regulatory, compliance, and privacy needs**: Adhere to
+   industry-specific regulations, compliance standards, and privacy
+   requirements. Google Cloud helps you meet these obligations through products
+   like Assured Workloads, Organization Policy Service, and our compliance
+   resource center. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/security/meet-regulatory-compliance-and-privacy-needs
+
+## Relevant Google Cloud products
+
+The following are _examples_ of Google Cloud products and features that are
+relevant to security:
+
+- **Identity and access management**
+
+  - **Identity and Access Management (IAM)**: Fine-grained access control for
+    Google Cloud resources.
+  - **Identity-Aware Proxy (IAP)**: Secure access to applications without a VPN.
+  - **Chrome Enterprise Premium**: Endpoint security and context-aware access.
+
+- **Network security**
+
+  - **Google Cloud Armor**: DDoS protection and Web Application Firewall (WAF).
+  - **VPC Service Controls**: Define security perimeters to prevent data
+    exfiltration.
+  - **Cloud Next-Generation Firewall (NGFW)**: Advanced threat protection for
+    network traffic.
+  - **Shared VPC**: Centralized network management across projects.
+  - **Cloud Interconnect and IPsec VPN**: Secure, private connectivity.
+
+- **Data security**
+
+  - **Cloud Key Management Service (KMS)**: Manage encryption keys.
+  - **Sensitive Data Protection (formerly Cloud DLP)**: Discover and redact
+    sensitive data.
+  - **Confidential Computing**: Encrypt data in use (memory).
+
+- **Security operations (SecOps)**
+
+  - **Google SecOps (Chronicle)**: Threat detection and security analytics.
+  - **Security Command Center (SCC)**: Centralized vulnerability and threat
+    management.
+  - **Cloud Logging and Cloud Monitoring**: Visibility into system activity.
+
+- **Automation and supply chain**
+
+  - **Cloud Build**: Secure CI/CD pipelines.
+  - **Artifact Analysis**: Vulnerability scanning for container images.
+  - **Binary Authorization**: Deploy-time policy enforcement.
+  - **Assured open source software**: Use secured OSS packages.
+
+## Workload assessment questions
+
+Ask appropriate questions to understand the security-related requirements and
+constraints of the workload and the user's organization. Choose questions from
+the following list:
+
+- **Security by design**:
+
+  - How do you incorporate security considerations into your project's initial
+    planning and design phases?
+  - How do you define and document security requirements for new applications
+    and services?
+  - How do you ensure that security is integrated into your development
+    lifecycle?
+  - What tools and techniques do you use to perform threat modeling during the
+    design phase?
+  - How do you manage and prioritize security vulnerabilities discovered during
+    the design and development process?
+  - How do you handle security updates and patches for your applications and
+    infrastructure?
+  - How do you document and communicate security design decisions to your team
+    and stakeholders?
+  - How do you ensure that security configurations are consistently applied
+    across your environments?
+  - How do you validate the effectiveness of your security controls and
+    measures?
+  - How do you handle security exceptions and deviations from your security
+    design?
+
+- **Zero trust**:
+
+  - How do you verify and authenticate users and devices accessing your Google
+    Cloud resources?
+  - How do you implement the principle of least privilege for access control?
+  - How do you monitor and control network traffic within your Google Cloud
+    environment?
+  - How do you secure data in transit and at rest in your Google Cloud
+    environment?
+  - How do you implement continuous monitoring and logging of user and device
+    activity?
+  - How do you handle and respond to security incidents and breaches in a Zero
+    Trust environment?
+  - How do you manage and update security policies and controls in a Zero Trust
+    environment?
+  - How do you ensure that third-party applications and services comply with
+    your Zero Trust principles?
+  - How do you handle remote access and BYOD devices in a Zero Trust
+    environment?
+  - How do you educate and train your employees on Zero Trust principles and
+    practices?
+
+- **Shift-left security**:
+
+  - How do you integrate security testing into your development pipeline early
+    in the process?
+  - What types of security testing do you perform during the development phase?
+  - How do you provide developers with feedback on security vulnerabilities and
+    best practices?
+  - How do you empower developers to take ownership of security in their code?
+  - How do you ensure that security requirements are clearly defined and
+    communicated to developers?
+  - How do you measure the effectiveness of your Shift Left security
+    initiatives?
+  - How do you handle security dependencies and third-party libraries in your
+    code?
+  - How do you manage and update security configurations in your development
+    environment?
+  - How do you handle security exceptions and deviations from your security
+    policies in development?
+  - How do you promote a culture of security awareness and responsibility among
+    developers?
+
+- **Preemptive cyber defense**:
+
+  - How do you proactively identify and mitigate potential security threats
+    before they impact your systems?
+  - What tools and techniques do you use for continuous security monitoring and
+    analysis?
+  - How do you respond to and remediate security alerts and incidents?
+  - How do you simulate and test your incident response plans?
+  - How do you stay up-to-date with the latest security threats and
+    vulnerabilities?
+  - How do you handle and mitigate DDoS attacks against your applications and
+    services?
+  - How do you protect your sensitive data from insider threats?
+  - How do you ensure that your security controls are effective against advanced
+    persistent threats (APTs)?
+  - How do you handle security vulnerabilities in your supply chain?
+  - How do you adapt your security posture to evolving threats and technologies?
+
+- **Security of AI workloads**:
+
+  - How do you ensure the security of your AI models and data?
+  - How do you address potential biases and ethical concerns in your AI models?
+  - How do you protect your AI models from adversarial attacks and data
+    poisoning?
+  - How do you ensure the privacy of data used in your AI models?
+  - How do you explain and interpret the decisions made by your AI models?
+  - How do you manage and control access to your AI models and data?
+  - How do you ensure compliance with regulations and standards related to
+    AI and ML?
+  - How do you monitor and detect anomalies in the behavior of your AI models?
+  - How do you handle and respond to security incidents involving your AI
+    models?
+  - How do you educate and train your employees on the secure and responsible
+    use of AI and ML?
+
+- **AI for security**:
+
+  - How do you leverage AI and ML to enhance your security posture?
+  - What types of AI models do you use for security purposes?
+  - How do you train and validate your AI models for security applications?
+  - How do you ensure the accuracy and reliability of AI-based security
+    systems?
+  - How do you handle false positives and false negatives from AI-based
+    security systems?
+  - How do you integrate AI-based security systems with your existing security
+    infrastructure?
+  - How do you manage and update your AI models for security applications?
+  - How do you explain and interpret the decisions made by your AI models for
+    security applications?
+  - How do you ensure the ethical and responsible use of AI and ML for security
+    purposes?
+  - How do you measure the effectiveness of AI and ML in improving your security
+    posture?
+
+- **Regulatory compliance and privacy**:
+
+  - What regulatory compliance frameworks and privacy standards do you need to
+    adhere to?
+  - How do you assess and manage compliance risks in your Google Cloud
+    environment?
+  - How do you ensure the privacy of sensitive data stored and processed in
+    Google Cloud?
+  - How do you handle data subject requests (DSRs) related to privacy
+    regulations?
+  - How do you document and track compliance activities and evidence?
+  - How do you ensure that third-party vendors and partners comply with your
+    regulatory and privacy requirements?
+  - How do you handle data breaches and security incidents related to compliance
+    regulations?
+  - How do you stay up-to-date with changes in regulatory compliance and privacy
+    standards?
+  - How do you educate and train your employees on regulatory compliance and
+    privacy requirements?
+  - How do you demonstrate and prove compliance to auditors and regulators?
+
+## Validation checklist
+
+Use the following checklist to evaluate the architecture's alignment with
+security recommendations:
+
+- **Security by design**:
+
+  - Are system components selected based on their security features and
+    hardening?
+  - Is defense-in-depth implemented at the network, host, and application
+    layers?
+  - Are safe libraries and application frameworks used to prevent common
+    vulnerabilities?
+  - Is a risk assessment performed using industry standards?
+
+- **Zero trust**:
+
+  - Is access control enforced based on user identity and context (device,
+    location)?
+  - Are private connectivity methods (Cloud Interconnect, VPN) used for internal
+    traffic?
+  - Are default networks disabled in all projects?
+  - Are VPC Service Controls perimeters established around sensitive data?
+
+- **Shift-left security**:
+
+  - Is infrastructure provisioned using Infrastructure as Code
+    (e.g., Terraform)?
+  - Are automated security scans integrated into the CI/CD pipeline?
+  - Is there a process for scanning and patching vulnerabilities in
+    dependencies?
+  - Is Binary Authorization used to ensure only trusted images are deployed?
+
+- **Preemptive cyber defense**:
+
+  - Is threat intelligence integrated into security operations?
+  - Is security logging enabled and centralized for all critical resources?
+  - Are automated responses configured for common security threats?
+  - Are defenses validated through periodic testing or red-teaming?
+
+- **AI security and governance**:
+
+  - Are AI pipelines secured against tampering and data poisoning?
+  - Is differential privacy or data masking used for training data where
+    appropriate?
+  - Are Vertex Explainable AI and fairness indicators used for model governance?

--- a/.claude/skills/google-firebase-basics/SKILL.md
+++ b/.claude/skills/google-firebase-basics/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: firebase-basics
+description: Use this skill whenever you are working on a project that uses Firebase products or services, especially for mobile or web apps.
+---
+
+# Firebase Basics
+
+### **CRITICAL** Mandatory prerequisites
+
+Before attempting to fulfill any user request regarding Firebase, you **MUST**
+follow these steps in order. Do not proceed to implementation until these are
+completed. Failure to follow these instructions may result in using outdated
+patterns and lack of access to essential reference materials.
+
+1.  **Leverage the planning phase**
+
+    If you use a planning mode (e.g., maintaining a `task.md` file), you
+    **MUST** include a task to check and install `firebase/agent-skills` as your
+    very first item.
+
+2.  **Ensure NPM is installed.**
+
+    ```bash
+    ## Check if NPM is installed
+    npm --version
+    ```
+
+    If NPM is not installed, guide the user to download and install the
+    LTS version from https://nodejs.org/en/download.
+
+    Then, request the user to manually install Node.js and to reply with a
+    confirmation that the installation is finished. **Stop and wait** for the
+    user's confirmation.
+
+3.  **Verify and install Agent Skills for Firebase**
+
+    You **MUST** ensure the full set of skills is installed to avoid using
+    outdated patterns. Run this command:
+
+    ```bash
+    npx -y skills add firebase/agent-skills -y
+    ```
+
+    *If the skills are already installed, this command will ensure they are up
+    to date. Do not skip this step.*
+
+
+## Quick start
+
+After completing the mandatory prerequisites above, proceed with these steps to
+set up your environment:
+
+1.  **Log in to the Firebase CLI.**
+
+    Run this command:
+
+    ```bash
+    npx -y firebase-tools@latest login
+    ```
+
+    Then, ask the user to complete the login flow in the browser.
+
+2.  **Set an active project for the CLI.**
+
+    Most Firebase tasks require an active project context. Check the current
+    project for the Firebase CLI by running this command:
+
+    ```bash
+    npx -y firebase-tools@latest use
+    ```
+
+    - If the command outputs `Active Project: <PROJECT_ID>`, you can proceed
+      with your task.
+
+    - If the command does *not* output an active project, ask the user if they
+      have an existing Firebase project ID.
+
+      - If yes: Set the ID as the active project and add a default alias by
+        running:
+
+        ```bash
+        npx -y firebase-tools@latest use --add <PROJECT_ID>
+        ```
+
+      - If no: Create a new Firebase project by running:
+
+        ```bash
+        npx -y firebase-tools@latest projects:create <PROJECT_ID> --display-name <DISPLAY_NAME>
+        ```
+
+## Reference directory
+
+- [Firebase core concepts](references/core-concepts.md)
+- [Firebase CLI usage](references/cli-usage.md)
+- [Firebase client library usage](references/client-library-usage.md)
+- [Firebase CLI and MCP server](references/mcp-usage.md)
+- [Firebase IaC usage](references/iac-usage.md)
+- [Firebase security-related features](references/iam-security.md)
+- [Additional Published Skills](references/additional-skills.md)
+
+If you need product information that's not found in these references, check the
+other skills for Firebase that you have installed, or use the `search_documents`
+tool of the Developer Knowledge MCP server.

--- a/.claude/skills/google-firebase-basics/references/additional-skills.md
+++ b/.claude/skills/google-firebase-basics/references/additional-skills.md
@@ -1,0 +1,122 @@
+## Additional Published Skills
+
+The following skills and reference files are published in the
+[Firebase Agent Skills repository](https://github.com/firebase/agent-skills/tree/main/skills):
+
+### `developing-genkit-dart`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/SKILL.md)
+-   [`references/genkit.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit.md)
+-   [`references/genkit_anthropic.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_anthropic.md)
+-   [`references/genkit_chrome.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_chrome.md)
+-   [`references/genkit_firebase_ai.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_firebase_ai.md)
+-   [`references/genkit_google_genai.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_google_genai.md)
+-   [`references/genkit_mcp.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_mcp.md)
+-   [`references/genkit_middleware.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_middleware.md)
+-   [`references/genkit_openai.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_openai.md)
+-   [`references/genkit_shelf.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_shelf.md)
+-   [`references/schemantic.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/schemantic.md)
+
+### `developing-genkit-go`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/SKILL.md)
+-   [`references/flows-and-http.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/references/flows-and-http.md)
+-   [`references/generation.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/references/generation.md)
+-   [`references/getting-started.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/references/getting-started.md)
+-   [`references/prompts.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/references/prompts.md)
+-   [`references/providers.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/references/providers.md)
+-   [`references/tools.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/references/tools.md)
+
+### `developing-genkit-js`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-js/SKILL.md)
+-   [`references/best-practices.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-js/references/best-practices.md)
+-   [`references/common-errors.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-js/references/common-errors.md)
+-   [`references/docs-and-cli.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-js/references/docs-and-cli.md)
+-   [`references/examples.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-js/references/examples.md)
+-   [`references/setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-js/references/setup.md)
+
+### `firebase-ai-logic-basics`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-ai-logic-basics/SKILL.md)
+-   [`references/usage_patterns_web.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-ai-logic-basics/references/usage_patterns_web.md)
+
+### `firebase-app-hosting-basics`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-app-hosting-basics/SKILL.md)
+-   [`references/cli_commands.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-app-hosting-basics/references/cli_commands.md)
+-   [`references/configuration.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-app-hosting-basics/references/configuration.md)
+-   [`references/emulation.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-app-hosting-basics/references/emulation.md)
+
+### `firebase-auth-basics`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-auth-basics/SKILL.md)
+-   [`references/client_sdk_web.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-auth-basics/references/client_sdk_web.md)
+-   [`references/security_rules.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-auth-basics/references/security_rules.md)
+
+### `firebase-basics`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/SKILL.md)
+-   [`references/firebase-cli-guide.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/firebase-cli-guide.md)
+-   [`references/firebase-service-init.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/firebase-service-init.md)
+-   [`references/local-env-setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/local-env-setup.md)
+-   [`references/web_setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/web_setup.md)
+-   [`references/refresh/antigravity.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/refresh/antigravity.md)
+-   [`references/refresh/claude.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/refresh/claude.md)
+-   [`references/refresh/gemini-cli.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/refresh/gemini-cli.md)
+-   [`references/refresh/other-agents.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/refresh/other-agents.md)
+-   [`references/setup/antigravity.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/setup/antigravity.md)
+-   [`references/setup/claude_code.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/setup/claude_code.md)
+-   [`references/setup/cursor.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/setup/cursor.md)
+-   [`references/setup/gemini_cli.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/setup/gemini_cli.md)
+-   [`references/setup/github_copilot.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/setup/github_copilot.md)
+-   [`references/setup/other_agents.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/setup/other_agents.md)
+
+### `firebase-data-connect-basics`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/SKILL.md)
+-   [`examples.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/examples.md)
+-   [`templates.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/templates.md)
+-   [`reference/advanced.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/advanced.md)
+-   [`reference/config.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/config.md)
+-   [`reference/native_sql.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/native_sql.md)
+-   [`reference/operations.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/operations.md)
+-   [`reference/schema.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/schema.md)
+-   [`reference/sdks.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/sdks.md)
+-   [`reference/security.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/security.md)
+
+### `firebase-firestore`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/SKILL.md)
+
+#### Enterprise Edition
+
+-   [`references/enterprise/android_sdk_usage.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/android_sdk_usage.md)
+-   [`references/enterprise/data_model.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/data_model.md)
+-   [`references/enterprise/flutter_setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/flutter_setup.md)
+-   [`references/enterprise/indexes.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/indexes.md)
+-   [`references/enterprise/ios_setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/ios_setup.md)
+-   [`references/enterprise/provisioning.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/provisioning.md)
+-   [`references/enterprise/python_sdk_usage.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/python_sdk_usage.md)
+-   [`references/enterprise/security_rules.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/security_rules.md)
+-   [`references/enterprise/web_sdk_usage.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/web_sdk_usage.md)
+
+#### Standard Edition
+
+-   [`references/standard/android_sdk_usage.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/android_sdk_usage.md)
+-   [`references/standard/flutter_setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/flutter_setup.md)
+-   [`references/standard/indexes.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/indexes.md)
+-   [`references/standard/ios_setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/ios_setup.md)
+-   [`references/standard/provisioning.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/provisioning.md)
+-   [`references/standard/security_rules.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/security_rules.md)
+-   [`references/standard/web_sdk_usage.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/web_sdk_usage.md)
+
+### `firebase-hosting-basics`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-hosting-basics/SKILL.md)
+-   [`references/configuration.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-hosting-basics/references/configuration.md)
+-   [`references/deploying.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-hosting-basics/references/deploying.md)
+
+### `firebase-security-rules-auditor`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-security-rules-auditor/SKILL.md)

--- a/.claude/skills/google-firebase-basics/references/cli-usage.md
+++ b/.claude/skills/google-firebase-basics/references/cli-usage.md
@@ -1,0 +1,31 @@
+# Firebase CLI usage
+
+The Firebase CLI (`firebase-tools`) is the primary tool for managing Firebase
+projects and resources from the command line.
+
+**Use npx for Firebase CLI commands**: To ensure you always use the latest
+version of the Firebase CLI, always run commands with
+`npx -y firebase-tools@latest` instead of just `firebase`. (e.g., use
+`npx -y firebase-tools@latest --version` instead of `firebase --version`).
+
+## Exploring commands
+
+The Firebase CLI documents itself. Use help commands to discover functionality.
+
+- **Global help**: List all available commands and categories:
+
+  ```bash
+  npx -y firebase-tools@latest --help
+  ```
+
+- **Command help**: Get detailed usage for a specific command:
+
+  ```bash
+  npx -y firebase-tools@latest [command] --help
+  ```
+
+  ```bash
+  # Example:
+  npx -y firebase-tools@latest deploy --help
+  npx -y firebase-tools@latest firestore:indexes --help
+  ```

--- a/.claude/skills/google-firebase-basics/references/client-library-usage.md
+++ b/.claude/skills/google-firebase-basics/references/client-library-usage.md
@@ -1,0 +1,45 @@
+# Firebase client library usage
+
+Firebase provides SDKs for both client-side application development and
+server-side administrative tasks.
+
+For a full list of Firebase client libraries and links to their documentation
+and GitHub repositories, see https://firebase.google.com/docs/libraries
+
+## Mobile and web client-side SDKs
+
+The Firebase client-side SDKs allow direct interaction with Firebase services
+from a mobile or web app. These SDKs are available for iOS (Swift and
+Objective-C), Android (Kotlin and Java), Web (JavaScript), Flutter (Dart),
+Unity, and C++.
+
+-   For **web apps**, Agent Skills for Firebase provide guides to get started
+    with the JavaScript client SDK. Install these skills by running:
+
+    ```bash
+    npx -y skills add firebase/agent-skills -y
+    ```
+
+-   For **native iOS or Android mobile apps**, see the documentation to get
+    started:
+
+    -   **iOS**: https://firebase.google.com/docs/ios/setup.md.txt
+    -   **Android**: https://firebase.google.com/docs/android/setup.md.txt
+
+-   For **Flutter apps**, see the documentation to get started:
+
+    -   **Flutter**: https://firebase.google.com/docs/flutter/setup.md.txt
+
+-   For **Unity and C++ mobile apps**, see the documentation to get started:
+
+    -   **Unity**: https://firebase.google.com/docs/unity/setup.md.txt
+    -   **C++**: https://firebase.google.com/docs/cpp/setup.md.txt
+
+## Server-side Admin SDKs
+
+The Firebase Admin SDKs provide privileged access to Firebase services from a
+server environment. These SDKs are available for Node.js, Java, Python, and Go.
+
+For details about Firebase Admin SDKs and getting started, see
+https://firebase.google.com/docs/reference/admin.md.txt and
+https://firebase.google.com/docs/admin/setup.md.txt

--- a/.claude/skills/google-firebase-basics/references/core-concepts.md
+++ b/.claude/skills/google-firebase-basics/references/core-concepts.md
@@ -1,0 +1,61 @@
+# Firebase core concepts
+
+Firebase is a platform of services for mobile and web applications. It offers
+products for managed backend infrastructure (BaaS), building AI-powered
+experiences in apps, DevOps, and end-user engagement. Most services are
+integrated into apps using mobile and web client SDKs.
+
+## Key services
+
+Here are some popular Firebase products:
+
+- **Firebase Authentication**: Simplify end-user authentication and sign-in on a
+  secure, all-in-one identity platform.
+- **Firestore**: Store and sync data using a secure, scalable NoSQL cloud
+  database with rich data models and queryability.
+- **Firebase Data Connect**: Build and scale your apps using a fully-managed
+  PostgreSQL relational database service.
+- **Cloud Storage for Firebase**: Store and serve unstructured content like
+  images, audio, video with a secure cloud-hosted solution.
+- **Firebase App Hosting**: Deploy modern, full-stack web apps that require
+  server-side rendering and automated secret management, CI/CD, and CDN caching.
+- **Firebase Hosting**: Deploy static and single-page web apps to a global CDN
+  with a single command.
+- **Cloud Functions for Firebase**: Run backend code in response to events and
+  HTTPS requests without provisioning or managing a server.
+- **Firebase AI Logic**: Build secure AI-powered experiences in mobile and web
+  apps using the Gemini API and without provisioning or managing a server.
+- **Firebase Crashlytics**: Track, prioritize, and fix stability issues in
+  mobile apps.
+- **Firebase Cloud Messaging (FCM)**: Send push notifications and messages to
+  end users.
+
+## Regional availability
+
+Firebase services are available globally, with several products supporting
+specific regional configurations.
+
+- **Firestore**: Each instance can be provisioned in a different location;
+  supports multi-region (e.g., `nam5`) and regional (e.g., `us-east1`)
+  locations.
+- **Cloud Storage for Firebase**: Each bucket can be provisioned in a different
+  location.
+- **Firebase App Hosting**: Can be deployed to specific regions to minimize
+  latency for operations and end users.
+- **Firebase Hosting**: Content is delivered via a global CDN.
+- **Cloud Functions for Firebase**: Can be deployed to specific regions to
+  minimize latency for operations and end users.
+
+## Pricing
+
+Firebase offers two pricing plans:
+
+- **Spark (no-cost) pricing plan**: Projects don't need a billing account to
+  use only the no-cost Firebase services and to get started with generous
+  no-cost usage quota.
+- **Blaze (pay-as-you-go) pricing plan**: Link a billing account to the project
+  to access more products and services and to get usage levels beyond the
+  no-cost usage quota.
+
+For up-to-date detailed pricing information, see the Firebase pricing
+page: https://firebase.google.com/pricing

--- a/.claude/skills/google-firebase-basics/references/iac-usage.md
+++ b/.claude/skills/google-firebase-basics/references/iac-usage.md
@@ -1,0 +1,40 @@
+# Firebase IaC usage
+
+Firebase resources can be provisioned using Infrastructure as Code (IaC) tools,
+like Terraform.
+
+## Terraform configuration
+
+Use the `google` or `google-beta` providers to manage Firebase resources.
+
+### Example: Firebase project setup
+
+```hcl
+resource "google_firebase_project" "default" {
+ provider = google-beta
+ project  = "user-defined-project-id"
+}
+
+resource "google_firebase_web_app" "default" {
+ provider     = google-beta
+ project      = google_firebase_project.default.project
+ display_name = "user-defined-display-name"
+}
+```
+
+### Supported Terraform resources
+
+Here are some common Terraform resources for Firebase:
+
+- `google_firebase_project`: Enable Firebase services on an existing
+  Google Cloud project.
+- `google_identity_platform_config`: Set up Firebase Authentication.
+- `google_firestore_database`: Provision a Firestore database.
+  Always set `type = "FIRESTORE_NATIVE"`.
+- `google_firebaserules_ruleset`: Define Firebase Security Rules to protect
+  Firestore data or Cloud Storage for Firebase data.
+- `google_firebaserules_release`: Deploy Firebase Security Rules rulesets for
+  Firestore or for Cloud Storage for Firebase.
+
+For a complete list of Terraform resources, and details about Terraform and
+Firebase, see: https://firebase.google.com/docs/projects/terraform/get-started

--- a/.claude/skills/google-firebase-basics/references/iam-security.md
+++ b/.claude/skills/google-firebase-basics/references/iam-security.md
@@ -1,0 +1,74 @@
+# Firebase security-related features
+
+Firebase offers several security-related features and services, including:
+
+- **Identity and Access Management (IAM)**: Restrict a project member's
+  administrative access for projects, resources, and data.
+- **Firebase Security Rules**: Restrict client-side access for Firestore data
+  and Cloud Storage for Firebase data to only authorized users.
+- **Firebase App Check**: Restrict client-side access for APIs and backend
+  resources to only an authentic client and an authentic, untampered device.
+
+## Identity and Access Management (IAM)
+
+Here are some common IAM roles:
+
+| Role | Description |
+|---|---|
+| `roles/viewer` | Permissions for read-only actions, such as viewing (but not modifying) existing resources or data. |
+| `roles/editor` | All the `roles/viewer` permissions, plus permissions for actions that modify state, such as changing existing resources. |
+| `roles/owner` | All the `roles/editor` permissions, plus permissions for the following actions: manage IAM for a project, manage all resources within the project, set up and manage billing for a project, and delete or restore a project. |
+| `roles/firebase.viewer` | Read-only access to Firebase resources and data. |
+| `roles/firebase.admin` | Full access to all Firebase products and project management. |
+
+For details about IAM and Firebase, see
+https://firebase.google.com/docs/projects/iam/overview.md.txt
+
+## Firebase Security Rules
+
+Firebase Security Rules are CRITICAL to protecting Firestore data and
+Cloud Storage for Firebase data from unauthorized mobile and web client-side
+access. They are defined in the project directory (e.g., `firestore.rules`)
+and deployed using the Firebase CLI.
+
+Here is a basic example of Security Rules for Firestore that restricts access
+to authenticated end-users only:
+
+```
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /some_collection/{document} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}
+```
+
+**CRITICAL**: Agent Skills for Firebase provide tools to draft and test Firebase
+Security Rules. Install these skills by running:
+
+```bash
+npx -y skills add firebase/agent-skills -y
+```
+
+## Firebase App Check
+
+Firebase App Check is CRITICAL to protecting a project's enabled APIs and
+backend resources from unauthorized clients and devices. For example, it can
+help protect Firebase AI Logic, Firestore, Cloud Storage for Firebase,
+Cloud Functions for Firebase, and Firebase Data Connect.
+
+For details about Firebase App Check, see
+https://firebase.google.com/docs/app-check.md.txt
+
+## Security best practices
+
+- **Principle of least privilege:** Assign specific product-level roles instead
+  of `roles/owner` whenever possible.
+- **Firebase App Check:** Use this service to protect a project's enabled APIs
+  and backend resources from abuse by allowing only authentic clients and
+  devices to access them.
+- **Environment management:** Use separate Firebase projects for development,
+  staging, and production.
+- **Sensitive operations:** Always have a human user approve sensitive
+  operations like granting permissive IAM roles or deleting a database.

--- a/.claude/skills/google-firebase-basics/references/mcp-usage.md
+++ b/.claude/skills/google-firebase-basics/references/mcp-usage.md
@@ -1,0 +1,63 @@
+# Firebase CLI and MCP server
+
+The Firebase CLI includes a built-in local MCP server that can help with common
+tasks.
+
+1.  **Locate MCP configuration**
+
+    Find the configuration file for your agent
+    (e.g., `~/.codeium/windsurf/mcp_config.json`, `cline_mcp_settings.json`, or
+    `claude_desktop_config.json`).
+
+    *Note: If the document or its containing directory does not exist, create
+    them and initialize the file with `{ "mcpServers": {} }` before proceeding.*
+
+2.  **Check existing configuration**
+
+    Open the configuration file and check the `mcpServers` section for a
+    `firebase` entry.
+
+    - Firebase is already configured if the `command` is `"firebase"` OR if the
+      `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
+
+    - **Important**: If a valid `firebase` entry is found, the MCP server is
+      already configured. **Skip step 3** and proceed directly to step 4.
+
+    **Example valid configurations**:
+    ```json
+    "firebase": {
+      "command": "npx",
+      "args": ["-y", "firebase-tools@latest", "mcp"]
+    }
+    ```
+    OR
+    ```json
+    "firebase": {
+      "command": "firebase",
+      "args": ["mcp"]
+    }
+    ```
+
+3.  **Add or update configuration**
+
+    If the `firebase` entry is missing or incorrect, add it to the `mcpServers`
+    object:
+
+    ```json
+    "firebase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "firebase-tools@latest",
+        "mcp"
+      ]
+    }
+    ```
+
+    *CRITICAL: Merge this configuration into the existing file. You MUST
+    preserve any other existing servers inside the `mcpServers` object.*
+
+4.  **Verify configuration**
+
+    Save the file and confirm the `firebase` block is present and is properly
+    formatted JSON.

--- a/docs/setup/ai/google-skills.md
+++ b/docs/setup/ai/google-skills.md
@@ -1,0 +1,68 @@
+# Google Agent Skills
+
+This repo curates a subset of skills from the official **Google Agent Skills** repository:
+
+- **Upstream:** <https://github.com/google/skills>
+- **Org:** `google` (official)
+- **License:** Apache 2.0
+- **Format:** each skill is a folder with a `SKILL.md` (YAML frontmatter + markdown body) and optional `references/` files. Same shape Claude Code already understands.
+
+The selected skills live under `.claude/skills/google-*/` and are committed to the repo so they are available to anyone who clones it.
+
+## Why a local sync script instead of `npx skills add`
+
+The official install command is:
+
+```bash
+npx skills add google/skills
+```
+
+That command delegates to `skills.sh` / `agentskills.io` — a third-party aggregator that is not Google. It runs arbitrary JS on your machine to copy what is essentially a handful of Markdown files. We avoid that layer entirely.
+
+Our script (`scripts/sync-google-skills.sh`) only trusts:
+
+- `git`
+- `https://github.com/google/skills.git` (official Google org)
+
+…and copies the selected `SKILL.md` files into the repo with diff + confirmation before any overwrite.
+
+## Usage
+
+```bash
+# What's available upstream
+./scripts/sync-google-skills.sh list
+
+# Install or update one or more skills
+./scripts/sync-google-skills.sh add cloud-run-basics firebase-basics
+
+# Check for upstream changes on every installed Google skill (run periodically)
+./scripts/sync-google-skills.sh sync
+
+# Remove
+./scripts/sync-google-skills.sh remove cloud-run-basics
+```
+
+Every overwrite is gated by an interactive `[y/N]` after showing the file-level diff. The script never touches skills that don't start with the `google-` prefix.
+
+## What's installed in this repo
+
+| Skill | Why it's relevant for lillorepo |
+|---|---|
+| `google-cloud-run-basics` | Every service (web, telegram_bot, chucknorris_bot) and job (scraper, teams_analyzer) is Cloud Run |
+| `google-cloud-recipe-auth` | We use ADC, Service Account keys, Secret Manager — this skill captures the canonical patterns |
+| `google-cloud-waf-security` | Security pillar of the Well-Architected Framework — IAM, network, data protection, ops |
+| `google-cloud-waf-reliability` | Reliability pillar — useful for the Cloud Run + Cloud Run Jobs setup |
+| `google-cloud-waf-cost-optimization` | Cost pillar — we run on the free tier and care about Artifact Registry cleanup |
+| `google-firebase-basics` | Pre-loaded for the upcoming Firestore migration (deferred, see `.claude/plans/next_phases.md`) |
+
+Skills explicitly not installed (and why): `alloydb-basics`, `bigquery-basics`, `cloud-sql-basics`, `gke-basics` (we don't use any of those Google products), `gemini-api` (this repo uses Claude / Anthropic), `google-cloud-networking-observability` (overkill for our footprint), `google-cloud-recipe-onboarding` (project already created).
+
+## Refresh cadence
+
+There's no automation. When you remember (or after a few weeks pass), run:
+
+```bash
+./scripts/sync-google-skills.sh sync
+```
+
+It will list each installed skill as `up to date` or show a diff and prompt you per change.

--- a/scripts/sync-google-skills.sh
+++ b/scripts/sync-google-skills.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# scripts/sync-google-skills.sh
+#
+# Selectively syncs Agent Skills from the official google/skills repo into
+# this project's .claude/skills/ directory.
+#
+# Source: https://github.com/google/skills (Apache 2.0, official Google org)
+# Avoids `npx skills add` to stay clear of third-party installers — the only
+# external trust is git + github.com/google/skills.
+
+set -euo pipefail
+
+REPO_URL="https://github.com/google/skills.git"
+PREFIX="google-"
+
+# Build the local skill directory name from an upstream skill name. Some
+# upstream skills already start with `google-` (e.g. `google-cloud-waf-security`)
+# — don't double the prefix in that case.
+local_name() {
+  local upstream="$1"
+  if [[ "$upstream" == ${PREFIX}* ]]; then
+    printf '%s\n' "$upstream"
+  else
+    printf '%s\n' "${PREFIX}${upstream}"
+  fi
+}
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$PROJECT_ROOT" ]]; then
+  echo "error: not inside a git repository." >&2
+  exit 1
+fi
+DEST_DIR="${PROJECT_ROOT}/.claude/skills"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <command> [args]
+
+Syncs Google Cloud skills from ${REPO_URL}
+into ${DEST_DIR}/${PREFIX}* (project-level skills).
+
+Commands:
+  list                  Show skills available upstream
+  add <skill> [...]     Install or update one or more skills by name
+  sync                  Check every installed Google skill for upstream changes
+  remove <skill> [...]  Delete one or more installed Google skills
+
+Every overwrite is confirmed interactively. Diffs are shown before applying.
+EOF
+}
+
+clone_upstream() {
+  echo "Cloning google/skills (shallow)…" >&2
+  git clone --depth 1 --quiet "$REPO_URL" "$TMP_DIR/repo"
+}
+
+# List skills present upstream (one per line), portable across BSD/GNU find.
+list_upstream_skills() {
+  local d
+  for d in "$TMP_DIR/repo/skills"/*/*/; do
+    [[ -d "$d" ]] || continue
+    basename "$d"
+  done | sort
+}
+
+# Resolve the upstream directory for a skill name. Echoes the absolute path
+# or returns 1 if not found.
+find_upstream_skill() {
+  local name="$1" d
+  for d in "$TMP_DIR/repo/skills"/*/"$name"/; do
+    [[ -d "$d" ]] || continue
+    printf '%s\n' "${d%/}"
+    return 0
+  done
+  return 1
+}
+
+# List installed skills (basenames), one per line. Returns the on-disk name —
+# either `google-<x>` or already-prefixed `google-cloud-<x>`.
+list_installed_skills() {
+  local d
+  for d in "$DEST_DIR/${PREFIX}"*/; do
+    [[ -d "$d" ]] || continue
+    basename "$d"
+  done | sort
+}
+
+# Show which files differ between local and upstream copies of a skill.
+show_diff_summary() {
+  local local_dir="$1"
+  local upstream_dir="$2"
+  diff -rq "$local_dir" "$upstream_dir" 2>/dev/null \
+    | sed -e "s|$TMP_DIR/repo|<upstream>|g" -e "s|$DEST_DIR|<local>|g" \
+    | sed 's/^/    /'
+}
+
+confirm() {
+  local prompt="$1" answer
+  read -r -p "$prompt [y/N] " answer
+  [[ "$answer" =~ ^[Yy] ]]
+}
+
+# Write a license notice once, alongside the synced skills. Required because
+# google/skills is Apache 2.0 and lillorepo is public.
+ensure_license_notice() {
+  local notice="$DEST_DIR/GOOGLE-SKILLS-LICENSE.md"
+  [[ -f "$notice" ]] && return
+  mkdir -p "$DEST_DIR"
+  cat > "$notice" <<'EOF'
+# Google Skills — License Notice
+
+The `google-*` skills in this directory are sourced from the official Google
+Agent Skills repository:
+
+  https://github.com/google/skills
+
+Licensed under the Apache License 2.0:
+
+  https://github.com/google/skills/blob/main/LICENSE
+
+They are synced via `scripts/sync-google-skills.sh`. Run that script to check
+for upstream changes or to install/remove skills.
+EOF
+}
+
+cmd_list() {
+  clone_upstream
+  echo ""
+  list_upstream_skills
+}
+
+cmd_add() {
+  if [[ $# -eq 0 ]]; then
+    echo "error: 'add' requires at least one skill name." >&2
+    echo "       Run '$(basename "$0") list' to see what's available." >&2
+    exit 1
+  fi
+  clone_upstream
+  ensure_license_notice
+  for name in "$@"; do
+    local src dest dirname
+    src="$(find_upstream_skill "$name" || true)"
+    if [[ -z "$src" ]]; then
+      echo "⚠ ${name}: not found upstream"
+      continue
+    fi
+    dirname="$(local_name "$name")"
+    dest="$DEST_DIR/${dirname}"
+    if [[ -d "$dest" ]]; then
+      if diff -rq "$src" "$dest" >/dev/null 2>&1; then
+        echo "✓ ${dirname}: already up to date"
+        continue
+      fi
+      echo ""
+      echo "🔄 ${dirname} differs from upstream:"
+      show_diff_summary "$dest" "$src"
+      if ! confirm "Overwrite ${dirname}?"; then
+        echo "  skipped."
+        continue
+      fi
+      rm -rf "$dest"
+    fi
+    cp -R "$src" "$dest"
+    echo "✓ ${dirname}: installed"
+  done
+}
+
+cmd_sync() {
+  clone_upstream
+  if [[ ! -d "$DEST_DIR" ]]; then
+    echo "No skills directory at $DEST_DIR — nothing to sync."
+    return
+  fi
+  local installed
+  installed="$(list_installed_skills)"
+  if [[ -z "$installed" ]]; then
+    echo "No Google skills installed (prefix '${PREFIX}')."
+    echo "Use: $(basename "$0") add <skill>"
+    return
+  fi
+  echo ""
+  for dirname in $installed; do
+    local src dest upstream_name
+    # The on-disk dir is `google-<x>`; upstream name might be the same
+    # (e.g. `google-cloud-waf-security`) or stripped (`cloud-run-basics`).
+    upstream_name="${dirname#${PREFIX}}"
+    src="$(find_upstream_skill "$upstream_name" || true)"
+    if [[ -z "$src" ]]; then
+      # Try with the prefix intact in case the upstream name is `google-...`
+      src="$(find_upstream_skill "$dirname" || true)"
+    fi
+    dest="$DEST_DIR/${dirname}"
+    if [[ -z "$src" ]]; then
+      echo "⚠ ${dirname}: no longer in upstream (kept locally)"
+      continue
+    fi
+    if diff -rq "$src" "$dest" >/dev/null 2>&1; then
+      echo "✓ ${dirname}: up to date"
+      continue
+    fi
+    echo ""
+    echo "🔄 ${dirname} has upstream changes:"
+    show_diff_summary "$dest" "$src"
+    if ! confirm "Update ${dirname}?"; then
+      echo "  kept current version."
+      continue
+    fi
+    rm -rf "$dest"
+    cp -R "$src" "$dest"
+    echo "  ✓ updated."
+  done
+}
+
+cmd_remove() {
+  if [[ $# -eq 0 ]]; then
+    echo "error: 'remove' requires at least one skill name." >&2
+    exit 1
+  fi
+  for name in "$@"; do
+    local dirname dest
+    dirname="$(local_name "$name")"
+    dest="$DEST_DIR/${dirname}"
+    if [[ ! -d "$dest" ]]; then
+      echo "  ${dirname}: not installed"
+      continue
+    fi
+    rm -rf "$dest"
+    echo "✓ removed ${dirname}"
+  done
+}
+
+case "${1:-}" in
+  list) shift; cmd_list "$@" ;;
+  add) shift; cmd_add "$@" ;;
+  sync) shift; cmd_sync "$@" ;;
+  remove) shift; cmd_remove "$@" ;;
+  -h|--help|help) usage ;;
+  "") usage; exit 1 ;;
+  *) echo "error: unknown command '$1'" >&2; usage; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary

Selectively syncs Agent Skills from the official [`google/skills`](https://github.com/google/skills) repository (Apache 2.0) into this repo's `.claude/skills/google-*/` directory — without `npx skills add`.

The `npx skills add` command delegates to `skills.sh` / `agentskills.io`, a third-party aggregator. This PR keeps the trust chain limited to `git` + the official Google org.

## What it does

- **`scripts/sync-google-skills.sh`** — bash, ~150 lines, depends only on `git`, `diff`, `cp`.
  - `list` — show skills available upstream
  - `add <skill> [...]` — install or update, with diff + confirmation when overwriting
  - `sync` — check every installed Google skill for upstream changes (run periodically)
  - `remove <skill> [...]` — delete installed skills
- **`.claude/skills/google-*/`** — 6 skills committed to the repo, so anyone who clones gets them. Stays clear of any non-`google-` skill so it never touches the custom skills like `season-rollover`, `add-python-dep`, etc.
- **`.claude/skills/GOOGLE-SKILLS-LICENSE.md`** — Apache 2.0 attribution.
- **`docs/setup/ai/google-skills.md`** — documentation: what's installed, why each one, refresh cadence.

## Skills pre-installed

| Skill | Why |
|---|---|
| `google-cloud-run-basics` | All services + jobs are Cloud Run |
| `google-cloud-recipe-auth` | ADC + SA keys + Secret Manager patterns |
| `google-cloud-waf-security` | Security pillar (relevant for the audit findings) |
| `google-cloud-waf-reliability` | Reliability pillar for our Cloud Run setup |
| `google-cloud-waf-cost-optimization` | Cost pillar (free tier) |
| `google-firebase-basics` | Pre-loaded for the deferred Firestore migration |

Not installed (and won't be unless we change stack): AlloyDB, BigQuery, Cloud SQL, GKE, Gemini API, networking observability, onboarding.

## Test plan

- [x] `./scripts/sync-google-skills.sh list` returns the 13 upstream skills
- [x] `./scripts/sync-google-skills.sh add cloud-run-basics` installs as `google-cloud-run-basics/`
- [x] Re-running `add` on an unchanged skill reports `already up to date`
- [x] Tampering a local `SKILL.md` and running `sync` detects drift and prompts before overwriting
- [x] `remove` deletes only the matching `google-*` directory
- [x] `add` skips the prefix when the upstream name already starts with `google-` (no `google-google-...`)
- [ ] Run `./scripts/sync-google-skills.sh sync` again in 2–3 weeks; expect diffs as Google iterates on the skills

## Not in this PR

- No automation (cron, GitHub Action) — refresh stays manual on purpose. If we want a periodic check, that goes in a follow-up.
- Doesn't conflict with PR #36 (`chore/cleanup-readability`); files don't overlap.