### PR TITLE
fix(security): close XSS, harden Flask, move JP token to secret

### DIFF
--- a/.claude/plans/next_phases.md
+++ b/.claude/plans/next_phases.md
@@ -11,7 +11,7 @@ are already taken.
 - **All packages in CI**: web, scraper_job, teams_analyzer, telegram_bot, chucknorris_bot.
 - **Python**: 3.13.
 - **GCP secrets**: consolidated — 3 JSON regional secrets only.
-  - `biwenger-credentials-regional` — `{email, password, gdrive_folder_id}`
+  - `biwenger-credentials-regional` — `{email, password, gdrive_folder_id, jp_auth_token}` *(jp_auth_token added 2026-05-16 to remove the hardcoded JP token from public git; see `fix/security-hardening`)*
   - `telegram-bot-config-regional` — `{bot_token, chat_id, webhook_secret}`
   - `chucknorris-bot-config-regional` — `{bot_token, webhook_secret}`
   - `biwenger-tools-sa-regional` — Google Drive SA key (file mount at `/gdrive_sa/`)

--- a/core/sdk/telegram.py
+++ b/core/sdk/telegram.py
@@ -1,3 +1,4 @@
+import hmac
 from typing import Any
 
 import requests
@@ -118,6 +119,10 @@ def extract_webhook_update(request: Any) -> tuple[str, str]:
 
 
 def validate_webhook_secret(request: Any, expected: str) -> bool:
-    """Return True if the X-Telegram-Bot-Api-Secret-Token header matches."""
+    """Return True if the X-Telegram-Bot-Api-Secret-Token header matches.
+
+    Uses constant-time comparison to avoid leaking the expected token via
+    response-time side channels.
+    """
     received = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
-    return received == expected
+    return hmac.compare_digest(received, expected)

--- a/packages/biwenger_tools/teams_analyzer/config.py
+++ b/packages/biwenger_tools/teams_analyzer/config.py
@@ -43,7 +43,12 @@ LEAGUE_DATA_URL = biwenger_sdk.league_standings_url(LEAGUE_ID)
 USER_SQUAD_URL = biwenger_sdk.manager_squad_url("{manager_id}")
 
 # --- JORNADA PERFECTA (API privada) ---
-JP_AUTH_TOKEN = "lks9k2k$iJK"
+# JP_AUTH_TOKEN is sourced from the BIWENGER_CREDENTIALS_JSON secret (new key
+# `jp_auth_token`) so it stops living in the public git history. Fallback to a
+# JP_AUTH_TOKEN env var for local dev. The token belongs to the JP mobile app
+# and can't be rotated by us, so this only limits exposure surface — it does
+# not "secret-ify" something we own.
+JP_AUTH_TOKEN = _BIWENGER_CFG.get("jp_auth_token") or os.getenv("JP_AUTH_TOKEN", "")
 JP_COMPETITION = 1  # LaLiga
 JP_SCORE_TYPE = 2  # SofaScore (sistema usado por el Automanager)
 

--- a/packages/biwenger_tools/telegram_bot/app.py
+++ b/packages/biwenger_tools/telegram_bot/app.py
@@ -37,7 +37,13 @@ _JOB_MODES = {
 @app.route("/telegram/webhook", methods=["POST"])
 def webhook():
     if not validate_webhook_secret(request, config.TELEGRAM_WEBHOOK_SECRET):
-        logger.warning("Webhook: invalid secret token")
+        logger.warning(
+            "Webhook: invalid secret token",
+            extra={
+                "remote_addr": request.remote_addr,
+                "user_agent": request.headers.get("User-Agent", ""),
+            },
+        )
         return "", 401
 
     chat_id, text = extract_webhook_update(request)

--- a/packages/biwenger_tools/web/app.py
+++ b/packages/biwenger_tools/web/app.py
@@ -6,17 +6,31 @@ import re
 from flask import Flask, g, request, session
 
 from packages.biwenger_tools.web import config, services
+from packages.biwenger_tools.web.csrf import get_csrf_token
 from packages.biwenger_tools.web.routes.admin import bp as admin_bp
 from packages.biwenger_tools.web.routes.main import bp as main_bp
 from packages.biwenger_tools.web.routes.season import bp as season_bp
+from packages.biwenger_tools.web.sanitize import safe_html
 
 _SEASON_RE = re.compile(r"^\d{2}-\d{2}$")
 
 template_dir = os.path.join(os.path.dirname(__file__), "templates")
 app = Flask(__name__, template_folder=template_dir)
 app.config["SECRET_KEY"] = config.SECRET_KEY
+# Session cookie hardening. SESSION_COOKIE_SECURE defaults to True so HTTPS
+# is enforced in Cloud Run; local dev over plain HTTP can set
+# SESSION_COOKIE_SECURE=false in .env.
+app.config.update(
+    SESSION_COOKIE_HTTPONLY=True,
+    SESSION_COOKIE_SAMESITE="Lax",
+    SESSION_COOKIE_SECURE=os.getenv("SESSION_COOKIE_SECURE", "true").lower() != "false",
+)
 
 services.init_services()
+
+# Register the sanitize filter so templates can do `{{ msg.contenido | safe_html }}`
+# instead of the unsafe `| safe`.
+app.jinja_env.filters["safe_html"] = safe_html
 
 app.register_blueprint(main_bp)
 app.register_blueprint(season_bp)
@@ -32,6 +46,7 @@ def inject_globals() -> dict:
         "temporadas_disponibles": config.TEMPORADAS_DISPONIBLES,
         "git_commit": config.GIT_COMMIT,
         "deploy_time": config.DEPLOY_TIME,
+        "csrf_token": get_csrf_token,
     }
 
 

--- a/packages/biwenger_tools/web/config.py
+++ b/packages/biwenger_tools/web/config.py
@@ -1,5 +1,7 @@
 # config.py
 import os
+import sys
+
 from dotenv import load_dotenv
 
 # Carga las variables del archivo .env si existe (para desarrollo local)
@@ -39,7 +41,20 @@ CLOUD_RUN_JOB_NAME = os.getenv("CLOUD_RUN_JOB_NAME")
 CLOUD_RUN_REGION = os.getenv("CLOUD_RUN_REGION", "europe-southwest1")
 
 # --- SECRETOS DE LA APLICACIÓN ---
-SECRET_KEY = os.getenv("SECRET_KEY", "default-dev-key")
+# Refuse to start without a SECRET_KEY in production. A predictable default
+# (the old "default-dev-key") makes Flask session cookies trivially forgeable,
+# so we never want it to silently leak into a real deploy.
+SECRET_KEY = os.getenv("SECRET_KEY")
+if not SECRET_KEY:
+    if "pytest" in sys.modules:
+        # Test suites set their own value on app.config after import; allow
+        # module import to succeed so collection doesn't fail.
+        SECRET_KEY = "pytest-secret-key-not-for-prod"
+    else:
+        raise RuntimeError(
+            "SECRET_KEY env var is required; refusing to start with a default."
+        )
+
 ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD")
 
 # --- VERSIÓN DESPLEGADA (short SHA, 7 chars) ---

--- a/packages/biwenger_tools/web/csrf.py
+++ b/packages/biwenger_tools/web/csrf.py
@@ -1,0 +1,30 @@
+"""CSRF token helpers for Flask form POSTs.
+
+Tokens live in the signed session cookie. Templates pull the current token
+via `{{ csrf_token() }}` (registered as a context processor in app.py).
+POST handlers gate themselves with `verify_csrf_token()`.
+
+A handwritten implementation is enough for our two admin forms; adding
+Flask-WTF for this would be more dependency than logic.
+"""
+
+import hmac
+import secrets
+
+from flask import request, session
+
+
+def get_csrf_token() -> str:
+    """Return the per-session CSRF token, creating it on first access."""
+    if "csrf_token" not in session:
+        session["csrf_token"] = secrets.token_urlsafe(32)
+    return session["csrf_token"]
+
+
+def verify_csrf_token() -> bool:
+    """Constant-time check of the submitted csrf_token form field."""
+    submitted = request.form.get("csrf_token", "")
+    expected = session.get("csrf_token", "")
+    if not submitted or not expected:
+        return False
+    return hmac.compare_digest(submitted, expected)

--- a/packages/biwenger_tools/web/routes/admin.py
+++ b/packages/biwenger_tools/web/routes/admin.py
@@ -22,6 +22,7 @@ from flask import (
 from core.sdk.gcp import get_file_metadata
 from core.utils import get_logger
 from packages.biwenger_tools.web import config, services
+from packages.biwenger_tools.web.csrf import verify_csrf_token
 
 bp = Blueprint("admin", __name__)
 logger = get_logger(__name__)
@@ -132,6 +133,13 @@ def admin() -> Response:
         )
 
     if request.method == "POST":
+        if not verify_csrf_token():
+            logger.warning(
+                "CSRF token mismatch on /admin login.",
+                extra={"remote_addr": request.remote_addr},
+            )
+            flash("Sesión expirada. Vuelve a intentarlo.", "error")
+            return redirect(url_for("admin.admin"))
         if request.form.get("password") == config.ADMIN_PASSWORD:
             session["admin_logged_in"] = True
             return redirect(url_for("admin.admin"))
@@ -145,6 +153,14 @@ def run_scraper() -> Response:
     """Trigger the scraper Cloud Run Job on demand."""
     if "admin_logged_in" not in session:
         flash("Acceso denegado.", "error")
+        return redirect(url_for("admin.admin"))
+
+    if not verify_csrf_token():
+        logger.warning(
+            "CSRF token mismatch on /admin/run-scraper.",
+            extra={"remote_addr": request.remote_addr},
+        )
+        flash("Sesión expirada. Recarga la página y vuelve a intentarlo.", "error")
         return redirect(url_for("admin.admin"))
 
     success, message = _trigger_scraper_job()

--- a/packages/biwenger_tools/web/routes/season.py
+++ b/packages/biwenger_tools/web/routes/season.py
@@ -11,13 +11,20 @@ from core.domain.models import Clausulazo, JusticeEntry, LeagueMessage, Particip
 from core.sdk.gcp import download_csv_as_dict, find_file_on_drive, get_sheets_data
 from core.utils import get_logger
 from packages.biwenger_tools.web import config, services
+from packages.biwenger_tools.web.sanitize import safe_html
 
 logger = get_logger(__name__)
 bp = Blueprint("season", __name__)
 
 
 def _load_messages(filename: str) -> tuple[list, Optional[str]]:
-    """Load all LeagueMessage entries from a Drive CSV. Returns (messages, error)."""
+    """Load all LeagueMessage entries from a Drive CSV. Returns (messages, error).
+
+    `contenido` is stripped of its HTML markup eagerly here: every caller either
+    renders it through the `safe_html` Jinja filter or ships it to the browser
+    via `tojson` to be assigned with `innerHTML`. Sanitizing once at load time
+    makes both paths XSS-safe regardless of what Biwenger writes upstream.
+    """
     if not services.drive_service:
         return [], "El servicio de Google Drive no está disponible."
     file_meta = find_file_on_drive(
@@ -26,7 +33,13 @@ def _load_messages(filename: str) -> tuple[list, Optional[str]]:
     if not file_meta:
         return [], f"El archivo '{filename}' no se encontró en Google Drive."
     rows = download_csv_as_dict(services.drive_service, file_meta["id"])
-    return [LeagueMessage.from_csv_row(r) for r in rows], None
+    messages = [LeagueMessage.from_csv_row(r) for r in rows]
+    for m in messages:
+        # Pre-render as HTML-escaped Markup with <br> for newlines so the
+        # value is safe for both server-side rendering and the JS innerHTML
+        # paths that pull it via `{{ ... | tojson }}`.
+        m.contenido = str(safe_html(m.contenido))
+    return messages, None
 
 
 @bp.route("/<season>/")

--- a/packages/biwenger_tools/web/sanitize.py
+++ b/packages/biwenger_tools/web/sanitize.py
@@ -1,0 +1,42 @@
+"""HTML sanitization for content coming from the Biwenger API.
+
+Biwenger lets league members write announcements in a rich editor, so the
+content arrives as HTML written by humans (and forwarded verbatim by the
+scraper). Rendering it with `|safe` lets any member inject `<script>` or
+event-handler attributes into the page — which is reachable because the
+web service is `allow-unauthenticated`.
+
+We sanitize by stripping the markup entirely with BeautifulSoup (already a
+dep for the scraper, no new package) and re-rendering as plain text with
+HTML line breaks. The trade-off is loss of formatting (bold, links, lists)
+in exchange for a guaranteed-safe output. If we ever need rich formatting
+back, swap this for `bleach.clean(html, tags=ALLOWED, attrs=ALLOWED_ATTRS)`.
+"""
+
+from bs4 import BeautifulSoup
+from markupsafe import Markup, escape
+
+
+def html_to_plain_text(html: str | None) -> str:
+    """Extract the text content from arbitrary HTML.
+
+    Block-level tags (<p>, <li>, ...) and <br> are turned into newlines so
+    the visual structure of the message is preserved when re-rendered.
+    """
+    if not html:
+        return ""
+    soup = BeautifulSoup(html, "html.parser")
+    for br in soup.find_all("br"):
+        br.replace_with("\n")
+    return soup.get_text(separator="\n", strip=True)
+
+
+def safe_html(html: str | None) -> Markup:
+    """Jinja filter: render sanitized HTML.
+
+    Returns a `Markup` (already escaped) with `\n` converted to `<br>` so
+    paragraph breaks survive. Safe to drop into `{{ ... | safe_html }}`.
+    """
+    text = html_to_plain_text(html)
+    lines = [escape(line) for line in text.split("\n")]
+    return Markup("<br>".join(lines))

--- a/packages/biwenger_tools/web/templates/admin_login.html
+++ b/packages/biwenger_tools/web/templates/admin_login.html
@@ -6,6 +6,7 @@
 <div class="card p-8 rounded-xl shadow-lg max-w-md mx-auto">
     <h2 class="font-header text-3xl font-bold text-gray-900 mb-6 text-center">Acceso al VAR</h2>
     <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="mb-4">
             <label for="password" class="block text-sm font-medium text-gray-700">Contraseña</label>
             <input type="password" name="password" id="password" required

--- a/packages/biwenger_tools/web/templates/admin_panel.html
+++ b/packages/biwenger_tools/web/templates/admin_panel.html
@@ -28,6 +28,7 @@
             <!-- Botón de forzar ejecución -->
             <form method="POST" action="{{ url_for('admin.run_scraper') }}"
                   onsubmit="return confirm('¿Lanzar el scraper ahora? La ejecución tarda ~2 min.');">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit"
                         class="inline-flex items-center gap-2 px-5 py-2.5 bg-green-600 hover:bg-green-700
                                text-white text-sm font-semibold rounded-lg shadow transition-colors">

--- a/packages/biwenger_tools/web/templates/index.html
+++ b/packages/biwenger_tools/web/templates/index.html
@@ -28,7 +28,7 @@
                     </div>
                     <span class="text-sm text-gray-500 text-right flex-shrink-0 ml-4">{{ message.fecha }}</span>
                 </div>
-                <div class="prose max-w-none leading-relaxed">{{ message.contenido | safe }}</div>
+                <div class="prose max-w-none leading-relaxed">{{ message.contenido | safe_html }}</div>
             </article>
             {% endfor %}
         {% else %}

--- a/packages/biwenger_tools/web/templates/salseo.html
+++ b/packages/biwenger_tools/web/templates/salseo.html
@@ -36,7 +36,7 @@
             </div>
             <span class="text-sm text-gray-500 text-right flex-shrink-0 ml-4">{{ message.fecha }}</span>
         </div>
-        <div class="prose max-w-none leading-relaxed">{{ message.contenido | safe }}</div>
+        <div class="prose max-w-none leading-relaxed">{{ message.contenido | safe_html }}</div>
     </article>
     {% else %}
     <div class="card p-8 text-center text-gray-400 rounded-xl">No hay crónicas esta temporada.</div>
@@ -54,7 +54,7 @@
             </div>
             <span class="text-sm text-gray-500 text-right flex-shrink-0 ml-4">{{ message.fecha }}</span>
         </div>
-        <div class="prose max-w-none leading-relaxed">{{ message.contenido | safe }}</div>
+        <div class="prose max-w-none leading-relaxed">{{ message.contenido | safe_html }}</div>
     </article>
     {% else %}
     <div class="card p-8 text-center text-gray-400 rounded-xl">No hay datos curiosos esta temporada.</div>

--- a/packages/biwenger_tools/web/tests/test_web_app.py
+++ b/packages/biwenger_tools/web/tests/test_web_app.py
@@ -280,6 +280,19 @@ def test_api_lloros_trofeos_returns_sheets_data(mock_get_sheets, client):
 # --- Admin panel tests ---
 
 
+def _seed_csrf(client) -> str:
+    """Plant a known CSRF token in the session and return it.
+
+    Form POSTs require the field to match `session["csrf_token"]`; we set both
+    sides explicitly so the tests exercise the real path instead of mocking
+    `verify_csrf_token`.
+    """
+    token = "test-csrf-token"
+    with client.session_transaction() as sess:
+        sess["csrf_token"] = token
+    return token
+
+
 @patch("packages.biwenger_tools.web.app.config.ADMIN_PASSWORD", "test_password")
 def test_admin_login_get_page(client):
     """Verify that the admin login page loads correctly."""
@@ -291,8 +304,11 @@ def test_admin_login_get_page(client):
 @patch("packages.biwenger_tools.web.app.config.ADMIN_PASSWORD", "test_password")
 def test_admin_login_post_success(client):
     """Verify that login succeeds with the correct password."""
+    token = _seed_csrf(client)
     response = client.post(
-        "/admin", data={"password": "test_password"}, follow_redirects=True
+        "/admin",
+        data={"password": "test_password", "csrf_token": token},
+        follow_redirects=True,
     )
     assert response.status_code == 200
     with client.session_transaction() as sess:
@@ -302,8 +318,22 @@ def test_admin_login_post_success(client):
 @patch("packages.biwenger_tools.web.app.config.ADMIN_PASSWORD", "test_password")
 def test_admin_login_post_fail(client):
     """Verify that login fails with an incorrect password."""
-    response = client.post("/admin", data={"password": "wrong_password"})
+    token = _seed_csrf(client)
+    response = client.post(
+        "/admin", data={"password": "wrong_password", "csrf_token": token}
+    )
     assert response.status_code == 200
+    with client.session_transaction() as sess:
+        assert "admin_logged_in" not in sess
+
+
+def test_admin_login_post_rejected_without_csrf(client):
+    """POST without a valid csrf_token must not authenticate."""
+    with patch(
+        "packages.biwenger_tools.web.app.config.ADMIN_PASSWORD", "test_password"
+    ):
+        response = client.post("/admin", data={"password": "test_password"})
+    assert response.status_code in (302, 200)
     with client.session_transaction() as sess:
         assert "admin_logged_in" not in sess
 
@@ -345,7 +375,12 @@ def test_run_scraper_triggers_job_and_redirects(mock_trigger, client):
     mock_trigger.return_value = (True, "Job lanzado correctamente (ejecución: abc123).")
     with client.session_transaction() as sess:
         sess["admin_logged_in"] = True
-    response = client.post("/admin/run-scraper", follow_redirects=False)
+        sess["csrf_token"] = "test-csrf-token"
+    response = client.post(
+        "/admin/run-scraper",
+        data={"csrf_token": "test-csrf-token"},
+        follow_redirects=False,
+    )
     assert response.status_code == 302
     assert "/admin" in response.headers["Location"]
     mock_trigger.assert_called_once()
@@ -357,7 +392,12 @@ def test_run_scraper_shows_error_flash_on_failure(mock_trigger, client):
     mock_trigger.return_value = (False, "Error al lanzar el job: timeout.")
     with client.session_transaction() as sess:
         sess["admin_logged_in"] = True
-    response = client.post("/admin/run-scraper", follow_redirects=True)
+        sess["csrf_token"] = "test-csrf-token"
+    response = client.post(
+        "/admin/run-scraper",
+        data={"csrf_token": "test-csrf-token"},
+        follow_redirects=True,
+    )
     assert response.status_code == 200
     assert b"Error al lanzar el job" in response.data
 
@@ -367,6 +407,16 @@ def test_run_scraper_requires_login(client):
     response = client.post("/admin/run-scraper", follow_redirects=False)
     assert response.status_code == 302
     assert "/admin" in response.headers["Location"]
+
+
+@patch("packages.biwenger_tools.web.routes.admin._trigger_scraper_job")
+def test_run_scraper_rejected_without_csrf(mock_trigger, client):
+    """Logged-in admin without csrf_token must not trigger the job."""
+    with client.session_transaction() as sess:
+        sess["admin_logged_in"] = True
+    response = client.post("/admin/run-scraper", follow_redirects=False)
+    assert response.status_code == 302
+    mock_trigger.assert_not_called()
 
 
 # --- Mercado route tests ---

--- a/packages/chucknorris_bot/bot/app.py
+++ b/packages/chucknorris_bot/bot/app.py
@@ -55,7 +55,13 @@ def index():
 @app.route("/telegram/webhook", methods=["POST"])
 def webhook():
     if not validate_webhook_secret(request, config.TELEGRAM_WEBHOOK_SECRET):
-        logger.warning("Webhook: invalid secret token")
+        logger.warning(
+            "Webhook: invalid secret token",
+            extra={
+                "remote_addr": request.remote_addr,
+                "user_agent": request.headers.get("User-Agent", ""),
+            },
+        )
         return "", 401
 
     chat_id, text = extract_webhook_update(request)


### PR DESCRIPTION
## Summary

Acts on the security findings from the recent audit. Cero overlap with PR #36 (which is naming/legibility only — this is behavioural change that deserves its own review).

## Findings addressed

| # | Issue | Fix |
|---|---|---|
| 1 | `JP_AUTH_TOKEN = "lks9k2k$iJK"` hardcoded in `teams_analyzer/config.py` and committed to a public repo | Read from existing secret `BIWENGER_CREDENTIALS_JSON.jp_auth_token`; fallback env var for local dev. **No new secret created** — extended the regional one |
| 2 | XSS via `{{ message.contenido \| safe }}` (3 occurrences in `index.html`/`salseo.html`) | New `web/sanitize.py`: BeautifulSoup-based HTML→plain-text + `<br>` for line breaks. Pre-rendered once in `_load_messages`. New `safe_html` Jinja filter for defense-in-depth |
| 3 | Timing attack: `received == expected` in `core/sdk/telegram.py:validate_webhook_secret` | `hmac.compare_digest(received, expected)` |
| 4 | `SECRET_KEY` defaulted to `"default-dev-key"` — silent leak risk in prod | `web/config.py` refuses to start in production without the env var; tests allowed |
| 5 | No CSRF on `/admin` (POST password) and `/admin/run-scraper` | Hand-rolled token in `web/csrf.py`, validated constant-time. No Flask-WTF added — 20 LOC suffice |
| 6 | Session cookies missing `Secure` / `HttpOnly` / `SameSite` | All three set in `web/app.py`; `SESSION_COOKIE_SECURE` env-var-overridable for local HTTP |
| 7 | Webhook reject log had no IP/UA | `remote_addr` + `User-Agent` added (both bots) |

## Trade-off notes

- **Sanitization** kills XSS but also kills rich formatting (bold, links, lists). Biwenger messages render as plain text with line breaks. If we want formatting back, swap `safe_html` for `bleach.clean(...)` — that needs a new PyPI dep + a `python-base` docker rebuild, which is why I avoided it in this PR.
- **No Flask-WTF** for CSRF. The whole web app has 2 POST forms; ~20 lines of token-in-session is enough and cuts one transitive dep.
- **JP token**: I can't rotate it (not ours), so the only available win is reducing exposure surface — getting it out of the public source tree. The bundled mobile app still contains it; anyone can re-extract.

## Operator step required BEFORE merging

The new code expects `jp_auth_token` inside `BIWENGER_CREDENTIALS_JSON`. Update the secret first, then merge:

```bash
# Pull current JSON
gcloud secrets versions access latest --secret=biwenger-credentials-regional > /tmp/creds.json

# Add the key — open in $EDITOR and add:
#   "jp_auth_token": "lks9k2k$iJK"

# Push a new version
gcloud secrets versions add biwenger-credentials-regional --data-file=/tmp/creds.json

# Verify the job picks it up (next scheduled run will use the new version automatically)
```

For local dev: either add `jp_auth_token` to your local `BIWENGER_CREDENTIALS_JSON` env or set `JP_AUTH_TOKEN` as a plain env var.

After merge, **purge the token from git history** is *not* in scope here (history rewrite is a separate, disruptive operation). The token stays accessible to anyone reading `git log`; the value of this PR is stopping the *forward-going* leak and removing it from `master` HEAD.

## Test plan

- [x] `bazel test //...` — 6/6 green (including new CSRF rejection tests)
- [x] `flake8 + black` — clean
- [ ] **Manual**: update the secret as above, deploy `biwenger-summary` and `biwenger-teams-analyzer`, then trigger `/analizar` and `/admin/run-scraper` to confirm
- [ ] **Manual**: visit `/` and `/<season>/salseo`, verify messages still render with newlines