### PR TITLE
chore(core): centralise residual duplicates (MADRID_TZ, LEAGUE_ID, etc.)

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -8,6 +8,7 @@ py_library(
     name = "_init",
     srcs = [
         "__init__.py",
+        "constants.py",
         "utils.py",
         "domain/__init__.py",
         "domain/models.py",

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,0 +1,20 @@
+"""Shared constants used across packages.
+
+Centralised here to avoid hand-duplication that has drifted in the past
+(`MADRID_TZ`, `LEAGUE_ID`, etc.). Import the symbol you need; don't redefine.
+"""
+
+from datetime import timedelta
+from zoneinfo import ZoneInfo
+
+# Madrid timezone — all timestamps surfaced to the user (CSV `fecha`,
+# admin panel "last updated", scheduled-job logs) are expected in this zone.
+MADRID_TZ = ZoneInfo("Europe/Madrid")
+
+# Biwenger league ID. Single value for now — if we ever need to operate
+# multiple leagues, this becomes per-config.
+LEAGUE_ID = "340703"
+
+# A dynamic Drive file is considered stale if it hasn't been touched in
+# this long. Surfaced as a red "is_stale" badge in the admin panel.
+DRIVE_STALE_THRESHOLD = timedelta(days=7)

--- a/core/sdk/gcp.py
+++ b/core/sdk/gcp.py
@@ -1,18 +1,16 @@
 import csv
 import io
-from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo
+from datetime import datetime
 
 from dateutil import parser
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
 
+from core.constants import DRIVE_STALE_THRESHOLD, MADRID_TZ
 from core.utils import get_logger
 
 logger = get_logger(__name__)
-
-MADRID_TZ = ZoneInfo("Europe/Madrid")
 
 
 # --- AUTHENTICATION ---
@@ -145,8 +143,9 @@ def get_file_metadata(
             dt_utc = parser.isoparse(file["modifiedTime"])
             dt_madrid = dt_utc.astimezone(MADRID_TZ)
             formatted_date = dt_madrid.strftime("%d-%m-%Y a las %H:%M:%S")
-            is_stale = name in dynamic_files and (now_madrid - dt_madrid) > timedelta(
-                days=7
+            is_stale = (
+                name in dynamic_files
+                and (now_madrid - dt_madrid) > DRIVE_STALE_THRESHOLD
             )
             statuses.append(
                 {

--- a/packages/biwenger_tools/scraper_job/config.py
+++ b/packages/biwenger_tools/scraper_job/config.py
@@ -1,8 +1,11 @@
 import os
 from dotenv import load_dotenv
 
+from core.constants import LEAGUE_ID  # re-exported for callers
 from core.sdk import biwenger as biwenger_sdk
 from core.utils import load_json_secret
+
+_ = LEAGUE_ID  # noqa: F841  (silence unused-import for callers via config.LEAGUE_ID)
 
 # Carga las variables del archivo .env para el desarrollo local
 load_dotenv()
@@ -22,7 +25,7 @@ GDRIVE_FOLDER_ID = _BIWENGER_CFG.get("gdrive_folder_id") or os.getenv(
 )
 
 # --- CONFIGURACIÓN NO CRÍTICA (valores fijos) ---
-LEAGUE_ID = "340703"
+# LEAGUE_ID re-exported from core.constants at the top of the file.
 SCOPES = ["https://www.googleapis.com/auth/drive"]
 
 # --- URLs DE LA API DE BIWENGER (constantes en core; deriva las de la liga) ---

--- a/packages/biwenger_tools/scraper_job/logic/processing.py
+++ b/packages/biwenger_tools/scraper_job/logic/processing.py
@@ -1,15 +1,13 @@
 from collections import defaultdict
 from datetime import datetime
-from zoneinfo import ZoneInfo
 
 import unidecode
 
+from core.constants import MADRID_TZ
 from core.domain.models import Clausulazo, JusticeEntry, LeagueMessage, Participation
 from core.utils import get_logger
 
 logger = get_logger(__name__)
-
-MADRID_TZ = ZoneInfo("Europe/Madrid")
 
 
 def categorize_title(title):

--- a/packages/biwenger_tools/scraper_job/main.py
+++ b/packages/biwenger_tools/scraper_job/main.py
@@ -6,10 +6,10 @@ import io
 import os
 from datetime import datetime, timezone
 from typing import Optional
-from zoneinfo import ZoneInfo
 
 from bs4 import BeautifulSoup
 
+from core.constants import MADRID_TZ
 from core.domain.models import Clausulazo, JusticeEntry, LeagueMessage, Participation
 from core.sdk.biwenger import BiwengerClient
 from core.sdk.gcp import (
@@ -29,8 +29,6 @@ from packages.biwenger_tools.scraper_job.logic.processing import (
 )
 
 logger = get_logger(__name__)
-
-MADRID_TZ = ZoneInfo("Europe/Madrid")
 
 
 def _read_credentials(cfg) -> tuple[str, str, str]:

--- a/packages/biwenger_tools/teams_analyzer/config.py
+++ b/packages/biwenger_tools/teams_analyzer/config.py
@@ -1,8 +1,11 @@
 import os
 from dotenv import load_dotenv
 
+from core.constants import LEAGUE_ID  # re-exported for callers
 from core.sdk import biwenger as biwenger_sdk
 from core.utils import load_json_secret
+
+_ = LEAGUE_ID  # noqa: F841  (silence unused-import for callers via config.LEAGUE_ID)
 
 load_dotenv()
 
@@ -23,7 +26,7 @@ TELEGRAM_CHAT_ID = (
 ).strip()
 
 # --- CONFIGURACIÓN NO CRÍTICA (valores fijos) ---
-LEAGUE_ID = "340703"
+# LEAGUE_ID re-exported from core.constants at the top of the file.
 
 # --- URLs DE LA API DE BIWENGER (desde core; deriva las dependientes de la liga) ---
 LOGIN_URL = biwenger_sdk.LOGIN_URL

--- a/packages/biwenger_tools/teams_analyzer/logic/lineup.py
+++ b/packages/biwenger_tools/teams_analyzer/logic/lineup.py
@@ -5,8 +5,7 @@ and 11-player assignment that maximises the total SF predict score.
 """
 
 from core.sdk.jp import get_predict_rate
-
-SCORE_SF = 2
+from packages.biwenger_tools.teams_analyzer.player_formatting import SCORE_SF
 
 # All supported formations as (label, def, mid, fwd)
 FORMATIONS = [

--- a/packages/biwenger_tools/web/routes/admin.py
+++ b/packages/biwenger_tools/web/routes/admin.py
@@ -1,7 +1,6 @@
 """Admin routes: login panel, logout, and on-demand scraper trigger."""
 
-from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo
+from datetime import datetime
 
 import google.auth
 import google.auth.transport.requests
@@ -19,6 +18,7 @@ from flask import (
     url_for,
 )
 
+from core.constants import DRIVE_STALE_THRESHOLD, MADRID_TZ
 from core.sdk.gcp import get_file_metadata
 from core.utils import get_logger
 from packages.biwenger_tools.web import config, services
@@ -26,8 +26,6 @@ from packages.biwenger_tools.web.csrf import verify_csrf_token
 
 bp = Blueprint("admin", __name__)
 logger = get_logger(__name__)
-
-MADRID_TZ = ZoneInfo("Europe/Madrid")
 
 _CLOUD_RUN_JOBS_API = (
     "https://run.googleapis.com/v2/projects/{project}/locations/{region}/jobs/{job}:run"
@@ -43,7 +41,7 @@ def _get_sheet_file_status(sheet_id: str) -> dict:
     )
     dt_utc = parser.isoparse(sheet_metadata["modifiedTime"])
     dt_madrid = dt_utc.astimezone(MADRID_TZ)
-    is_stale = (datetime.now(MADRID_TZ) - dt_madrid) > timedelta(days=7)
+    is_stale = (datetime.now(MADRID_TZ) - dt_madrid) > DRIVE_STALE_THRESHOLD
     return {
         "name": f"{sheet_metadata['name']} (Sheet)",
         "status": "Encontrado",


### PR DESCRIPTION
## Summary

Cierra los 4 duplicados que sobrevivieron al cleanup de PR #36 (los que toqué en aquel PR eran funciones/constantes con prefix `_` o magic numbers obvios — éstos son shared values entre paquetes que conviene tener en `core/`).

## What moves to `core/constants.py`

| Constant | Lived in | Now |
|---|---|---|
| `MADRID_TZ = ZoneInfo("Europe/Madrid")` | 4 sitios (gcp, scraper_job/main, scraper_job/processing, web/admin) | `core/constants.py` |
| `LEAGUE_ID = "340703"` | 2 sitios (scraper_job/config, teams_analyzer/config) | `core/constants.py`, ambos configs lo re-exportan |
| `DRIVE_STALE_THRESHOLD = timedelta(days=7)` | Magic en gcp.py + admin.py | `core/constants.py` |
| `SCORE_SF = 2` | Duplicado en lineup.py además de player_formatting.py | `lineup.py` ahora importa de `player_formatting` |

`core/BUILD.bazel` actualizado para incluir `constants.py` en el target `_init`.

## Test plan

- [x] `bazel test //...` — 6/6 green
- [x] `flake8 + black` — clean
- [ ] CI on master will rebuild all 5 service/job images (core changed → todos los servicios se redeployan)

Cero cambio de comportamiento. Solo extracción de constantes.