### PR TITLE
feat(web): bleach sanitization to restore rich HTML formatting

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,7 +32,7 @@ oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 # Imagen base CON TODAS las dependencias preinstaladas (para producción)
 oci.pull(
     name = "python_with_deps",
-    digest = "sha256:5553373fe4697cd936f56eb9ead8d289d8184aa58e4455d94d23a3bb0a75aeac",
+    digest = "sha256:62b2c9cb5090d4993c5592f9111f63595671c39b03dedbd461640ddde79f4016",
     image = "europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/python-base",
     platforms = [
         "linux/amd64",

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -11,6 +11,7 @@ FROM python:3.13-slim@sha256:0ee2df98db454606ca92bb7a79d47ff7dc9cc0c8d5901e32eb7
 RUN pip install --no-cache-dir \
     beautifulsoup4==4.14.3 \
     black==26.3.1 \
+    bleach==6.3.0 \
     blinker==1.9.0 \
     certifi==2026.4.22 \
     cffi==2.0.0 \
@@ -70,6 +71,7 @@ RUN pip install --no-cache-dir \
     unidecode==1.4.0 \
     uritemplate==4.2.0 \
     urllib3==2.6.3 \
+    webencodings==0.5.1 \
     werkzeug==3.1.8
 
 ENV PYTHONUNBUFFERED=1

--- a/packages/biwenger_tools/web/BUILD.bazel
+++ b/packages/biwenger_tools/web/BUILD.bazel
@@ -6,6 +6,7 @@ python_service(
     main = "app.py",
     repository = "europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/web",
     secrets = ["biwenger-tools-sa.json", ".env"],
+    deps = ["@pypi//bleach"],
     extra_env = {
         "PORT": "8080",
         "PYTHONPATH": "/app",

--- a/packages/biwenger_tools/web/requirements.txt
+++ b/packages/biwenger_tools/web/requirements.txt
@@ -3,6 +3,7 @@ Flask
 python-dotenv
 unidecode
 beautifulsoup4
+bleach
 gunicorn
 
 # Para el manejo de fechas y zonas horarias

--- a/packages/biwenger_tools/web/sanitize.py
+++ b/packages/biwenger_tools/web/sanitize.py
@@ -2,41 +2,68 @@
 
 Biwenger lets league members write announcements in a rich editor, so the
 content arrives as HTML written by humans (and forwarded verbatim by the
-scraper). Rendering it with `|safe` lets any member inject `<script>` or
-event-handler attributes into the page — which is reachable because the
-web service is `allow-unauthenticated`.
+scraper). Rendering it with `|safe` would let any member inject `<script>`
+or event-handler attributes into the page — reachable because the web
+service is `allow-unauthenticated`.
 
-We sanitize by stripping the markup entirely with BeautifulSoup (already a
-dep for the scraper, no new package) and re-rendering as plain text with
-HTML line breaks. The trade-off is loss of formatting (bold, links, lists)
-in exchange for a guaranteed-safe output. If we ever need rich formatting
-back, swap this for `bleach.clean(html, tags=ALLOWED, attrs=ALLOWED_ATTRS)`.
+We sanitize with `bleach.clean` against a fixed allowlist. Tags outside
+the allowlist are stripped (not escaped, so the rest of the message reads
+naturally); attributes are likewise filtered. The result is a `Markup`
+object safe to drop into a Jinja template or to assign with `innerHTML`
+on the JS side after a `{{ ... | tojson }}`.
 """
 
-from bs4 import BeautifulSoup
-from markupsafe import Markup, escape
+import bleach
+from markupsafe import Markup
 
+# Tags we accept from Biwenger announcements. Kept conservative:
+# block + inline + lists + links. No <img>, <script>, <iframe>, no events.
+ALLOWED_TAGS = {
+    "p",
+    "br",
+    "b",
+    "strong",
+    "em",
+    "i",
+    "u",
+    "a",
+    "ul",
+    "ol",
+    "li",
+    "blockquote",
+    "code",
+}
 
-def html_to_plain_text(html: str | None) -> str:
-    """Extract the text content from arbitrary HTML.
+# Only `href`/`title` on links. bleach also enforces a URL allowlist on
+# `href` (http/https/mailto by default) and rejects `javascript:` URIs.
+ALLOWED_ATTRS = {"a": ["href", "title"]}
 
-    Block-level tags (<p>, <li>, ...) and <br> are turned into newlines so
-    the visual structure of the message is preserved when re-rendered.
-    """
-    if not html:
-        return ""
-    soup = BeautifulSoup(html, "html.parser")
-    for br in soup.find_all("br"):
-        br.replace_with("\n")
-    return soup.get_text(separator="\n", strip=True)
+# Drop the content of <script>/<style> entirely instead of escaping it,
+# which is the safest default for our use case.
+STRIP_TAGS = True
 
 
 def safe_html(html: str | None) -> Markup:
-    """Jinja filter: render sanitized HTML.
+    """Return Biwenger HTML cleaned of unsafe markup, ready to render.
 
-    Returns a `Markup` (already escaped) with `\n` converted to `<br>` so
-    paragraph breaks survive. Safe to drop into `{{ ... | safe_html }}`.
+    Idempotent: calling it twice on the same value yields the same value.
     """
-    text = html_to_plain_text(html)
-    lines = [escape(line) for line in text.split("\n")]
-    return Markup("<br>".join(lines))
+    if not html:
+        return Markup("")
+    cleaned = bleach.clean(
+        html,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRS,
+        strip=STRIP_TAGS,
+    )
+    return Markup(cleaned)
+
+
+def html_to_plain_text(html: str | None) -> str:
+    """Sanitized HTML rendered as a plain string.
+
+    Used by the routes that ship the value to the browser via `tojson` —
+    storing the cleaned HTML once at load time keeps both the Jinja
+    template path and the `innerHTML` JS path safe.
+    """
+    return str(safe_html(html))

--- a/requirements.in
+++ b/requirements.in
@@ -34,6 +34,7 @@ Flask
 python-dotenv
 unidecode
 beautifulsoup4
+bleach
 gunicorn
 
 # Para el manejo de fechas y zonas horarias

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -8,6 +8,8 @@ beautifulsoup4==4.14.3
     # via -r requirements.in
 black==26.3.1
     # via -r requirements.in
+bleach==6.3.0
+    # via -r requirements.in
 blinker==1.9.0
     # via flask
 certifi==2026.4.22
@@ -156,5 +158,7 @@ uritemplate==4.2.0
     # via google-api-python-client
 urllib3==2.6.3
     # via requests
+webencodings==0.5.1
+    # via bleach
 werkzeug==3.1.8
     # via flask


### PR DESCRIPTION
## Summary

PR #38 fixed the XSS by stripping all HTML to plain text — safe but visually lossy. This PR restores rich formatting (bold, links, lists, blockquote) using \`bleach.clean\` with a conservative allowlist.

## What changes for the user

Comunicados/datos/crónicas y todos los \`{{ ... | safe_html }}\` ahora preservan el formato que escribió el autor en Biwenger:

- **párrafos** (\`<p>\`), saltos de línea (\`<br>\`)
- **negrita** (\`<b>\`, \`<strong>\`), cursiva (\`<em>\`, \`<i>\`), subrayado (\`<u>\`)
- listas (\`<ul>\`, \`<ol>\`, \`<li>\`)
- enlaces (\`<a href title>\` — bleach rechaza \`javascript:\` URIs)
- bloques de cita / código (\`<blockquote>\`, \`<code>\`)

Cualquier otro tag (\`<script>\`, \`<iframe>\`, \`<img>\`, event attributes, etc.) se **strippea** — el contenido textual se conserva pero el tag desaparece.

## Why bleach over a handwritten sanitizer

bleach es la librería estándar de Python para esto: parser HTML tolerante, allowlist explícita en lugar de blocklist, URL filtering nativo. Escribir un sanitizer a mano para HTML del wild es invitación a CVE.

## Dep wiring (the five layers + image)

Sigue el flujo de \`docs/operations.md\` / skill \`add-python-dep\`:

| Layer | File | Change |
|---|---|---|
| 1 | \`packages/biwenger_tools/web/requirements.txt\` | + \`bleach\` |
| 2 | \`requirements.in\` | regenerated by concatenation script |
| 3 | \`requirements_lock.txt\` | \`bleach==6.3.0\` (+ \`webencodings==0.5.1\` transitive) |
| 4 | \`packages/biwenger_tools/web/BUILD.bazel\` | \`deps = ["@pypi//bleach"]\` |
| 5 | \`docker/Dockerfile.base\` | + \`bleach==6.3.0\`, + \`webencodings==0.5.1\` |
| image | \`python-base:latest\` | rebuilt multi-arch and pushed to Artifact Registry |
| digest | \`MODULE.bazel\` | bumped to \`sha256:62b2c9cb509...\` |

## Public API unchanged

\`web/sanitize.py\` keeps the same exports (\`safe_html\`, \`html_to_plain_text\`) so callers in \`routes/season.py\` and the Jinja filter in \`app.py\` need zero changes. The new \`html_to_plain_text\` just delegates to \`safe_html\` and returns a \`str\`.

## Test plan

- [x] \`bazel build //...\` — green
- [x] \`bazel test //...\` — 6/6 green
- [x] \`flake8 + black\` — clean
- [x] \`docker run bazel/web:local python3 -c \"import bleach\"\` — works (bleach 6.3.0 inside the prod image)
- [ ] CI on master will rebuild every service/job image against the new base digest — todos se redeployan
- [ ] Visual check post-deploy: \`/<season>/\` y \`/<season>/salseo\` muestran formato (negritas, enlaces, listas)