### PR TITLE
chore: narrow broad except clauses where failure type is obvious

### DIFF
--- a/core/sdk/telegram.py
+++ b/core/sdk/telegram.py
@@ -46,7 +46,7 @@ def send_telegram_message(
         response = requests.post(url, json=payload, timeout=15)
         response.raise_for_status()
         logger.info("Telegram message sent.", extra={"chars": len(text)})
-    except Exception as e:
+    except requests.RequestException as e:
         logger.error("Failed to send Telegram message.", extra={"error": str(e)})
 
 
@@ -67,7 +67,7 @@ def send_telegram_photo(
         )
         response.raise_for_status()
         logger.info("Telegram photo sent.", extra={"caption": caption[:40]})
-    except Exception as e:
+    except requests.RequestException as e:
         logger.error("Failed to send Telegram photo.", extra={"error": str(e)})
 
 
@@ -82,7 +82,7 @@ def register_bot_commands(bot_token: str, commands: list[dict]) -> None:
         response = requests.post(url, json={"commands": commands}, timeout=15)
         response.raise_for_status()
         logger.info("Bot commands registered.", extra={"count": len(commands)})
-    except Exception as e:
+    except requests.RequestException as e:
         logger.error("Failed to register bot commands.", extra={"error": str(e)})
 
 
@@ -95,7 +95,7 @@ def set_commands_menu_button(bot_token: str) -> None:
         )
         response.raise_for_status()
         logger.info("Menu button set to 'commands'.")
-    except Exception as e:
+    except requests.RequestException as e:
         logger.error("Failed to set menu button.", extra={"error": str(e)})
 
 

--- a/packages/biwenger_tools/web/routes/admin.py
+++ b/packages/biwenger_tools/web/routes/admin.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 
 import google.auth
+import google.auth.exceptions
 import google.auth.transport.requests
 import requests as http_requests
 from dateutil import parser
@@ -96,7 +97,10 @@ def _trigger_scraper_job() -> tuple[bool, str]:
         execution_name = resp.json().get("name", "").split("/")[-1]
         logger.info("Scraper job triggered.", extra={"execution": execution_name})
         return True, f"Job lanzado correctamente (ejecución: {execution_name})."
-    except Exception as exc:
+    except (
+        google.auth.exceptions.GoogleAuthError,
+        http_requests.RequestException,
+    ) as exc:
         logger.error("Failed to trigger scraper job.", extra={"error": str(exc)})
         return False, f"Error al lanzar el job: {exc}"
 


### PR DESCRIPTION
## Summary

Acotar 5 \`except Exception:\` que envuelven operaciones con un tipo de fallo claro. El resto de los 20 sites del audit se quedan como están — viven en boundaries donde un catch-all es la herramienta correcta.

## Cambios

| Sitio | Antes | Ahora |
|---|---|---|
| \`core/sdk/telegram.py\` × 4 (send_message, send_photo, register_commands, set_menu_button) | \`except Exception\` | \`except requests.RequestException\` |
| \`web/routes/admin.py:_trigger_scraper_job\` | \`except Exception\` | \`except (google.auth.exceptions.GoogleAuthError, requests.RequestException)\` |

## Quedan broad (a propósito)

- \`teams_analyzer/main.py\` + \`scraper_job/main.py\`: top-level wrappers del job. Si crashan, el Cloud Run Job marca failure y se pierde el log estructurado.
- Webhook handlers (chucknorris, telegram_bot): el endpoint debe devolver 200 a Telegram pase lo que pase, o reintentan.
- \`web/services.py\`: init de servicios Google; logger.critical es la respuesta correcta a cualquier fallo de arranque.
- 7 routes en \`web/routes/season.py\` + 2 en \`main.py\` + 2 en \`admin.py\`: cada uno termina renderizando un template con \`error=...\`. Narrow aquí expandiría línea sin valor.

## Test plan
- [x] \`bazel test //...\` 6/6
- [x] \`flake8 + black\` clean