### PR TITLE
chore(docker): slim python-base from 443 MB to 275 MB

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,7 +32,7 @@ oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 # Imagen base CON TODAS las dependencias preinstaladas (para producción)
 oci.pull(
     name = "python_with_deps",
-    digest = "sha256:62b2c9cb5090d4993c5592f9111f63595671c39b03dedbd461640ddde79f4016",
+    digest = "sha256:8d2946bb92128c6a4e9873852068c81db1671c21c0875cc74d4ff6a11f9cbaad",
     image = "europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/python-base",
     platforms = [
         "linux/amd64",

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,16 +1,20 @@
 # docker/Dockerfile.base
-# Imagen base con TODAS las dependencias del monorepo pre-instaladas
-# Se construye UNA VEZ y se reutiliza en todos los servicios
+# Imagen base con TODAS las dependencias de runtime del monorepo pre-instaladas.
+# Se construye UNA VEZ y se reutiliza en todos los servicios.
 #
 # Sincronizada con requirements_lock.txt (mantener orden alfabético).
 # Si añades/quitas una dep en cualquier requirements.txt, regenera el lock
 # y actualiza esta lista (ver docs/operations.md).
+#
+# Test/dev deps (pytest, black, flake8, freezegun, requests-mock y sus transitivas)
+# viven en el lockfile para que Bazel los use en su sandbox, pero NO se instalan
+# aquí: en Cloud Run son peso muerto.
 
 FROM python:3.13-slim@sha256:0ee2df98db454606ca92bb7a79d47ff7dc9cc0c8d5901e32eb71e6b5203377b2
 
 RUN pip install --no-cache-dir \
+    --no-compile \
     beautifulsoup4==4.14.3 \
-    black==26.3.1 \
     bleach==6.3.0 \
     blinker==1.9.0 \
     certifi==2026.4.22 \
@@ -20,10 +24,8 @@ RUN pip install --no-cache-dir \
     contourpy==1.3.3 \
     cryptography==48.0.0 \
     cycler==0.12.1 \
-    flake8==7.3.0 \
     flask==3.1.3 \
     fonttools==4.62.1 \
-    freezegun==1.5.5 \
     google-api-core==2.30.3 \
     google-api-python-client==2.195.0 \
     google-auth==2.50.0 \
@@ -33,37 +35,25 @@ RUN pip install --no-cache-dir \
     gunicorn==26.0.0 \
     httplib2==0.31.2 \
     idna==3.13 \
-    iniconfig==2.3.0 \
     itsdangerous==2.2.0 \
     jinja2==3.1.6 \
     kiwisolver==1.5.0 \
     markupsafe==3.0.3 \
     matplotlib==3.10.9 \
-    mccabe==0.7.0 \
-    mypy-extensions==1.1.0 \
     numpy==2.4.4 \
     oauthlib==3.3.1 \
     packaging==26.2 \
     pillow==12.2.0 \
-    pathspec==1.1.1 \
-    platformdirs==4.9.6 \
-    pluggy==1.6.0 \
     proto-plus==1.27.2 \
     protobuf==7.34.1 \
     pyasn1==0.6.3 \
     pyasn1-modules==0.4.2 \
-    pycodestyle==2.14.0 \
     pycparser==3.0 \
-    pyflakes==3.4.0 \
-    pygments==2.20.0 \
     pyparsing==3.3.2 \
-    pytest==9.0.3 \
     python-dateutil==2.9.0.post0 \
     python-dotenv==1.2.2 \
     python-json-logger==4.1.0 \
-    pytokens==0.4.1 \
     requests==2.33.1 \
-    requests-mock==1.12.1 \
     requests-oauthlib==2.0.0 \
     six==1.17.0 \
     soupsieve==2.8.3 \
@@ -72,6 +62,23 @@ RUN pip install --no-cache-dir \
     uritemplate==4.2.0 \
     urllib3==2.6.3 \
     webencodings==0.5.1 \
-    werkzeug==3.1.8
+    werkzeug==3.1.8 \
+ && find /usr/local/lib/python3.13/site-packages/googleapiclient/discovery_cache/documents \
+    -type f -name '*.json' \
+    ! -name 'drive.*.json' \
+    ! -name 'sheets.*.json' \
+    ! -name 'run.*.json' \
+    -delete \
+ && find /usr/local/lib/python3.13 -name '__pycache__' -type d -exec rm -rf {} + \
+ && find /usr/local/lib/python3.13 -name '*.pyc' -delete \
+ && rm -rf /root/.cache /tmp/*
+
+# Notes on the cleanups above (all in one RUN so the savings land in one layer):
+# - googleapiclient/discovery_cache/documents ships ~96 MB of JSON discovery
+#   docs for every Google API. We hit only Drive, Sheets and Cloud Run; the
+#   rest are regenerated on demand at runtime if ever needed.
+# - --no-compile + pyc cleanup drops ~10 MB of compiled bytecode that Python
+#   re-creates on first import anyway.
+# - pip cache and /tmp leftovers from the install go too.
 
 ENV PYTHONUNBUFFERED=1

--- a/docs/gcp.md
+++ b/docs/gcp.md
@@ -51,6 +51,18 @@ This is rebuilt only when dependencies change, not on every deploy. Benefits:
 - Cold start time drops significantly (heavy deps like `google-cloud-*` are pre-installed).
 - Artifact Registry storage stays low — only incremental layers change per deploy.
 
+The image is **runtime-only**: test/dev deps (pytest, black, flake8, freezegun,
+requests-mock and their transitives) are listed in `requirements_lock.txt` for
+Bazel's hermetic sandbox but **not installed** in `Dockerfile.base`. Same for
+the `googleapiclient/discovery_cache/documents` cache, which is pruned in the
+same `RUN` layer to drive/sheets/run only — the 581 other JSON discovery docs
+are dead weight (~96 MB). These two together drop the image from ~443 MB to
+~275 MB, well inside the 500 MB Artifact Registry free tier.
+
+When using \`pip install\` in the Dockerfile, keep \`--no-compile\` and the
+\`__pycache__\` / \`.pyc\` cleanup at the end of the same \`RUN\` — Python
+re-creates bytecode on first import, no need to ship it.
+
 ### min-instances = 0 on all services
 No idle compute billing. All services are request-driven or job-driven.
 Acceptable because this is a private league intranet, not a latency-sensitive product.


### PR DESCRIPTION
## Summary

\`python-base\` was bloating Artifact Registry past its 500 MB free tier
(repo at ~524 MB). Tres optimizaciones, mismas dependencias prod, todo
en una sola layer para que el ahorro caiga en la imagen final:

| Cambio | Ahorro |
|---|---|
| Quitar test/dev deps (pytest, black, flake8, freezegun, requests-mock + transitive) | ~25 MB |
| Purgar \`googleapiclient/discovery_cache/documents\` a solo Drive/Sheets/Run (de 581 JSON a 7) | ~94 MB |
| \`--no-compile\` + cleanup de \`__pycache__\`, \`*.pyc\`, pip cache, /tmp | ~50 MB |
| **Total** | **~168 MB (443 → 275 MB, −38%)** |

## ¿Por qué no Alpine?

- \`python:3.13-slim\` es Debian slim, ya solo ~45 MB de base
- Alpine usa **musl libc** → numpy/matplotlib/pillow/cryptography requieren wheels \`musllinux_*\`. Cuando faltan se compilan desde código C con ~500 MB de build-essential que después purgar es no trivial
- Resultado típico Alpine: imagen IGUAL o más grande, build 10× más lento, runtime con overhead conocido de Python en musl
- Pérdida de tiempo

## Risk

- Bazel's hermetic sandbox sigue teniendo todas las deps (incluyendo las de test) del \`requirements_lock.txt\`. No cambia el comportamiento de tests
- \`googleapiclient\` regenera un discovery doc on-demand si en el futuro consultamos otra API (Vertex, BigQuery, etc.)
- \`--no-compile\` solo afecta a la primera importación post-deploy: añade unos ms al primer cold start de cada container. Inapreciable

## Smoke test

```
docker run --rm python-base python3 -c \\
  'import bleach, matplotlib, requests, flask, gunicorn, bs4, dateutil, google.auth;
   from googleapiclient.discovery import build;
   print("All imports OK")'
→ All imports OK
```

## Test plan

- [x] \`bazelisk mod tidy\` aplica el nuevo digest
- [x] \`bazel build //...\` — green
- [x] \`bazel test //...\` — 6/6 green
- [x] \`flake8 + black\` — clean
- [ ] CI on master triggers rebuild of all 5 service/job images against new base; redespliegue verifica que las 3 services y 2 jobs siguen sirviendo