### PR TITLE
chore(ci): trigger redeploys on docker/ or MODULE.bazel changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,22 +67,32 @@ jobs:
             web:
               - 'core/**'
               - 'tools/**'
+              - 'docker/**'
+              - 'MODULE.bazel'
               - 'packages/biwenger_tools/web/**'
             scraper:
               - 'core/**'
               - 'tools/**'
+              - 'docker/**'
+              - 'MODULE.bazel'
               - 'packages/biwenger_tools/scraper_job/**'
             teams_analyzer:
               - 'core/**'
               - 'tools/**'
+              - 'docker/**'
+              - 'MODULE.bazel'
               - 'packages/biwenger_tools/teams_analyzer/**'
             telegram_bot:
               - 'core/**'
               - 'tools/**'
+              - 'docker/**'
+              - 'MODULE.bazel'
               - 'packages/biwenger_tools/telegram_bot/**'
             chucknorris_bot:
               - 'core/**'
               - 'tools/**'
+              - 'docker/**'
+              - 'MODULE.bazel'
               - 'packages/chucknorris_bot/**'
 
   # -------------------------------------------------------


### PR DESCRIPTION
## Summary

\`paths-filter\` for every Cloud Run service now also matches \`docker/**\` and \`MODULE.bazel\`. Today, a change in \`Dockerfile.base\` or the digest pinned in \`MODULE.bazel\` silently skipped redeploys — discovered when PR #43 (\`chore(docker): slim python-base...\`) merged without triggering any service rebuild.

Net effect: any future tweak of the base image will redeploy the 5 services + jobs automatically, as expected.

## Note

This PR alone does **not** trigger redeploys (the filter evaluates the files changed in *this* commit, which is just \`deploy.yml\`). I'll force the rebuild manually via \`bazel run :push_image_to_gcp\` + \`gcloud run services update\` for each service so the slim base lands today.