### PR TITLE
refactor(teams_analyzer): make lineup.py easier to follow + document algorithm in README

### DIFF
--- a/packages/biwenger_tools/teams_analyzer/README.md
+++ b/packages/biwenger_tools/teams_analyzer/README.md
@@ -78,3 +78,63 @@ If you don't have a bot yet:
 based on the `ANALYSIS_MODE` env var (`daily`, `all`, `my_team`, `market`,
 `alinear`). To follow the flow, open `main.py` and look at `_MODE_HANDLERS` —
 each handler is its own function.
+
+## 🧠 How `/alinear` picks the lineup
+
+All in `logic/lineup.py`. Read it top-to-bottom: `pick_lineup` is the public
+entry, helpers come after.
+
+### Step by step
+
+1. **Filter to available players** (`_is_available`). Out: no JP data,
+   injured, suspended, team has no match this week, or JP says
+   `playerInLineup=False` (explicit "no convocado"). `None` ("don't know
+   yet") is *kept* — we want the gamble. `doubt` is also kept.
+2. **Iterate the 12 supported formations** (`FORMATIONS`).
+3. For each formation, **find the 11-player assignment that maximises the
+   sum of SF** (`_try_fill`). This honours multi-position players (a
+   FWD/MID can play either slot) and chooses the placement that gives the
+   best total, not the first that fits.
+4. **Compare totals across formations** and keep the best.
+5. **Pick reserves** (`_pick_reserves`) in Biwenger's positional order
+   POR → DEF → MED → DEL: highest-SF eligible bench player per slot.
+6. **Pick captain** (`_pick_captain`): highest SF among starters whose
+   market value is strictly below 3 M€ (Biwenger API rejects ≥ 3 M).
+   Fallback: cheapest known-price player if nobody is under the cap.
+
+### Why exhaustive backtracking
+
+The previous version of `_try_fill` returned the first feasible assignment
+and used a "prefer primary position" heuristic for multi-position players.
+That broke as soon as moving a multi-position player to their alt freed up
+a stronger combination at the primary. Worked example with formation 4-3-3:
+
+- Squad: 4 FWDs (one is FWD/MID with SF 400, others 380/360/340) and 3 MIDs
+  (350/320/280).
+- **Option A** — multi-position player as FWD:
+  FWDs = 400 + 380 + 360 = **1140** · MIDs = 350 + 320 + 280 = **950** → 2090
+- **Option B** — multi-position player as MID:
+  FWDs = 380 + 360 + 340 = **1080** · MIDs = 400 + 350 + 320 = **1070** → **2150** ← picked
+
+Now the function explores every valid assignment for a given formation and
+returns the one with the highest total SF. The unit test
+`test_try_fill_places_multiposition_where_it_maximises_total` reproduces
+exactly this scenario.
+
+### Performance
+
+Squad sizes are 20-25 players. Worst case is `O((squad_size choose 11) × 11!)`
+in theory, but the "most-constrained slot first" pruning + the small input
+size keep it well under a second per `/alinear`. If the squad grows to 50+
+players (it won't in Biwenger) we'd add memoisation by sorted-bw_id key.
+
+### When you want to tweak something
+
+- **Add or remove a formation** → edit `FORMATIONS`.
+- **Change the "no convocado" policy** (e.g. penalise SF instead of
+  excluding) → edit the last branch of `_is_available`.
+- **Change the captain rule** → `_pick_captain` is the only place.
+- **Reserves order** → currently `(GK, DEF, MID, FWD)` in `_pick_reserves`,
+  which mirrors Biwenger's slot order on the bench.
+- **Penalise `doubt` status** → not done today (user wants to gamble); if
+  reopened, the place would be `_sf` returning a discounted value.

--- a/packages/biwenger_tools/teams_analyzer/logic/lineup.py
+++ b/packages/biwenger_tools/teams_analyzer/logic/lineup.py
@@ -2,12 +2,18 @@
 
 Given a squad of rows (with jp_player and position data), finds the formation
 and 11-player assignment that maximises the total SF predict score.
+
+For a high-level walkthrough of the algorithm (with the multi-position
+example that motivated exhaustive backtracking), see the
+"How `/alinear` picks the lineup" section of `../README.md`.
 """
+
+from html import escape
 
 from core.sdk.jp import get_predict_rate
 from packages.biwenger_tools.teams_analyzer.player_formatting import SCORE_SF
 
-# All supported formations as (label, def, mid, fwd)
+# All supported formations as (label, def, mid, fwd). GK is always 1.
 FORMATIONS = [
     ("3-4-3", 3, 4, 3),
     ("3-5-2", 3, 5, 2),
@@ -23,18 +29,107 @@ FORMATIONS = [
     ("5-2-3", 5, 2, 3),
 ]
 
-# Position IDs: 1=GK, 2=DEF, 3=MID, 4=FWD
+# Position IDs as Biwenger reports them.
 GK, DEF, MID, FWD = 1, 2, 3, 4
 
+# Biwenger refuses to set a captain whose market value is ≥ 3M.
 _CAPTAIN_MAX_PRICE = 3_000_000
 
 
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def pick_lineup(squad_rows: list) -> dict | None:
+    """Pick the best (formation, starters, reserves, captain) for the squad.
+
+    Returns `None` if no valid lineup can be formed from the available
+    players (e.g. nobody can play GK).
+
+    Return shape::
+
+        {
+            "formation": "4-5-1",
+            "starters": [(row, pos_id), ...],   # 11 entries
+            "reserves": [row | None, ...],       # 4 entries (None = empty slot)
+            "captain": row,
+            "total_sf": int,
+        }
+    """
+    available = [r for r in squad_rows if _is_available(r)]
+    available.sort(key=_sf, reverse=True)
+
+    best: dict | None = None
+    best_sf = -1
+
+    for label, n_def, n_mid, n_fwd in FORMATIONS:
+        slots = {GK: 1, DEF: n_def, MID: n_mid, FWD: n_fwd}
+        assignment = _try_fill(available, slots)
+        if assignment is None:
+            continue
+
+        total_sf = sum(_sf(r) for r, _ in assignment)
+        if total_sf <= best_sf:
+            continue
+
+        starter_ids = {r["bw_id"] for r, _ in assignment}
+        reserves = _pick_reserves(available, starter_ids)
+        captain = _pick_captain([r for r, _ in assignment])
+
+        best_sf = total_sf
+        best = {
+            "formation": label,
+            "starters": assignment,
+            "reserves": reserves,
+            "captain": captain,
+            "total_sf": total_sf,
+        }
+
+    return best
+
+
+def format_lineup_message(result: dict) -> str:
+    """Returns an HTML Telegram message confirming the lineup."""
+    formation = result["formation"]
+    starters = result["starters"]
+    reserves = result["reserves"]
+    captain = result["captain"]
+    total_sf = result["total_sf"]
+
+    pos_name = {GK: "POR", DEF: "DEF", MID: "MED", FWD: "DEL"}
+    lines = [f"<b>✅ Alineación aplicada — {formation}</b> (SF total: {total_sf})\n"]
+
+    for pos_id in (GK, DEF, MID, FWD):
+        group = [(r, p) for r, p in starters if p == pos_id]
+        group.sort(key=lambda rp: _sf(rp[0]), reverse=True)
+        for row, _ in group:
+            sf = _sf(row)
+            cap = " ©" if row["bw_id"] == captain["bw_id"] else ""
+            lines.append(f"{pos_name[pos_id]} {escape(row['name'])} (SF:{sf}){cap}")
+
+    filled = [(pos_name[pos], r) for pos, r in zip((GK, DEF, MID, FWD), reserves) if r]
+    if filled:
+        lines.append("\n<b>Suplentes:</b>")
+        for label, r in filled:
+            lines.append(f"  {label} {escape(r['name'])} (SF:{_sf(r)})")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — tiny pure functions used throughout
+# ---------------------------------------------------------------------------
+
+
 def _sf(row: dict) -> int:
+    """Predicted SF score for a player. 0 if JP has no prediction."""
     jp = row.get("jp_player")
     return get_predict_rate(jp, SCORE_SF) or 0
 
 
 def _positions(row: dict) -> set:
+    """All positions a player can cover — primary + any alts."""
     primary = row.get("position_id")
     alts = row.get("alt_positions") or []
     return {primary} | set(alts)
@@ -64,11 +159,16 @@ def _is_available(row: dict) -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# Internal: starters assignment (exhaustive backtracking)
+# ---------------------------------------------------------------------------
+
+
 def _try_fill(players: list, slots: dict) -> list | None:
     """Pick the assignment of `players` to `slots` that maximises total SF.
 
-    This is exhaustive backtracking: for each open slot we try every eligible
-    candidate, recurse, and keep the assignment with the highest sum of SF.
+    Exhaustive backtracking: for each open slot try every eligible candidate,
+    recurse on the rest, and keep the assignment with the highest sum of SF.
     Returns `None` if no valid assignment exists.
 
     Why exhaustive: a previous version returned the first feasible solution,
@@ -122,67 +222,37 @@ def _try_fill(players: list, slots: dict) -> list | None:
     return best
 
 
-def pick_lineup(squad_rows: list) -> dict | None:
-    """Returns the best lineup dict or None if no valid lineup can be formed.
+# ---------------------------------------------------------------------------
+# Internal: reserves and captain
+# ---------------------------------------------------------------------------
 
-    Return shape:
-    {
-        "formation": "4-5-1",
-        "starters": [(row, pos_id), ...],   # 11 entries
-        "reserves": [row | None, ...],       # 4 entries (None = empty slot)
-        "captain": row,
-        "total_sf": int,
-    }
+
+def _pick_reserves(available: list, starter_ids: set) -> list:
+    """Pick up to 4 reserves in Biwenger's positional order: GK → DEF → MID → FWD.
+
+    For each position slot we pick the highest-SF eligible bench player that
+    has not already been picked for an earlier slot. If no candidate exists
+    for a slot we leave a `None` there — Biwenger accepts a partial bench.
     """
-    available = [r for r in squad_rows if _is_available(r)]
-    available.sort(key=_sf, reverse=True)
-
-    best: dict | None = None
-    best_sf = -1
-
-    for label, n_def, n_mid, n_fwd in FORMATIONS:
-        slots = {GK: 1, DEF: n_def, MID: n_mid, FWD: n_fwd}
-        assignment = _try_fill(available, slots)
-        if assignment is None:
-            continue
-
-        total_sf = sum(_sf(r) for r, _ in assignment)
-        if total_sf <= best_sf:
-            continue
-
-        starter_ids = {r["bw_id"] for r, _ in assignment}
-        bench_pool = [r for r in available if r["bw_id"] not in starter_ids]
-        # Biwenger reserve slots are positional: GK→DEF→MID→FWD
-        used_ids: set = set()
-        reserves = []
-        for slot_pos in (GK, DEF, MID, FWD):
-            candidates = sorted(
-                (
-                    r
-                    for r in bench_pool
-                    if r["bw_id"] not in used_ids and slot_pos in _positions(r)
-                ),
-                key=_sf,
-                reverse=True,
-            )
-            if candidates:
-                reserves.append(candidates[0])
-                used_ids.add(candidates[0]["bw_id"])
-            else:
-                reserves.append(None)
-
-        captain = _pick_captain([r for r, _ in assignment])
-
-        best_sf = total_sf
-        best = {
-            "formation": label,
-            "starters": assignment,
-            "reserves": reserves,
-            "captain": captain,
-            "total_sf": total_sf,
-        }
-
-    return best
+    bench_pool = [r for r in available if r["bw_id"] not in starter_ids]
+    used_ids: set = set()
+    reserves: list = []
+    for slot_pos in (GK, DEF, MID, FWD):
+        candidates = sorted(
+            (
+                r
+                for r in bench_pool
+                if r["bw_id"] not in used_ids and slot_pos in _positions(r)
+            ),
+            key=_sf,
+            reverse=True,
+        )
+        if candidates:
+            reserves.append(candidates[0])
+            used_ids.add(candidates[0]["bw_id"])
+        else:
+            reserves.append(None)
+    return reserves
 
 
 def _pick_captain(starters: list) -> dict:
@@ -208,36 +278,3 @@ def _pick_captain(starters: list) -> dict:
 
     # All prices unknown — fall back to best SF
     return max(starters, key=_sf)
-
-
-def format_lineup_message(result: dict) -> str:
-    """Returns an HTML Telegram message confirming the lineup."""
-    from html import escape
-
-    formation = result["formation"]
-    starters = result["starters"]
-    reserves = result["reserves"]
-    captain = result["captain"]
-    total_sf = result["total_sf"]
-
-    pos_name = {GK: "POR", DEF: "DEF", MID: "MED", FWD: "DEL"}
-    lines = [f"<b>✅ Alineación aplicada — {formation}</b> (SF total: {total_sf})\n"]
-
-    for pos_id in (GK, DEF, MID, FWD):
-        group = [(r, p) for r, p in starters if p == pos_id]
-        group.sort(key=lambda rp: _sf(rp[0]), reverse=True)
-        for row, _ in group:
-            sf = _sf(row)
-            cap = " ©" if row["bw_id"] == captain["bw_id"] else ""
-            lines.append(f"{pos_name[pos_id]} {escape(row['name'])} (SF:{sf}){cap}")
-
-    slot_label = {GK: "POR", DEF: "DEF", MID: "MED", FWD: "DEL"}
-    filled = [
-        (slot_label[pos], r) for pos, r in zip((GK, DEF, MID, FWD), reserves) if r
-    ]
-    if filled:
-        lines.append("\n<b>Suplentes:</b>")
-        for label, r in filled:
-            lines.append(f"  {label} {escape(r['name'])} (SF:{_sf(r)})")
-
-    return "\n".join(lines)


### PR DESCRIPTION
## Summary

Zero behavioural change. Cuatro toques de legibilidad + sección nueva en el README para que abras \`lineup.py\` y puedas seguir + tocar el algoritmo sin abrir 5 ficheros.

## Cambios en \`logic/lineup.py\`

- **Reorden**: \`pick_lineup\` (público) va arriba; helpers, backtracking y reservas/capitán siguen detrás, cada bloque con un comentario divisor.
- **Extracto** \`_pick_reserves\`: el cuerpo del bucle de formaciones tenía un bloque de ~15 líneas de "calcular bench" anidado. Ahora hay tres líneas con nombres claros: \`_try_fill\`, \`_pick_reserves\`, \`_pick_captain\`.
- **Docstrings cortas** en los helpers atómicos (\`_sf\`, \`_positions\`).
- **\`from html import escape\`** subido al top del módulo.

## Cambio en \`teams_analyzer/README.md\`

Nueva sección **"How \`/alinear\` picks the lineup"** con:

1. Step-by-step en lenguaje natural (6 pasos).
2. **Por qué exhaustive backtracking** con el ejemplo del bug reproducido del PR #49 (multi-posición FWD/MID en formación 4-3-3).
3. Notas de **performance** (squad 20-25 jugadores → <1 s por \`/alinear\`).
4. **"When you want to tweak something"** — mapa de qué función edita cada comportamiento (añadir formación, política "no convocado", regla del capitán, etc.).

## Tests

40/40 pass. \`flake8 + black\` clean.

## Riesgo

Cero. Mismo comportamiento que PR #49, mismas firmas públicas (\`pick_lineup\`, \`format_lineup_message\`), mismos tests sin tocar.