### PR TITLE
feat(bots): /version command on Telegram bots

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -308,7 +308,9 @@ jobs:
             --set-env-vars="\
           GCP_PROJECT_ID=${{ env.PROJECT_ID }},\
           CLOUD_RUN_REGION=${{ env.REGION }},\
-          CLOUD_RUN_JOB_NAME=biwenger-teams-analyzer"
+          CLOUD_RUN_JOB_NAME=biwenger-teams-analyzer,\
+          GIT_COMMIT=${GITHUB_SHA::7},\
+          DEPLOY_TIME=$(TZ=Europe/Madrid date '+%d/%m/%Y %H:%M')"
 
   # -------------------------------------------------------
   # 2e. Build and deploy Chuck Norris bot Cloud Run Service
@@ -354,7 +356,10 @@ jobs:
             --memory=256Mi \
             --cpu=0.5 \
             --concurrency=1 \
-            --update-secrets="CHUCKNORRIS_BOT_CONFIG_JSON=chucknorris-bot-config-regional:latest"
+            --update-secrets="CHUCKNORRIS_BOT_CONFIG_JSON=chucknorris-bot-config-regional:latest" \
+            --set-env-vars="\
+          GIT_COMMIT=${GITHUB_SHA::7},\
+          DEPLOY_TIME=$(TZ=Europe/Madrid date '+%d/%m/%Y %H:%M')"
 
   # -------------------------------------------------------
   # 3. Clean up old images once any deploy succeeds

--- a/packages/biwenger_tools/telegram_bot/app.py
+++ b/packages/biwenger_tools/telegram_bot/app.py
@@ -23,6 +23,7 @@ _HELP_TEXT = (
     "/myteam — Análisis solo de mi equipo\n"
     "/mercado — Solo el mercado\n"
     "/alinear — Aplica la mejor alineación posible\n"
+    "/version — Versión desplegada del bot y del job\n"
     "/help — Muestra este mensaje"
 )
 
@@ -32,6 +33,25 @@ _JOB_MODES = {
     "/mercado": "market",
     "/alinear": "alinear",
 }
+
+
+def _build_version_text() -> str:
+    """Render the /version response showing bot + analyzer-job state."""
+    bot_commit = config.GIT_COMMIT or "unknown"
+    bot_time = config.DEPLOY_TIME or "—"
+    job_time = (
+        job_trigger.get_job_update_time(
+            config.GCP_PROJECT_ID,
+            config.CLOUD_RUN_REGION,
+            config.CLOUD_RUN_JOB_NAME,
+        )
+        or "—"
+    )
+    return (
+        "<b>📦 Versiones desplegadas</b>\n\n"
+        f"🤖 Bot service:\n  <code>{bot_commit}</code> · {bot_time}\n\n"
+        f"⚙️ Analyzer job ({config.CLOUD_RUN_JOB_NAME}):\n  updated {job_time}"
+    )
 
 
 @app.route("/telegram/webhook", methods=["POST"])
@@ -88,6 +108,13 @@ def webhook():
             bot_token=config.TELEGRAM_BOT_TOKEN,
             chat_id=config.TELEGRAM_CHAT_ID,
             text=_HELP_TEXT,
+        )
+    elif cmd == "/version":
+        logger.info("Webhook: /version received")
+        send_telegram_message(
+            bot_token=config.TELEGRAM_BOT_TOKEN,
+            chat_id=config.TELEGRAM_CHAT_ID,
+            text=_build_version_text(),
         )
     else:
         logger.info("Webhook: unknown command, ignoring", extra={"text": text[:50]})

--- a/packages/biwenger_tools/telegram_bot/config.py
+++ b/packages/biwenger_tools/telegram_bot/config.py
@@ -24,3 +24,7 @@ TELEGRAM_WEBHOOK_SECRET = (
 GCP_PROJECT_ID = os.getenv("GCP_PROJECT_ID", "biwenger-tools")
 CLOUD_RUN_REGION = os.getenv("CLOUD_RUN_REGION", "europe-southwest1")
 CLOUD_RUN_JOB_NAME = os.getenv("CLOUD_RUN_JOB_NAME", "biwenger-teams-analyzer")
+
+# Deployed version metadata (set by CI, see deploy.yml). Used by /version.
+GIT_COMMIT = os.getenv("GIT_COMMIT", "local")
+DEPLOY_TIME = os.getenv("DEPLOY_TIME", "")

--- a/packages/biwenger_tools/telegram_bot/job_trigger.py
+++ b/packages/biwenger_tools/telegram_bot/job_trigger.py
@@ -1,10 +1,42 @@
 import google.auth
+import google.auth.exceptions
 import google.auth.transport.requests
 import requests as http_requests
 
 from core.utils import get_logger
 
 logger = get_logger(__name__)
+
+
+def get_job_update_time(project: str, region: str, job_name: str) -> str | None:
+    """Return the updateTime of the Cloud Run Job's current state.
+
+    Used by `/version` to report when the analyzer job was last redeployed.
+    Returns the raw RFC3339 timestamp from the API, or `None` if the lookup
+    fails (auth, transient network errors, job missing).
+    """
+    try:
+        creds, _ = google.auth.default(
+            scopes=["https://www.googleapis.com/auth/cloud-platform"]
+        )
+        creds.refresh(google.auth.transport.requests.Request())
+        url = (
+            f"https://run.googleapis.com/v2/projects/{project}"
+            f"/locations/{region}/jobs/{job_name}"
+        )
+        resp = http_requests.get(
+            url,
+            headers={"Authorization": f"Bearer {creds.token}"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json().get("updateTime")
+    except (
+        google.auth.exceptions.GoogleAuthError,
+        http_requests.RequestException,
+    ) as exc:
+        logger.warning("Failed to fetch job updateTime.", extra={"error": str(exc)})
+        return None
 
 
 def trigger_analyzer_job(

--- a/packages/biwenger_tools/telegram_bot/setup_commands.py
+++ b/packages/biwenger_tools/telegram_bot/setup_commands.py
@@ -16,6 +16,7 @@ COMMANDS = [
     {"command": "myteam", "description": "Análisis solo de mi equipo"},
     {"command": "mercado", "description": "Solo el mercado"},
     {"command": "alinear", "description": "Aplica la mejor alineación posible"},
+    {"command": "version", "description": "Versión desplegada del bot y del job"},
     {"command": "help", "description": "Muestra todos los comandos disponibles"},
 ]
 

--- a/packages/biwenger_tools/telegram_bot/tests/test_telegram_bot.py
+++ b/packages/biwenger_tools/telegram_bot/tests/test_telegram_bot.py
@@ -139,6 +139,41 @@ def test_help_sends_message(client):
     assert call_kwargs.get("chat_id") == _VALID_CHAT
 
 
+def test_version_returns_bot_and_job_state(client):
+    """`/version` includes the bot SHA and the job updateTime."""
+    cfg.GIT_COMMIT = "abc1234"
+    cfg.DEPLOY_TIME = "17/05/2026 14:00"
+    with patch(
+        "packages.biwenger_tools.telegram_bot.app.job_trigger.get_job_update_time",
+        return_value="2026-05-17T12:34:56Z",
+    ), patch(
+        "packages.biwenger_tools.telegram_bot.app.send_telegram_message"
+    ) as mock_send:
+        resp = _post(client, _update(_VALID_CHAT, "/version"))
+    assert resp.status_code == 200
+    text = mock_send.call_args.kwargs.get("text", "")
+    assert "abc1234" in text
+    assert "17/05/2026 14:00" in text
+    assert "2026-05-17T12:34:56Z" in text
+
+
+def test_version_tolerates_job_lookup_failure(client):
+    """If the Cloud Run API call fails the bot still responds, with '—'."""
+    cfg.GIT_COMMIT = "abc1234"
+    cfg.DEPLOY_TIME = "17/05/2026 14:00"
+    with patch(
+        "packages.biwenger_tools.telegram_bot.app.job_trigger.get_job_update_time",
+        return_value=None,
+    ), patch(
+        "packages.biwenger_tools.telegram_bot.app.send_telegram_message"
+    ) as mock_send:
+        resp = _post(client, _update(_VALID_CHAT, "/version"))
+    assert resp.status_code == 200
+    text = mock_send.call_args.kwargs.get("text", "")
+    assert "abc1234" in text
+    assert "updated —" in text
+
+
 def test_unknown_command_is_ignored(client):
     with patch(
         "packages.biwenger_tools.telegram_bot.app.job_trigger.trigger_analyzer_job"

--- a/packages/chucknorris_bot/bot/app.py
+++ b/packages/chucknorris_bot/bot/app.py
@@ -30,8 +30,19 @@ _HELP_TEXT = (
     "/food — food fact\n"
     "/animal — animal fact\n"
     "/dev — developer fact\n"
+    "/version — deployed bot version\n"
     "/help — show this message"
 )
+
+
+def _build_version_text() -> str:
+    """Render the /version response."""
+    commit = config.GIT_COMMIT or "unknown"
+    deploy_time = config.DEPLOY_TIME or "—"
+    return (
+        "<b>📦 Bot version</b>\n\n"
+        f"🤜 chucknorris-bot:\n  <code>{commit}</code> · {deploy_time}"
+    )
 
 
 def _fetch_joke(category: str | None = None) -> str:
@@ -75,6 +86,12 @@ def webhook():
             bot_token=config.TELEGRAM_BOT_TOKEN,
             chat_id=chat_id,
             text=_HELP_TEXT,
+        )
+    elif cmd == "/version":
+        send_telegram_message(
+            bot_token=config.TELEGRAM_BOT_TOKEN,
+            chat_id=chat_id,
+            text=_build_version_text(),
         )
     elif cmd == "/random":
         joke = _fetch_joke()

--- a/packages/chucknorris_bot/bot/config.py
+++ b/packages/chucknorris_bot/bot/config.py
@@ -17,3 +17,7 @@ TELEGRAM_BOT_TOKEN = (
 TELEGRAM_WEBHOOK_SECRET = (
     _CHUCKNORRIS_CFG.get("webhook_secret") or os.getenv("TELEGRAM_WEBHOOK_SECRET", "")
 ).strip()
+
+# Deployed version metadata (set by CI, see deploy.yml). Used by /version.
+GIT_COMMIT = os.getenv("GIT_COMMIT", "local")
+DEPLOY_TIME = os.getenv("DEPLOY_TIME", "")

--- a/packages/chucknorris_bot/bot/setup_commands.py
+++ b/packages/chucknorris_bot/bot/setup_commands.py
@@ -17,6 +17,7 @@ COMMANDS = [
     {"command": "food", "description": "Food fact"},
     {"command": "animal", "description": "Animal fact"},
     {"command": "dev", "description": "Developer fact"},
+    {"command": "version", "description": "Deployed bot version"},
     {"command": "help", "description": "Show all commands"},
 ]
 

--- a/packages/chucknorris_bot/bot/tests/test_app.py
+++ b/packages/chucknorris_bot/bot/tests/test_app.py
@@ -68,6 +68,18 @@ def test_start_sends_message(client):
     mock_send.assert_called_once()
 
 
+def test_version_returns_commit_and_deploy_time(client):
+    """`/version` returns the bot SHA + deploy timestamp injected by CI."""
+    cfg.GIT_COMMIT = "abc1234"
+    cfg.DEPLOY_TIME = "17/05/2026 14:00"
+    with patch("packages.chucknorris_bot.bot.app.send_telegram_message") as mock_send:
+        resp = _post(client, _update("123", "/version"))
+    assert resp.status_code == 200
+    text = mock_send.call_args.kwargs.get("text", "")
+    assert "abc1234" in text
+    assert "17/05/2026 14:00" in text
+
+
 def test_random_fetches_and_sends(client):
     with patch(
         "packages.chucknorris_bot.bot.app._fetch_joke", return_value="A joke."


### PR DESCRIPTION
## Summary

Añade el comando \`/version\` a los dos bots de Telegram. La trampa importante: \`telegram_bot\` muestra **bot service + analyzer job** porque la mayoría de comandos (\`/alinear\`, \`/myteam\`, etc.) ejecutan código del job, no del bot. \`chucknorris_bot\` es simple porque no hay downstream.

## Salida esperada

\`telegram_bot\`:

\`\`\`
📦 Versiones desplegadas

🤖 Bot service:
  abc1234 · 17/05/2026 14:00

⚙️ Analyzer job (biwenger-teams-analyzer):
  updated 2026-05-17T12:34:56Z
\`\`\`

\`chucknorris_bot\`:

\`\`\`
📦 Bot version

🤜 chucknorris-bot:
  abc1234 · 17/05/2026 14:00
\`\`\`

## Cambios

- \`deploy.yml\`: inyecta \`GIT_COMMIT\` (short SHA) y \`DEPLOY_TIME\` (Madrid) en ambos bots, igual que ya hace para \`web\`.
- \`telegram_bot/job_trigger.py\`: nuevo \`get_job_update_time()\` consulta el Cloud Run Job vía REST (v2) usando el ADC que el bot ya tiene. Si falla, devuelve \`None\` y el bot responde con \`updated —\` en vez de petar.
- \`telegram_bot/app.py\` + \`chucknorris_bot/app.py\`: nueva rama del webhook para \`/version\` con \`_build_version_text()\` separado.
- Ambos \`setup_commands.py\` registran \`/version\` para que aparezca en el menú \`/\` de Telegram tras la próxima ejecución manual del script.

## Test plan

- [x] Tests nuevos en ambos bots: rendering OK + tolera fallo de API
- [x] \`bazel test //...\` 6/6 verde
- [x] \`flake8 + black\` clean
- [ ] Tras merge: \`/version\` en producción muestra los valores reales
- [ ] (Manual, una vez) Ejecutar \`setup_commands.py\` de cada bot para que el menú \`/\` muestre el nuevo comando

## Riesgo

Bajo. Comando nuevo, no toca el flujo de los comandos existentes. La llamada extra al Cloud Run API solo se ejecuta en respuesta a \`/version\`.