### PR TITLE
fix(teams_analyzer): /alinear prefers back positions on SF ties

### DIFF
--- a/packages/biwenger_tools/teams_analyzer/README.md
+++ b/packages/biwenger_tools/teams_analyzer/README.md
@@ -91,16 +91,35 @@ entry, helpers come after.
    `playerInLineup=False` (explicit "no convocado"). `None` ("don't know
    yet") is *kept* — we want the gamble. `doubt` is also kept.
 2. **Iterate the 12 supported formations** (`FORMATIONS`).
-3. For each formation, **find the 11-player assignment that maximises the
-   sum of SF** (`_try_fill`). This honours multi-position players (a
-   FWD/MID can play either slot) and chooses the placement that gives the
-   best total, not the first that fits.
-4. **Compare totals across formations** and keep the best.
+3. For each formation, **find the 11-player assignment that maximises
+   `(sum_of_SF, back_bias)`** lexicographically (`_try_fill`). SF is the
+   primary signal; the back-bias tiebreaker is explained below.
+4. **Compare across formations** with the same lexicographic ordering and
+   keep the best.
 5. **Pick reserves** (`_pick_reserves`) in Biwenger's positional order
    POR → DEF → MED → DEL: highest-SF eligible bench player per slot.
 6. **Pick captain** (`_pick_captain`): highest SF among starters whose
    market value is strictly below 3 M€ (Biwenger API rejects ≥ 3 M).
    Fallback: cheapest known-price player if nobody is under the cap.
+
+### Why the back-bias tiebreaker
+
+Biwenger awards a per-position bonus when a player scores: POR +10, DEF +7,
+MED +5, DEL +4. JP's SF is a single number per player and does **not**
+recalculate based on the slot you use. So when you can place the same
+player at his primary FWD or at a back-line alt position with the same SF
+prediction, the alt placement has higher expected points (more bonus if
+he scores). The optimiser captures this with `_back_bias_one`: +1 if the
+slot is behind the primary, 0 if the same, -1 if ahead. Asssignments are
+compared on `(total_sf, total_back_bias)` lexicographically.
+
+Real example from the lineup the user got in the screenshot 2026-05-17:
+three formations (3-4-3, 4-3-3, 4-4-2) summed to the exact same SF total
+of 5832. Without the tiebreaker the optimiser picked 3-4-3 (just because
+it comes first in `FORMATIONS`), which placed Mingueza and J.Iglesias —
+both defenders by primary — as MIDs. With the tiebreaker it picks 5-3-2:
+both stay at DEF (their primary), and the Tsygankov who was a primary FWD
+moves back to MED. Same SF; better expected goal-bonus.
 
 ### Why exhaustive backtracking
 
@@ -138,3 +157,7 @@ players (it won't in Biwenger) we'd add memoisation by sorted-bw_id key.
   which mirrors Biwenger's slot order on the bench.
 - **Penalise `doubt` status** → not done today (user wants to gamble); if
   reopened, the place would be `_sf` returning a discounted value.
+- **Strengthen the back-bias** (e.g. so it overrides small SF differences,
+  not only ties) → fold the bias into `_sf` directly or change the
+  comparison to weighted sum `sf + k * bias` in both `_try_fill` and
+  `pick_lineup`.

--- a/packages/biwenger_tools/teams_analyzer/logic/lineup.py
+++ b/packages/biwenger_tools/teams_analyzer/logic/lineup.py
@@ -61,7 +61,11 @@ def pick_lineup(squad_rows: list) -> dict | None:
     available.sort(key=_sf, reverse=True)
 
     best: dict | None = None
-    best_sf = -1
+    # Lexicographic (sum_sf, back_bias). Same tiebreaker as `_try_fill`, so
+    # ties between formations (3-4-3 vs 4-4-2 with the same SF) are broken in
+    # favour of the one that places more players further back than their
+    # primary position.
+    best_score: tuple[int, int] = (-1, -(10**9))
 
     for label, n_def, n_mid, n_fwd in FORMATIONS:
         slots = {GK: 1, DEF: n_def, MID: n_mid, FWD: n_fwd}
@@ -70,14 +74,16 @@ def pick_lineup(squad_rows: list) -> dict | None:
             continue
 
         total_sf = sum(_sf(r) for r, _ in assignment)
-        if total_sf <= best_sf:
+        total_bias = _back_bias(assignment)
+        score = (total_sf, total_bias)
+        if score <= best_score:
             continue
 
         starter_ids = {r["bw_id"] for r, _ in assignment}
         reserves = _pick_reserves(available, starter_ids)
         captain = _pick_captain([r for r, _ in assignment])
 
-        best_sf = total_sf
+        best_score = score
         best = {
             "formation": label,
             "starters": assignment,
@@ -135,6 +141,36 @@ def _positions(row: dict) -> set:
     return {primary} | set(alts)
 
 
+def _back_bias_one(player: dict, slot: int) -> int:
+    """Score how "back" a player ends up vs their primary position.
+
+    Biwenger gives a bigger goal-scoring bonus the further back the slot:
+    POR +10, DEF +7, MED +5, DEL +4. JP's SF is a single per-player number
+    that does NOT model the slot bonus, so when two assignments tie on SF
+    we still prefer the one that places more players further back than
+    their natural position.
+
+    Returns +1 if the slot is strictly behind the player's primary
+    (e.g. a FWD/MID played as MID), 0 if exactly the primary, -1 if the
+    slot is ahead of the primary.
+
+    Position IDs increase as you move forward: GK=1 < DEF=2 < MID=3 < FWD=4.
+    """
+    primary = player.get("position_id")
+    if primary is None:
+        return 0
+    if slot < primary:
+        return 1
+    if slot > primary:
+        return -1
+    return 0
+
+
+def _back_bias(assignment: list) -> int:
+    """Sum of `_back_bias_one` across an assignment. Higher = more "back"."""
+    return sum(_back_bias_one(p, slot) for p, slot in assignment)
+
+
 def _is_available(row: dict) -> bool:
     """Whether a player can be picked for the lineup.
 
@@ -165,24 +201,36 @@ def _is_available(row: dict) -> bool:
 
 
 def _try_fill(players: list, slots: dict) -> list | None:
-    """Pick the assignment of `players` to `slots` that maximises total SF.
+    """Pick the assignment of `players` to `slots` that maximises (SF, back-bias).
 
     Exhaustive backtracking: for each open slot try every eligible candidate,
-    recurse on the rest, and keep the assignment with the highest sum of SF.
-    Returns `None` if no valid assignment exists.
+    recurse on the rest, and keep the assignment with the highest **lexicographic**
+    `(sum of SF, back-bias)` score. Returns `None` if no valid assignment exists.
 
-    Why exhaustive: a previous version returned the first feasible solution,
-    which was wrong for multi-position players. Example with formation 4-3-3
-    (3 MID + 3 FWD), a FWD/MID player X with SF 400, three other FWDs
-    (380/360/340) and three MIDs (350/320/280):
+    Why two metrics:
+
+    1. SF (predicted score) is the primary signal. It already accounts for
+       most of what makes a player valuable for a given matchday.
+    2. When two assignments tie on SF — which happens often once you have
+       multi-position players — Biwenger's per-position goal bonus breaks
+       the tie. A DEF that scores a goal earns +7 points, a MID +5, a DEL
+       +4. JP's SF is a single number per player and does NOT change with
+       the slot, so picking the assignment that places players further back
+       captures expected bonus points the SF can't see. See `_back_bias_one`.
+
+    Worked example with formation 4-3-3 that motivated the exhaustive search
+    (a FWD/MID player X with SF 400, three other FWDs 380/360/340 and three
+    MIDs 350/320/280):
 
       X as FWD → FWDs sum 1140, MIDs sum 950 = 2090
-      X as MID → FWDs sum 1080, MIDs sum 1070 = 2150  ← global optimum
+      X as MID → FWDs sum 1080, MIDs sum 1070 = 2150  ← higher SF, picked
 
-    The "first feasible" heuristic picked X as FWD because that's its primary
-    position; the exhaustive variant picks the assignment that maximises the
-    11-player SF total. The outer `pick_lineup()` still iterates the 12
-    formations and keeps the best of those.
+    And the tiebreaker example (3-4-3 vs 4-4-2 with multi-position players
+    that all sum to the same SF total):
+
+      3-4-3 with Mingueza/J.Iglesias as MED, Tsygankov as DEL  → bias 0
+      4-4-2 with Mingueza/J.Iglesias as DEF, Tsygankov as MED   → bias +3
+      Same SF, the 4-4-2 variant wins on bias.
 
     To prune the search a bit, we fill the most-constrained position first
     (fewest eligible players). This does not change correctness but cuts
@@ -208,15 +256,17 @@ def _try_fill(players: list, slots: dict) -> list | None:
     )
 
     best: list | None = None
-    best_sf = -1
+    best_score = (-1, -(10**9))  # (sum_sf, back_bias) lexicographic
     for player in candidates:
         remaining = [r for r in players if r["bw_id"] != player["bw_id"]]
         sub = _try_fill(remaining, new_slots)
         if sub is None:
             continue
         sub_sf = _sf(player) + sum(_sf(r) for r, _ in sub)
-        if sub_sf > best_sf:
-            best_sf = sub_sf
+        sub_bias = _back_bias_one(player, pos_to_fill) + _back_bias(sub)
+        score = (sub_sf, sub_bias)
+        if score > best_score:
+            best_score = score
             best = [(player, pos_to_fill)] + sub
 
     return best

--- a/packages/biwenger_tools/teams_analyzer/tests/test_lineup.py
+++ b/packages/biwenger_tools/teams_analyzer/tests/test_lineup.py
@@ -164,20 +164,36 @@ def test_pick_lineup_returns_none_when_no_gk():
     assert pick_lineup(squad) is None
 
 
-def test_pick_lineup_uses_alt_positions():
-    # 1 GK, 4 DEF, 6 MID (one with FWD alt), 0 primary FWD
-    # 4-5-1: place MID-as-FWD in FWD slot, 5 remaining MIDs fill MID, 4 DEFs fill DEF
+def test_pick_lineup_uses_alt_positions_when_needed():
+    """When a formation cannot be filled with pure-position players, the
+    algorithm uses alt_positions to bridge the gap.
+
+    Setup (11 players total):
+      - 1 GK
+      - 4 pure DEFs
+      - 4 pure MIDs
+      - 1 multi MID/FWD
+      - 1 pure FWD
+
+    4-6-0 not viable (only 5 MIDs available). 4-5-1 wins: pure FWD at his
+    slot, multi-MID/FWD stays at his MID primary (bias 0). 4-4-2 with the
+    multi pushed to FWD would have bias -1 and lose the tiebreaker.
+    """
     squad = [_player(1, GK)]
     for i in range(4):
         squad.append(_player(10 + i, DEF, sf=300))
-    for i in range(6):
+    for i in range(4):
         squad.append(_player(20 + i, MID, sf=300))
-    squad[5]["alt_positions"] = [FWD]  # squad[5] = player(20, MID) can also play FWD
+    squad.append(_player(50, MID, sf=300, alts=[FWD]))  # multi MID/FWD
+    squad.append(_player(60, FWD, sf=300))  # pure FWD
 
     result = pick_lineup(squad)
     assert result is not None
-    fwd_count = sum(1 for _, pos in result["starters"] if pos == FWD)
-    assert fwd_count >= 1
+    by_id = {r["bw_id"]: pos for r, pos in result["starters"]}
+    # Multi player stays at his primary MID (back-bias prefers it).
+    assert by_id[50] == MID
+    # Pure FWD fills the FWD slot.
+    assert by_id[60] == FWD
 
 
 def test_try_fill_picks_max_sf_for_single_slot():
@@ -193,6 +209,53 @@ def test_try_fill_picks_max_sf_for_single_slot():
     assert result is not None
     assigned_player, _ = result[0]
     assert assigned_player["bw_id"] == 2  # SF 350 beats SF 300
+
+
+def test_pick_lineup_breaks_sf_tie_by_back_position():
+    """Reported by the user 2026-05-17 with a real /alinear output.
+
+    Biwenger gives a per-position goal bonus (DEF +7, MID +5, DEL +4) that
+    JP's SF does not model. When two formations tie on SF total, we prefer
+    the one that puts more players further back than their primary, so the
+    expected bonus from any goal they score is higher.
+
+    Setup mirrors the lineup from the screenshot:
+      - 1 GK
+      - 3 pure DEFs (Huijsen 715, Affengruber 573, Bellerín 451)
+      - 1 DEF/MID multi (Mingueza 447, primary DEF)
+      - 1 DEF/MID multi (J.Iglesias 432, primary DEF)
+      - 2 pure MIDs (Kubo 486, P.Martinez 434)
+      - 1 DEL/MID multi (Tsygankov 495, primary DEL)
+      - 2 pure FWDs (Mbappé 721, Jutglà 551)
+
+    Multiple formations tie on SF total 5832. With the back-position
+    tiebreaker 5-3-2 wins: both Mingueza and J.Iglesias stay at their
+    primary DEF (so neither goes forward), and Tsygankov pulls back from
+    his primary FWD to MED — net bias +1 (vs e.g. 4-4-2 where J.Iglesias
+    would have to go forward to MED, giving bias 0).
+    """
+    squad = [
+        _player(0, GK, sf=527),
+        _player(1, DEF, sf=715),
+        _player(2, DEF, sf=573),
+        _player(3, DEF, sf=451),
+        _player(10, DEF, sf=447, alts=[MID]),  # Mingueza
+        _player(11, DEF, sf=432, alts=[MID]),  # J.Iglesias
+        _player(12, MID, sf=486),  # Kubo
+        _player(13, MID, sf=434),  # P.Martinez
+        _player(20, FWD, sf=495, alts=[MID]),  # Tsygankov
+        _player(21, FWD, sf=721),  # Mbappé
+        _player(22, FWD, sf=551),  # Jutglà
+    ]
+    result = pick_lineup(squad)
+    assert result is not None
+    # Multiple valid formations sum to the same SF, so SF alone can't decide.
+    assert result["total_sf"] == 5832
+    assert result["formation"] == "5-3-2"
+    by_id = {r["bw_id"]: pos for r, pos in result["starters"]}
+    assert by_id[10] == DEF  # Mingueza at her primary
+    assert by_id[11] == DEF  # J.Iglesias at her primary
+    assert by_id[20] == MID  # Tsygankov pulled back from FWD primary
 
 
 def test_try_fill_places_multiposition_where_it_maximises_total():


### PR DESCRIPTION
## Summary

Tras tu aclaración del bonus por posición de Biwenger (DEF +7, MED +5, DEL +4 al marcar), el SF de JP no captura ese bonus. Cuando dos asignaciones empatan en SF total — como en tu lineup de hoy 5832 con 3-4-3, 4-3-3 y 4-4-2 — el picker no tenía criterio para elegir la mejor.

Este PR introduce un **tiebreaker secundario: back-bias**. Para cada jugador, se mide:

- +1 si su slot está **más atrás** que su primary (e.g. FWD/MID jugado como MED)
- 0 si está en su primary
- -1 si está **adelantado** respecto a su primary

Se suma sobre toda la asignación. Compara lexicográficamente: `(sum_sf, sum_back_bias)`. **SF sigue siendo el ganador absoluto cuando difiere**; el bias solo decide entre asignaciones que JP rata igual.

## Tu lineup de hoy con la nueva lógica

Antes: **3-4-3** SF 5832 (Mingueza y J.Iglesias como MED, Tsygankov como DEL).
Ahora: **5-3-2** SF 5832 (Mingueza y J.Iglesias en DEF, Tsygankov pulled back a MED).

Mismo SF, más bonus posicional esperado.

## Cambios

- `logic/lineup.py`: nuevos `_back_bias_one` y `_back_bias`; `_try_fill` y `pick_lineup` comparan `(sum_sf, sum_back_bias)`.
- `tests/test_lineup.py`:
  - Nuevo `test_pick_lineup_breaks_sf_tie_by_back_position` reproduce el escenario de tu foto.
  - `test_pick_lineup_uses_alt_positions_when_needed` reescrito (el setup viejo con 6 MIDs ahora elige 4-6-0 — correcto bajo la regla nueva). El nuevo setup constrains a 5 MIDs para forzar 4-5-1.
- `teams_analyzer/README.md`: nueva sub-sección "Why the back-bias tiebreaker" con el ejemplo numérico de tu lineup.

## Test plan

- [x] 41 tests passing
- [x] `flake8 + black` clean
- [ ] Tras merge: CI redeploya `biwenger-teams-analyzer`
- [ ] Próximo `/alinear` debería darte 5-3-2 (asumiendo squad/SF similares a hoy)