### PR TITLE
fix(telegram_bot): format analyzer-job updateTime in Madrid time

### DIFF
--- a/packages/biwenger_tools/telegram_bot/app.py
+++ b/packages/biwenger_tools/telegram_bot/app.py
@@ -1,9 +1,11 @@
 """Telegram bot service — handles webhook requests and triggers Cloud Run Jobs."""
 
 import os
+from datetime import datetime
 
 from flask import Flask, request
 
+from core.constants import MADRID_TZ
 from core.sdk.telegram import (
     extract_webhook_update,
     parse_command,
@@ -35,17 +37,33 @@ _JOB_MODES = {
 }
 
 
+def _format_madrid(iso_str: str | None) -> str:
+    """Render an ISO-8601 UTC timestamp as `dd/MM/YYYY HH:mm` in Madrid time.
+
+    The Cloud Run Jobs API returns `updateTime` as RFC3339 / ISO 8601 in UTC
+    (e.g. `2026-05-17T13:25:20.461797Z`). We surface it next to the bot's own
+    DEPLOY_TIME, which is already Madrid-localised by CI, so the two read at
+    a glance instead of forcing the user to do timezone math.
+    """
+    if not iso_str:
+        return "—"
+    try:
+        dt_utc = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+        return dt_utc.astimezone(MADRID_TZ).strftime("%d/%m/%Y %H:%M")
+    except (ValueError, TypeError):
+        return iso_str  # fall back to raw if the API ever returns an oddity
+
+
 def _build_version_text() -> str:
     """Render the /version response showing bot + analyzer-job state."""
     bot_commit = config.GIT_COMMIT or "unknown"
     bot_time = config.DEPLOY_TIME or "—"
-    job_time = (
+    job_time = _format_madrid(
         job_trigger.get_job_update_time(
             config.GCP_PROJECT_ID,
             config.CLOUD_RUN_REGION,
             config.CLOUD_RUN_JOB_NAME,
         )
-        or "—"
     )
     return (
         "<b>📦 Versiones desplegadas</b>\n\n"

--- a/packages/biwenger_tools/telegram_bot/tests/test_telegram_bot.py
+++ b/packages/biwenger_tools/telegram_bot/tests/test_telegram_bot.py
@@ -140,7 +140,7 @@ def test_help_sends_message(client):
 
 
 def test_version_returns_bot_and_job_state(client):
-    """`/version` includes the bot SHA and the job updateTime."""
+    """`/version` includes the bot SHA and the job updateTime formatted in Madrid."""
     cfg.GIT_COMMIT = "abc1234"
     cfg.DEPLOY_TIME = "17/05/2026 14:00"
     with patch(
@@ -154,7 +154,8 @@ def test_version_returns_bot_and_job_state(client):
     text = mock_send.call_args.kwargs.get("text", "")
     assert "abc1234" in text
     assert "17/05/2026 14:00" in text
-    assert "2026-05-17T12:34:56Z" in text
+    # UTC 12:34 → Madrid CEST 14:34 (Mayo 17 cae en DST).
+    assert "17/05/2026 14:34" in text
 
 
 def test_version_tolerates_job_lookup_failure(client):
@@ -172,6 +173,22 @@ def test_version_tolerates_job_lookup_failure(client):
     text = mock_send.call_args.kwargs.get("text", "")
     assert "abc1234" in text
     assert "updated —" in text
+
+
+def test_version_falls_back_to_raw_on_malformed_timestamp(client):
+    """If the API ever returns an unparseable timestamp, surface it raw."""
+    cfg.GIT_COMMIT = "abc1234"
+    cfg.DEPLOY_TIME = "17/05/2026 14:00"
+    with patch(
+        "packages.biwenger_tools.telegram_bot.app.job_trigger.get_job_update_time",
+        return_value="not-a-timestamp",
+    ), patch(
+        "packages.biwenger_tools.telegram_bot.app.send_telegram_message"
+    ) as mock_send:
+        resp = _post(client, _update(_VALID_CHAT, "/version"))
+    assert resp.status_code == 200
+    text = mock_send.call_args.kwargs.get("text", "")
+    assert "not-a-timestamp" in text
 
 
 def test_unknown_command_is_ignored(client):


### PR DESCRIPTION
## Summary

\`/version\` mostraba el deploy time del bot en formato Madrid local pero el del analyzer job en ISO UTC con microsegundos. Lo unifico — los dos en \`dd/MM/YYYY HH:mm\` Madrid.

## Antes / después

\`\`\`
ANTES:
🤖 Bot service:   10e34b8 · 17/05/2026 14:56
⚙️ Analyzer job:  updated 2026-05-17T13:25:20.461797Z

DESPUÉS:
🤖 Bot service:   10e34b8 · 17/05/2026 14:56
⚙️ Analyzer job:  updated 17/05/2026 15:25
\`\`\`

## Cambios

- \`telegram_bot/app.py\`: nuevo \`_format_madrid()\` que parsea el ISO con \`datetime.fromisoformat\`, convierte a \`core.constants.MADRID_TZ\` y devuelve el mismo pattern que el CI usa para \`DEPLOY_TIME\`. Si el parsing falla, devuelve el string crudo (degradación amable, no 500).
- Tests: ahora asertan el Madrid time formateado (CEST en mayo → UTC+2). Test extra para el fallback en timestamp malformado.

## Test plan

- [x] 41 tests passing
- [x] \`flake8 + black\` clean
- [ ] Tras merge, en Telegram: \`/version\` muestra ambas líneas con el mismo formato Madrid