### PR TITLE
fix(teams_analyzer): 'no convocado' = last-resort penalty, not hard filter

### DIFF
--- a/packages/biwenger_tools/teams_analyzer/logic/lineup.py
+++ b/packages/biwenger_tools/teams_analyzer/logic/lineup.py
@@ -35,6 +35,13 @@ GK, DEF, MID, FWD = 1, 2, 3, 4
 # Biwenger refuses to set a captain whose market value is ≥ 3M.
 _CAPTAIN_MAX_PRICE = 3_000_000
 
+# Score we attribute to a player JP has explicitly marked as not in the lineup.
+# Big enough to keep the picker honest (positive, so it still beats an empty
+# slot), small enough that any other eligible player wins on SF. The user
+# prefers filling the slot with someone unlikely to play (0 points) over
+# leaving a hole and losing the -4 "empty slot" penalty Biwenger applies.
+_UNCALLED_SF = 1
+
 
 # ---------------------------------------------------------------------------
 # Public entry point
@@ -120,6 +127,13 @@ def format_lineup_message(result: dict) -> str:
         for label, r in filled:
             lines.append(f"  {label} {escape(r['name'])} (SF:{_sf(r)})")
 
+    uncalled = [r for r, _ in starters if _is_uncalled(r)]
+    if uncalled:
+        lines.append("\n<b>⚠️ Aviso — alineados sin estar convocados</b>")
+        lines.append("  (mejor 0 puntos que dejar hueco y perder -4):")
+        for r in uncalled:
+            lines.append(f"  · {escape(r['name'])}")
+
     return "\n".join(lines)
 
 
@@ -129,9 +143,28 @@ def format_lineup_message(result: dict) -> str:
 
 
 def _sf(row: dict) -> int:
-    """Predicted SF score for a player. 0 if JP has no prediction."""
-    jp = row.get("jp_player")
+    """Predicted SF score for a player.
+
+    Special cases:
+    - 0 if JP has no prediction at all.
+    - `_UNCALLED_SF` (1) if JP has marked the player as `playerInLineup=False`
+      ("no convocado"). They stay eligible so the picker doesn't leave a slot
+      empty (Biwenger penalises an empty slot by -4), but they only get used
+      when there is no real alternative — any other available player at the
+      same position wins easily on SF.
+    """
+    jp = row.get("jp_player") or {}
+    next_match = jp.get("nextMatch") or {}
+    if next_match.get("playerInLineup") is False:
+        return _UNCALLED_SF
     return get_predict_rate(jp, SCORE_SF) or 0
+
+
+def _is_uncalled(row: dict) -> bool:
+    """True if JP has explicitly flagged the player as not in the lineup."""
+    jp = row.get("jp_player") or {}
+    next_match = jp.get("nextMatch") or {}
+    return next_match.get("playerInLineup") is False
 
 
 def _positions(row: dict) -> set:
@@ -177,10 +210,13 @@ def _is_available(row: dict) -> bool:
     Excludes:
     - players with no JP data (we can't predict their SF),
     - injured or suspended (per JP status),
-    - matches in `break` (their team has no game this matchday),
-    - `playerInLineup is False` — JP has *explicitly* said the player is not
-      in the official squad list. A `None` means "unknown yet", which is the
-      normal state hours before kickoff and is treated as still available.
+    - matches in `break` (their team has no game this matchday).
+
+    Note: `playerInLineup is False` ("no convocado") used to be a hard
+    exclusion. It is now a soft penalty applied in `_sf` instead — a
+    not-called player still beats an empty slot in Biwenger's scoring
+    (empty slot = -4, not playing = 0), so we want them as fallback,
+    not removed.
     """
     jp = row.get("jp_player")
     if jp is None:
@@ -189,8 +225,6 @@ def _is_available(row: dict) -> bool:
         return False
     next_match = jp.get("nextMatch") or {}
     if next_match.get("status") == "break":
-        return False
-    if next_match.get("playerInLineup") is False:
         return False
     return True
 

--- a/packages/biwenger_tools/teams_analyzer/tests/test_lineup.py
+++ b/packages/biwenger_tools/teams_analyzer/tests/test_lineup.py
@@ -83,10 +83,59 @@ def test_unavailable_no_jp():
     assert _is_available(row) is False
 
 
-def test_unavailable_when_not_in_lineup():
-    """JP says playerInLineup=False (explicit "not convocado") → excluded."""
+def test_uncalled_player_is_available_with_penalty_sf():
+    """JP says playerInLineup=False ("no convocado") — kept eligible but with
+    SF penalised to 1 so the picker only uses them as a last resort.
+
+    User-reported scenario 2026-05-17: the squad had a single GK and JP
+    marked him uncalled. The previous "hard filter" rule made pick_lineup
+    return None and Biwenger applied a -4 empty-slot penalty. We prefer
+    fielding the uncalled player (0 points if he doesn't play) to losing
+    the empty-slot penalty.
+    """
+    from packages.biwenger_tools.teams_analyzer.logic.lineup import (
+        _UNCALLED_SF,
+        _sf as lineup_sf,
+    )
+
     p = _player(1, GK, sf=400, in_lineup=False)
-    assert _is_available(p) is False
+    assert _is_available(p) is True
+    assert lineup_sf(p) == _UNCALLED_SF
+
+
+def test_uncalled_only_used_when_no_alternative():
+    """In a single-slot duel, an uncalled SF=500 loses to a convocado SF=300.
+    With only the uncalled player available, the picker still uses him."""
+    convocado = _player(1, GK, sf=300, in_lineup=True)
+    uncalled = _player(2, GK, sf=500, in_lineup=False)
+
+    # Duel: convocado wins despite lower raw SF (uncalled gets penalised to 1).
+    duel = pick_lineup(
+        [
+            convocado,
+            uncalled,
+            *[_player(10 + i, DEF, sf=300) for i in range(4)],
+            *[_player(20 + i, MID, sf=300) for i in range(4)],
+            *[_player(30 + i, FWD, sf=300) for i in range(2)],
+        ]
+    )
+    assert duel is not None
+    gk = next(r for r, pos in duel["starters"] if pos == GK)
+    assert gk["bw_id"] == 1  # convocado picked
+
+    # Same setup, only the uncalled GK available → still picked rather than
+    # leaving an empty GK slot.
+    only_uncalled = pick_lineup(
+        [
+            uncalled,
+            *[_player(10 + i, DEF, sf=300) for i in range(4)],
+            *[_player(20 + i, MID, sf=300) for i in range(4)],
+            *[_player(30 + i, FWD, sf=300) for i in range(2)],
+        ]
+    )
+    assert only_uncalled is not None
+    gk = next(r for r, pos in only_uncalled["starters"] if pos == GK)
+    assert gk["bw_id"] == 2  # uncalled picked as last resort
 
 
 def test_available_when_lineup_unknown():


### PR DESCRIPTION
## Summary

Tras tu hallazgo: \`/alinear\` devolvió "jugadores insuficientes" porque Escandell (tu único POR) está flagged como **no convocado** por JP. Con la regla de PR #38 (filtro duro), eso vaciaba los 11 → Biwenger te habría aplicado **-4 por slot POR vacío**.

Tu preferencia es clara: **mejor un no-convocado (worst case 0 puntos si no juega) que un hueco (-4 garantizado)**.

## Cambio

\`playerInLineup is False\` pasa de **filtro duro** a **penalty suave**:

- \`_is_available\`: ya **no** los excluye.
- \`_sf\`: devuelve \`_UNCALLED_SF = 1\` si el jugador es no-convocado. Cualquier otro disponible al mismo slot le gana en SF. Solo se usa **cuando no hay alternativa**.
- \`_is_uncalled\`: helper para detectar el caso.
- \`format_lineup_message\`: añade un aviso explícito al mensaje cuando el lineup final incluye no-convocados, para que sepas que el picker hizo fallback.

## Mensaje de Telegram tras el cambio

\`\`\`
✅ Alineación aplicada — 4-4-2 (SF total: 5234)
POR Escandell (SF:1)
DEF Huijsen ...
...

⚠️ Aviso — alineados sin estar convocados
  (mejor 0 puntos que dejar hueco y perder -4):
  · Escandell
\`\`\`

## Tests

- Old test (\`test_unavailable_when_not_in_lineup\`) → reescrito como \`test_uncalled_player_is_available_with_penalty_sf\`.
- Nuevo \`test_uncalled_only_used_when_no_alternative\` cubre los dos casos: duel pierde, último recurso gana.

42 tests passing, lint clean.

## Riesgo

Bajo. La regla solo se relaja para no-convocados (que antes excluíamos). Cualquier squad que antes tenía un lineup válido sigue teniendo el mismo (los no-convocados no aparecen porque otros les ganan en SF). Los squads sin alternativa ahora devuelven lineup en vez de None.