### PR TITLE
fix(alinear): retry Biwenger PUT, surface failures to Telegram

### DIFF
--- a/core/sdk/biwenger.py
+++ b/core/sdk/biwenger.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+import time
 from typing import Optional, Union
 
 import requests
@@ -9,6 +10,11 @@ import requests
 from core.utils import get_logger
 
 logger = get_logger(__name__)
+
+# Backoff schedule (seconds) for transient network failures on the lineup PUT.
+# Biwenger has occasionally dropped TCP mid-response — when that happens, the
+# right move is to retry rather than fail the whole `/alinear` flow.
+_LINEUP_RETRY_BACKOFFS = (2, 5, 10)
 
 # --- URLs públicas del API de Biwenger ---
 # Cualquier paquete puede importar estas constantes en lugar de redefinirlas.
@@ -264,7 +270,13 @@ class BiwengerClient:
         reserves_id: list,
         captain: int,
     ) -> dict:
-        """Sets the lineup via PUT. Returns the API response dict."""
+        """Sets the lineup via PUT. Returns the API response dict.
+
+        Retries the PUT on transient network errors (Connection reset, read
+        timeout, etc.) with the backoff schedule in `_LINEUP_RETRY_BACKOFFS`.
+        A 4xx response (e.g. invalid captain) is treated as terminal — those
+        won't get better on retry. Only network-level failures are retried.
+        """
         payload = {
             "lineup": {
                 "type": formation,
@@ -282,15 +294,55 @@ class BiwengerClient:
                 "captain": captain,
             },
         )
-        response = self.session.put(lineup_url, json=payload)
-        if not response.ok:
-            logger.error(
-                "Lineup PUT failed.",
-                extra={"status": response.status_code, "body": response.text[:500]},
+
+        last_exc: Optional[requests.RequestException] = None
+        for attempt, backoff in enumerate((0,) + _LINEUP_RETRY_BACKOFFS, start=1):
+            if backoff:
+                logger.warning(
+                    "Lineup PUT transient failure — retrying.",
+                    extra={
+                        "attempt": attempt,
+                        "backoff_s": backoff,
+                        "error": str(last_exc),
+                    },
+                )
+                time.sleep(backoff)
+            try:
+                response = self.session.put(lineup_url, json=payload, timeout=30)
+            except requests.RequestException as exc:
+                last_exc = exc
+                continue
+
+            if not response.ok:
+                logger.error(
+                    "Lineup PUT returned non-2xx.",
+                    extra={
+                        "status": response.status_code,
+                        "body": response.text[:500],
+                    },
+                )
+                # 4xx is a terminal error (invalid payload, wrong captain, etc.)
+                # 5xx is worth retrying — Biwenger backend may recover.
+                if 400 <= response.status_code < 500:
+                    response.raise_for_status()
+                last_exc = requests.HTTPError(
+                    f"Biwenger HTTP {response.status_code}", response=response
+                )
+                continue
+
+            logger.info(
+                "Lineup set.",
+                extra={"formation": formation, "captain": captain, "attempts": attempt},
             )
-        response.raise_for_status()
-        logger.info(
-            "Lineup set.",
-            extra={"formation": formation, "captain": captain},
+            return response.json()
+
+        # Out of retries.
+        logger.error(
+            "Lineup PUT failed after retries.",
+            extra={
+                "attempts": len(_LINEUP_RETRY_BACKOFFS) + 1,
+                "error": str(last_exc),
+            },
         )
-        return response.json()
+        assert last_exc is not None
+        raise last_exc

--- a/packages/biwenger_tools/teams_analyzer/main.py
+++ b/packages/biwenger_tools/teams_analyzer/main.py
@@ -12,6 +12,8 @@ import math
 import time
 from datetime import datetime
 
+import requests
+
 from core.sdk.biwenger import BiwengerClient
 from core.sdk.jp import check_api_health, fetch_all_players
 from core.sdk.telegram import send_telegram_message, send_telegram_photo
@@ -282,13 +284,33 @@ def _run_alinear(
         r["bw_id"] for r, _ in sorted(result["starters"], key=lambda rp: rp[1])
     ]
     reserves_ids = [r["bw_id"] if r else None for r in result["reserves"]]
-    biwenger.set_lineup(
-        config.LINEUP_URL,
-        result["formation"],
-        starters_ids,
-        reserves_ids,
-        result["captain"]["bw_id"],
-    )
+    try:
+        biwenger.set_lineup(
+            config.LINEUP_URL,
+            result["formation"],
+            starters_ids,
+            reserves_ids,
+            result["captain"]["bw_id"],
+        )
+    except requests.RequestException as exc:
+        # The Biwenger PUT already retries transient failures internally
+        # (see core/sdk/biwenger.py:set_lineup). If we get here it means the
+        # retries also failed, or Biwenger returned a 4xx (e.g. invalid
+        # captain). Either way the user deserves a clear message instead of
+        # silence.
+        logger.error("set_lineup failed after retries.", extra={"error": str(exc)})
+        send_telegram_message(
+            bot_token=token,
+            chat_id=chat_id,
+            text=(
+                "❌ No se pudo aplicar la alineación en Biwenger.\n"
+                f"<code>{exc}</code>\n"
+                "Suele ser un blip de la API — vuelve a probar /alinear "
+                "en 1-2 minutos."
+            ),
+        )
+        return
+
     send_telegram_message(
         bot_token=token, chat_id=chat_id, text=format_lineup_message(result)
     )


### PR DESCRIPTION
## Summary

Cierra el agujero del blip de Biwenger que vimos esta mañana (execution \`hcxmk\` murió en silencio con \`ConnectionResetError\` mid-PUT).

Dos piezas:

1. **\`BiwengerClient.set_lineup\`** retries el PUT con backoff **2/5/10 s** ante fallos transitorios (network errors, 5xx). 4xx es terminal — no se reintenta. Timeout explícito de 30s por intento.
2. **\`_run_alinear\`** wrappea \`set_lineup\` con try/except. Si los retries fallan también, manda mensaje claro al chat:

   \`\`\`
   ❌ No se pudo aplicar la alineación en Biwenger.
   <exception>
   Suele ser un blip de la API — vuelve a probar /alinear en 1-2 minutos.
   \`\`\`

## Resultado

- **Blip transitorio** (lo que pasó hoy): el retry lo salva. Tú no te enteras.
- **Fallo persistente** (4xx, o Biwenger down): mensaje claro, no silencio.
- **Cron diario** también se beneficia — si Biwenger tiene un hipo a las 16:00, no se pierde la matchday.

## Test plan

- [x] 42 tests siguen pasando
- [x] \`flake8 + black\` clean
- [ ] Tras merge: CI redepliega \`biwenger-teams-analyzer\`. Próxima vez que falle Biwenger, te llega el mensaje