### PR TITLE
feat(api): add POST /digests/daily and rename /healthz to /health

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -365,6 +365,7 @@ jobs:
             --memory=512Mi \
             --cpu=1 \
             --concurrency=10 \
+            --update-secrets="BIWENGER_CREDENTIALS_JSON=biwenger-credentials-regional:latest,TELEGRAM_BOT_CONFIG_JSON=telegram-bot-config-regional:latest" \
             --set-env-vars="\
           GIT_COMMIT=${GITHUB_SHA::7},\
           DEPLOY_TIME=$(TZ=Europe/Madrid date '+%d/%m/%Y %H:%M')"

--- a/packages/biwenger_tools/api/BUILD.bazel
+++ b/packages/biwenger_tools/api/BUILD.bazel
@@ -5,6 +5,11 @@ python_service(
     package = "biwenger_tools",
     main = "app.py",
     repository = "europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/api",
+    deps = [
+        "@pypi//matplotlib",
+        "@pypi//requests",
+        "@pypi//unidecode",
+    ],
     extra_env = {
         "PORT": "8080",
         "PYTHONPATH": "/app",

--- a/packages/biwenger_tools/api/app.py
+++ b/packages/biwenger_tools/api/app.py
@@ -1,8 +1,7 @@
 """Biwenger API service — HTTP entry points for Telegram bot + Cloud Scheduler.
 
-Skeleton in this PR: only /healthz and /version. The business-logic endpoints
-(/teams, /lineups/auto-pick, /digests/daily, /budget/recommendations, etc.)
-land in subsequent PRs as we move modes out of teams_analyzer.
+PR 1 scaffold: /health and /version.
+PR 2 (this): adds POST /digests/daily for the cron.
 """
 
 import os
@@ -11,14 +10,18 @@ from flask import Flask, jsonify
 
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
+from packages.biwenger_tools.api.logic import digests
 
 logger = get_logger(__name__)
 
 app = Flask(__name__)
 
 
-@app.route("/healthz", methods=["GET"])
-def healthz():
+@app.route("/health", methods=["GET"])
+def health():
+    # Note: do NOT use "/healthz" — Google Frontend reserves that path on
+    # *.run.app and returns its own 404 before the request reaches the
+    # container. "/health" works.
     return jsonify({"status": "ok"}), 200
 
 
@@ -34,6 +37,22 @@ def version():
         ),
         200,
     )
+
+
+@app.route("/digests/daily", methods=["POST"])
+def digests_daily():
+    """Cron-triggered: send "my team + market" PNGs to Telegram.
+
+    Cloud Scheduler hits this once a day with an OIDC token. The Biwenger
+    + JP traffic is real (no preview mode), so this should only ever be
+    called by the Scheduler.
+    """
+    try:
+        result = digests.run_daily()
+        return jsonify({"status": "ok", **result}), 200
+    except Exception as exc:
+        logger.exception("Daily digest failed.")
+        return jsonify({"status": "error", "error": str(exc)}), 500
 
 
 if __name__ == "__main__":

--- a/packages/biwenger_tools/api/config.py
+++ b/packages/biwenger_tools/api/config.py
@@ -2,7 +2,46 @@ import os
 
 from dotenv import load_dotenv
 
+from core.constants import LEAGUE_ID  # re-exported for callers
+from core.sdk import biwenger as biwenger_sdk
+from core.utils import load_json_secret
+
+_ = LEAGUE_ID  # noqa: F841  (silence unused-import for callers via config.LEAGUE_ID)
+
 load_dotenv()
+
+
+# Production secrets:
+#   BIWENGER_CREDENTIALS_JSON  → email, password, jp_auth_token
+#   TELEGRAM_BOT_CONFIG_JSON   → bot_token, chat_id
+# Local dev: individual env vars as fallback.
+_BIWENGER_CFG = load_json_secret("BIWENGER_CREDENTIALS_JSON")
+_TELEGRAM_CFG = load_json_secret("TELEGRAM_BOT_CONFIG_JSON")
+
+BIWENGER_EMAIL = _BIWENGER_CFG.get("email") or os.getenv("BIWENGER_EMAIL", "")
+BIWENGER_PASSWORD = _BIWENGER_CFG.get("password") or os.getenv("BIWENGER_PASSWORD", "")
+TELEGRAM_BOT_TOKEN = (
+    _TELEGRAM_CFG.get("bot_token") or os.getenv("TELEGRAM_BOT_TOKEN", "")
+).strip()
+TELEGRAM_CHAT_ID = (
+    _TELEGRAM_CFG.get("chat_id") or os.getenv("TELEGRAM_CHAT_ID", "")
+).strip()
+
+# --- BIWENGER API URLs (derived from core for the user's league) ---
+LOGIN_URL = biwenger_sdk.LOGIN_URL
+ACCOUNT_URL = biwenger_sdk.ACCOUNT_URL
+MARKET_URL = biwenger_sdk.MARKET_URL
+LINEUP_URL = biwenger_sdk.LINEUP_URL
+ALL_PLAYERS_DATA_URL = biwenger_sdk.ALL_PLAYERS_DATA_URL
+LEAGUE_DATA_URL = biwenger_sdk.league_standings_url(LEAGUE_ID)
+USER_SQUAD_URL = biwenger_sdk.manager_squad_url("{manager_id}")
+
+# --- JORNADA PERFECTA (private API) ---
+# Token sourced from BIWENGER_CREDENTIALS_JSON.jp_auth_token — it belongs to
+# the JP mobile app and can't be rotated by us, but we keep it out of git.
+JP_AUTH_TOKEN = _BIWENGER_CFG.get("jp_auth_token") or os.getenv("JP_AUTH_TOKEN", "")
+JP_COMPETITION = 1  # LaLiga
+JP_SCORE_TYPE = 2  # SofaScore (Automanager system)
 
 # Deployed version metadata (set by CI, see deploy.yml). Used by /version.
 GIT_COMMIT = os.getenv("GIT_COMMIT", "local")

--- a/packages/biwenger_tools/api/logic/digests.py
+++ b/packages/biwenger_tools/api/logic/digests.py
@@ -1,0 +1,80 @@
+"""Daily digest logic — sends "my team + market" as PNGs to Telegram.
+
+Used by `POST /digests/daily`, which Cloud Scheduler hits once a day. The
+orchestration (JP health check, build index, Biwenger session, send) lives
+here so the Flask handler stays a thin shell that translates HTTP errors.
+"""
+
+import time
+
+from core.sdk.biwenger import BiwengerClient
+from core.sdk.jp import check_api_health, fetch_all_players
+from core.sdk.telegram import send_telegram_photo
+from core.utils import get_logger
+from packages.biwenger_tools.api import config
+from packages.biwenger_tools.api.logic.image_formatter import build_table_image
+from packages.biwenger_tools.api.logic.player_matching import build_jp_index
+from packages.biwenger_tools.api.logic.rows import build_market_rows, build_squad_rows
+
+logger = get_logger(__name__)
+
+
+def _send_image(token: str, chat_id: str, image: bytes, caption: str) -> None:
+    """sendPhoto + a small pause to stay under Telegram's send-rate cap."""
+    send_telegram_photo(token, chat_id, image, caption)
+    time.sleep(0.5)
+
+
+def run_daily() -> dict:
+    """Send my squad + market images. Returns a small summary for the response.
+
+    Side effects: hits JP, hits Biwenger, sends 2 PNGs to Telegram.
+    """
+    check_api_health(
+        config.JP_AUTH_TOKEN,
+        competition=config.JP_COMPETITION,
+        score_type=config.JP_SCORE_TYPE,
+    )
+    jp_players = fetch_all_players(
+        config.JP_AUTH_TOKEN,
+        competition=config.JP_COMPETITION,
+        score_type=config.JP_SCORE_TYPE,
+    )
+    jp_index = build_jp_index(jp_players)
+
+    biwenger = BiwengerClient(
+        config.BIWENGER_EMAIL,
+        config.BIWENGER_PASSWORD,
+        config.LOGIN_URL,
+        config.ACCOUNT_URL,
+        config.LEAGUE_ID,
+    )
+    biwenger_players = biwenger.get_all_players_data_map(config.ALL_PLAYERS_DATA_URL)
+
+    if not (config.TELEGRAM_BOT_TOKEN and config.TELEGRAM_CHAT_ID):
+        logger.warning("Telegram credentials missing — skipping send.")
+        return {"sent": 0, "reason": "telegram_credentials_missing"}
+
+    my_squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, biwenger.user_id)
+    my_team = build_squad_rows(my_squad, biwenger_players, jp_index)
+    _send_image(
+        config.TELEGRAM_BOT_TOKEN,
+        config.TELEGRAM_CHAT_ID,
+        build_table_image(my_team, "Mi equipo"),
+        "Mi equipo",
+    )
+
+    market_players = biwenger.get_market_players(config.MARKET_URL)
+    market_rows = build_market_rows(market_players, biwenger_players, jp_index)
+    _send_image(
+        config.TELEGRAM_BOT_TOKEN,
+        config.TELEGRAM_CHAT_ID,
+        build_table_image(market_rows, "Mercado"),
+        "Mercado",
+    )
+
+    logger.info(
+        "Daily analysis sent.",
+        extra={"my_team": len(my_team), "market": len(market_rows)},
+    )
+    return {"sent": 2, "my_team": len(my_team), "market": len(market_rows)}

--- a/packages/biwenger_tools/api/logic/image_formatter.py
+++ b/packages/biwenger_tools/api/logic/image_formatter.py
@@ -1,0 +1,194 @@
+"""Generates PNG table images for Telegram using matplotlib."""
+
+import io
+
+import matplotlib
+
+matplotlib.use("Agg")  # non-interactive backend, must be set before pyplot import
+import matplotlib.pyplot as plt  # noqa: E402
+
+from core.sdk.jp import get_predict_rate  # noqa: E402
+from packages.biwenger_tools.api.player_formatting import (  # noqa: E402
+    SCORE_SF,
+    count_status_buckets,
+    play_status_label,
+    short_position,
+    sort_key_sf_desc,
+    status_emoji,
+)
+
+_ROW_BG = {
+    "🟢": "#e8f5e9",
+    "🟡": "#fffde7",
+    "🔴": "#ffebee",
+    "⚪": "#f5f5f5",
+}
+
+_HEADER_BG = "#1a237e"
+_HEADER_FG = "white"
+_TITLE_FG = "#1a237e"
+_EDGE = "#e0e0e0"
+
+_GREEN = "#388e3c"
+_AMBER = "#f57f17"
+_RED = "#c62828"
+
+# Base columns: (header, relative_width). Keep header and width together so
+# adding/removing a column is a single-line edit instead of two parallel lists.
+_BASE_COLUMNS: list[tuple[str, float]] = [
+    ("Jugador", 0.30),
+    ("Pos", 0.07),
+    ("Precio", 0.09),
+    ("SF", 0.07),
+    ("Racha", 0.08),
+    ("Juega", 0.14),
+]
+_EXTRA_COL_WIDTH = 0.18
+
+
+def _strip_emoji(text: str) -> str:
+    """Remove characters outside the Basic Multilingual Plane (emoji, etc.)."""
+    return "".join(c for c in text if ord(c) <= 0xFFFF).strip()
+
+
+def _price_exact(price) -> str:
+    """Show price with one decimal place (e.g. 24.5M) instead of rounding."""
+    if not price:
+        return "0"
+    m = int(price) / 1_000_000
+    return f"{m:.1f}M" if price % 1_000_000 else f"{int(m)}M"
+
+
+def _pos_str(row: dict) -> str:
+    """Primary position + alt positions, e.g. 'DEF/MED'."""
+    primary = short_position(row.get("position_id"))
+    alts = row.get("alt_positions") or []
+    if alts:
+        return "/".join([primary] + [short_position(a) for a in alts[:2]])
+    return primary
+
+
+def _row_data(row: dict, extra_cols: list[str]) -> list[str]:
+    jp = row.get("jp_player")
+    sf = get_predict_rate(jp, SCORE_SF) if jp else None
+    cells = [
+        _strip_emoji(row.get("name", ""))[:22],
+        _pos_str(row),
+        _price_exact(row.get("price", 0)),
+        str(sf) if sf is not None else "-",
+        str(jp.get("streak", 0)) if jp else "-",
+        play_status_label(jp),
+    ]
+    for col in extra_cols:
+        cells.append(str(row.get(col, "")))
+    return cells
+
+
+def _draw_status_summary(ax, g: int, y: int, r: int, n: int) -> None:
+    """Draws a colored-dot status summary line below the title."""
+    parts = [
+        (f"  {n} jugadores  ", "#555555"),
+        ("  ●  ", _GREEN),
+        (f"{g} ok  ", "#333333"),
+        ("  ●  ", _AMBER),
+        (f"{y} alerta  ", "#333333"),
+        ("  ●  ", _RED),
+        (f"{r} baja  ", "#333333"),
+    ]
+    x = 0.02
+    for text, color in parts:
+        ax.text(
+            x,
+            0.935,
+            text,
+            transform=ax.transAxes,
+            fontsize=9,
+            ha="left",
+            va="top",
+            color=color,
+        )
+        x += len(text) * 0.012
+
+
+def build_table_image(
+    rows: list[dict],
+    title: str,
+    extra_cols: list[str] | None = None,
+) -> bytes:
+    """Returns PNG bytes of a styled player table."""
+    extra_cols = extra_cols or []
+    base_headers = [h for h, _ in _BASE_COLUMNS]
+    base_widths = [w for _, w in _BASE_COLUMNS]
+    headers = base_headers + extra_cols
+
+    sorted_rows = sorted(rows, key=sort_key_sf_desc, reverse=True)
+    green, yellow, red, _ = count_status_buckets(sorted_rows)
+
+    cell_data = [_row_data(row, extra_cols) for row in sorted_rows]
+    cell_colors = [
+        [_ROW_BG.get(status_emoji(row.get("jp_player")), _ROW_BG["⚪"])] * len(headers)
+        for row in sorted_rows
+    ]
+
+    n_rows = len(cell_data)
+    n_cols = len(headers)
+    extra_width = 0.20 * len(extra_cols)
+    fig_w = 9 + extra_width
+    # Slow height growth so all images stay in the ~750–975 px range at 150 dpi.
+    # This keeps Telegram's display-scale consistent across small and large squads.
+    fig_h = min(6.5, max(3.5, 4.5 + 0.06 * n_rows))
+
+    fig, ax = plt.subplots(figsize=(fig_w, fig_h))
+    fig.patch.set_facecolor("white")
+    ax.set_facecolor("white")
+    ax.axis("off")
+
+    ax.text(
+        0.5,
+        0.995,
+        _strip_emoji(title),
+        transform=ax.transAxes,
+        fontsize=14,
+        fontweight="bold",
+        ha="center",
+        va="top",
+        color=_TITLE_FG,
+    )
+    _draw_status_summary(ax, green, yellow, red, len(sorted_rows))
+
+    col_widths = base_widths + [_EXTRA_COL_WIDTH] * len(extra_cols)
+    total = sum(col_widths)
+    col_widths = [w / total for w in col_widths]
+
+    table = ax.table(
+        cellText=cell_data,
+        colLabels=headers,
+        cellColours=cell_colors,
+        cellLoc="left",
+        loc="center",
+        bbox=[0, 0, 1, 0.88],
+    )
+
+    for j in range(n_cols):
+        cell = table[0, j]
+        cell.set_facecolor(_HEADER_BG)
+        cell.get_text().set_color(_HEADER_FG)
+        cell.get_text().set_fontweight("bold")
+        cell.get_text().set_fontsize(10)
+        cell.set_edgecolor(_EDGE)
+
+    for i in range(1, n_rows + 1):
+        for j in range(n_cols):
+            cell = table[i, j]
+            cell.get_text().set_fontsize(9.5)
+            cell.set_edgecolor(_EDGE)
+
+    for j, width in enumerate(col_widths):
+        for i in range(n_rows + 1):
+            table[i, j].set_width(width)
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=150, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    buf.seek(0)
+    return buf.read()

--- a/packages/biwenger_tools/api/logic/player_matching.py
+++ b/packages/biwenger_tools/api/logic/player_matching.py
@@ -1,0 +1,95 @@
+from unidecode import unidecode
+
+# Mapeo manual Biwenger -> JP para casos en los que ninguna estrategia
+# automática funciona (nombres completamente distintos, apodos, alias).
+# Las claves están normalizadas (lowercase + sin acentos).
+PLAYER_NAME_MAPPINGS = {
+    # Vinicius en Biwenger ↔ "Vini Jr" en JP
+    "vinicius jr": "vini jr",
+    "vinicius junior": "vini jr",
+    # Inversiones / variaciones conocidas históricas
+    "sancet": "oihan sancet",
+    "javi hernandez": "javier hernandez",
+    "javier rueda": "javi rueda",
+    "brugue": "brugui",
+    "ricardo rodriguez": "r. rodriguez",
+    "matias moreno": "m. moreno",
+}
+
+
+def normalize_name(name: str) -> str:
+    """Normaliza nombres: minúsculas, sin acentos, recortado."""
+    return unidecode(name.lower().strip())
+
+
+def build_jp_index(jp_players: list[dict]) -> dict:
+    """Construye índices del listado JP para acelerar el matching.
+
+    Devuelve dict con dos claves:
+      - 'by_name': nombre normalizado -> jugador JP
+      - 'by_slug': slug normalizado -> jugador JP (fallback)
+    """
+    by_name: dict[str, dict] = {}
+    by_slug: dict[str, dict] = {}
+    for p in jp_players:
+        name = p.get("name") or ""
+        slug = p.get("slug") or ""
+        if name:
+            by_name[normalize_name(name)] = p
+        if slug:
+            by_slug[normalize_name(slug)] = p
+    return {"by_name": by_name, "by_slug": by_slug}
+
+
+def find_player_match(biwenger_name: str, jp_index: dict) -> dict | None:
+    """Busca el jugador JP que corresponde al nombre Biwenger dado.
+
+    Prueba en orden:
+      1. Coincidencia directa por nombre normalizado
+      2. Mapeo manual de excepciones (PLAYER_NAME_MAPPINGS)
+      3. Coincidencia por slug
+      4. Transformaciones automáticas (apellido, nombre, "i. apellido")
+      5. Subconjunto de tokens
+
+    Devuelve el dict del jugador JP o None si no hay coincidencia.
+    """
+    by_name = jp_index["by_name"]
+    by_slug = jp_index["by_slug"]
+    norm = normalize_name(biwenger_name)
+
+    if norm in by_name:
+        return by_name[norm]
+
+    if norm in PLAYER_NAME_MAPPINGS:
+        mapped = PLAYER_NAME_MAPPINGS[norm]
+        if mapped in by_name:
+            return by_name[mapped]
+
+    if norm in by_slug:
+        return by_slug[norm]
+
+    # Slug suele ser sin espacios; probar también la variante sin espacios
+    no_spaces = norm.replace(" ", "")
+    if no_spaces in by_slug:
+        return by_slug[no_spaces]
+
+    parts = norm.split()
+    if len(parts) > 1:
+        last = parts[-1]
+        if last in by_name:
+            return by_name[last]
+
+        first = parts[0]
+        if first in by_name:
+            return by_name[first]
+
+        initial_last = f"{parts[0][0]}. {parts[-1]}"
+        if initial_last in by_name:
+            return by_name[initial_last]
+
+    parts_set = set(parts)
+    for jp_norm, jp_player in by_name.items():
+        if parts_set and parts_set.issubset(set(jp_norm.split())):
+            return jp_player
+
+    return None

--- a/packages/biwenger_tools/api/logic/rows.py
+++ b/packages/biwenger_tools/api/logic/rows.py
@@ -1,0 +1,79 @@
+"""Row builders shared by every endpoint that renders a squad or market view.
+
+Pure functions over `(biwenger_player_dict, jp_index)`. Kept free of side
+effects so the same row dict feeds the PNG image builder, the JSON
+recommendations endpoint, etc.
+"""
+
+import math
+import time
+
+from packages.biwenger_tools.api.logic.player_matching import find_player_match
+
+SECONDS_PER_DAY = 86400
+
+
+def clausulable_str(locked_until) -> str:
+    """Render the `Clausulable` table cell from a `clauseLockedUntil` epoch."""
+    if locked_until is None:
+        return "Sí"
+    remaining_secs = locked_until - time.time()
+    if remaining_secs <= 0:
+        return "Sí"
+    # floor: 11.28 days → 11 (matches "día 21" when today is the 10th)
+    # max(1, ...) so sub-day locks still show "No (1d)" instead of "Sí"
+    remaining = max(1, math.floor(remaining_secs / SECONDS_PER_DAY))
+    return f"No ({remaining}d)"
+
+
+def clause_str(clause) -> str:
+    if not clause:
+        return "-"
+    m = int(clause) / 1_000_000
+    return f"{m:.1f}M" if int(clause) % 1_000_000 else f"{int(m)}M"
+
+
+def build_row(biwenger_player: dict, jp_index: dict) -> dict:
+    name = biwenger_player.get("name", "N/A")
+    return {
+        "bw_id": biwenger_player.get("id"),
+        "name": name,
+        "position_id": biwenger_player.get("position"),
+        "alt_positions": biwenger_player.get("altPositions") or [],
+        "price": biwenger_player.get("price", 0),
+        "jp_player": find_player_match(name, jp_index),
+    }
+
+
+def build_market_rows(
+    market_players: list, biwenger_players: dict, jp_index: dict
+) -> list:
+    rows = []
+    for sale in market_players:
+        if sale.get("user") is not None:
+            continue
+        bw_player = biwenger_players.get(sale.get("player", {}).get("id"))
+        if not bw_player:
+            continue
+        rows.append(build_row(bw_player, jp_index))
+    return rows
+
+
+def build_squad_rows(
+    squad: list,
+    biwenger_players: dict,
+    jp_index: dict,
+    include_clause: bool = False,
+) -> list:
+    rows = []
+    for player_data in squad:
+        bw_player = biwenger_players.get(player_data.get("id"))
+        if not bw_player:
+            continue
+        row = build_row(bw_player, jp_index)
+        if include_clause:
+            owner = player_data.get("owner") or {}
+            row["Clausulable"] = clausulable_str(owner.get("clauseLockedUntil"))
+            row["Cláusula"] = clause_str(owner.get("clause"))
+        rows.append(row)
+    return rows

--- a/packages/biwenger_tools/api/player_formatting.py
+++ b/packages/biwenger_tools/api/player_formatting.py
@@ -1,0 +1,86 @@
+"""Player formatting helpers (status, position, play status) shared across renderers."""
+
+from core.sdk.jp import get_predict_rate
+
+POSITION_SHORT = {1: "POR", 2: "DEF", 3: "MED", 4: "DEL"}
+
+# Score type 2 = "SF" (SofaScore-based Automanager rate).
+# Used wherever we read predictions from JP.
+SCORE_SF = 2
+
+# Traffic-light thresholds based on the predicted SF score.
+# Tuned by hand against past matchdays; reused by status_emoji().
+SF_GREEN_THRESHOLD = 300
+SF_YELLOW_THRESHOLD = 100
+
+
+def short_position(position_id) -> str:
+    return POSITION_SHORT.get(position_id, "?")
+
+
+def status_emoji(jp_player: dict | None) -> str:
+    """Traffic-light status for a player.
+
+    🔴 injured / suspended / no match / not in lineup / SF < 100
+    🟡 100 ≤ SF < 300
+    🟢 SF ≥ 300
+    ⚪ no JP data
+    """
+    if jp_player is None:
+        return "⚪"
+    if jp_player.get("status") in ("injured", "suspended"):
+        return "🔴"
+    next_match = jp_player.get("nextMatch") or {}
+    if next_match.get("status") == "break":
+        return "🔴"
+    if next_match.get("playerInLineup") is False:
+        return "🔴"
+    sf = get_predict_rate(jp_player, SCORE_SF)
+    if sf is None:
+        return "🔴"
+    if sf >= SF_GREEN_THRESHOLD:
+        return "🟢"
+    if sf >= SF_YELLOW_THRESHOLD:
+        return "🟡"
+    return "🔴"
+
+
+def play_status_label(jp_player: dict | None) -> str:
+    if jp_player is None:
+        return "sin datos"
+    status = jp_player.get("status", "ok")
+    if status == "injured":
+        return "lesionado"
+    if status == "suspended":
+        return "sancionado"
+    if status == "doubt":
+        return "duda"
+    next_match = jp_player.get("nextMatch") or {}
+    if next_match.get("status") == "break":
+        return "sin partido"
+    if next_match.get("playerInLineup") is False:
+        return "no convocado"
+    return "casa" if next_match.get("isLocal") else "fuera"
+
+
+def sort_key_sf_desc(row: dict):
+    """Sort key: players with SF first, then by SF descending."""
+    jp = row.get("jp_player")
+    sf = get_predict_rate(jp, SCORE_SF) if jp else None
+    return (0 if sf is None else 1, sf or 0)
+
+
+def count_status_buckets(rows: list[dict]) -> tuple[int, int, int, int]:
+    """Returns (green, yellow, red, white) counts."""
+    green = yellow = red = white = 0
+    for row in rows:
+        emoji = status_emoji(row.get("jp_player"))
+        if emoji == "🟢":
+            green += 1
+        elif emoji == "🟡":
+            yellow += 1
+        elif emoji == "🔴":
+            red += 1
+        else:
+            white += 1
+    return green, yellow, red, white

--- a/packages/biwenger_tools/api/tests/test_api.py
+++ b/packages/biwenger_tools/api/tests/test_api.py
@@ -1,4 +1,6 @@
-"""Tests for the Biwenger API skeleton endpoints."""
+"""Tests for the Biwenger API endpoints."""
+
+from unittest.mock import patch
 
 import pytest
 
@@ -13,10 +15,21 @@ def client():
         yield c
 
 
-def test_healthz_returns_ok(client):
-    resp = client.get("/healthz")
+# --- /health ---
+
+
+def test_health_returns_ok(client):
+    resp = client.get("/health")
     assert resp.status_code == 200
     assert resp.get_json() == {"status": "ok"}
+
+
+def test_unknown_path_returns_404(client):
+    resp = client.get("/does-not-exist")
+    assert resp.status_code == 404
+
+
+# --- /version ---
 
 
 def test_version_returns_service_metadata(client):
@@ -36,11 +49,90 @@ def test_version_tolerates_missing_metadata(client):
     resp = client.get("/version")
     assert resp.status_code == 200
     body = resp.get_json()
-    assert body["service"] == "biwenger-api"
     assert body["commit"] == "unknown"
-    assert body["deploy_time"] == ""
 
 
-def test_unknown_path_returns_404(client):
-    resp = client.get("/does-not-exist")
-    assert resp.status_code == 404
+# --- /digests/daily ---
+
+
+def test_digests_daily_calls_run_daily_and_returns_summary(client):
+    fake = {"sent": 2, "my_team": 12, "market": 8}
+    with patch(
+        "packages.biwenger_tools.api.app.digests.run_daily",
+        return_value=fake,
+    ) as mock_run:
+        resp = client.post("/digests/daily")
+    mock_run.assert_called_once()
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "ok"
+    assert body["sent"] == 2
+    assert body["my_team"] == 12
+    assert body["market"] == 8
+
+
+def test_digests_daily_returns_500_on_exception(client):
+    with patch(
+        "packages.biwenger_tools.api.app.digests.run_daily",
+        side_effect=RuntimeError("biwenger 503"),
+    ):
+        resp = client.post("/digests/daily")
+    assert resp.status_code == 500
+    body = resp.get_json()
+    assert body["status"] == "error"
+    assert "biwenger 503" in body["error"]
+
+
+def test_digests_daily_rejects_get(client):
+    resp = client.get("/digests/daily")
+    assert resp.status_code == 405  # method not allowed
+
+
+# --- digests.run_daily unit tests ---
+
+
+def _make_jp_player(name, sf=200, status="ok"):
+    return {
+        "name": name,
+        "slug": name.lower().replace(" ", "-"),
+        "status": status,
+        "predict": [{"type": 2, "rate": sf}],
+        "nextMatch": {"status": "ok", "isLocal": True, "playerInLineup": True},
+    }
+
+
+def _patches(target):
+    return f"packages.biwenger_tools.api.logic.digests.{target}"
+
+
+def test_run_daily_skips_send_when_telegram_creds_missing(client):
+    with patch(_patches("config")) as mock_cfg, patch(
+        _patches("check_api_health")
+    ), patch(_patches("fetch_all_players"), return_value=[]), patch(
+        _patches("build_jp_index"), return_value={"by_name": {}, "by_slug": {}}
+    ), patch(
+        _patches("BiwengerClient")
+    ) as mock_client, patch(
+        _patches("_send_image")
+    ) as mock_send:
+        mock_cfg.JP_AUTH_TOKEN = "tok"
+        mock_cfg.JP_COMPETITION = 1
+        mock_cfg.JP_SCORE_TYPE = 2
+        mock_cfg.BIWENGER_EMAIL = "u"
+        mock_cfg.BIWENGER_PASSWORD = "p"
+        mock_cfg.LOGIN_URL = mock_cfg.ACCOUNT_URL = "x"
+        mock_cfg.LEAGUE_ID = "1"
+        mock_cfg.ALL_PLAYERS_DATA_URL = "x"
+        mock_cfg.USER_SQUAD_URL = "x/{manager_id}"
+        mock_cfg.MARKET_URL = "x"
+        mock_cfg.TELEGRAM_BOT_TOKEN = ""
+        mock_cfg.TELEGRAM_CHAT_ID = ""
+        mock_client.return_value.user_id = 1
+        mock_client.return_value.get_all_players_data_map.return_value = {}
+
+        from packages.biwenger_tools.api.logic import digests
+
+        result = digests.run_daily()
+    assert result["sent"] == 0
+    assert result["reason"] == "telegram_credentials_missing"
+    mock_send.assert_not_called()


### PR DESCRIPTION
## Summary

PR 2/6 of the **`teams_analyzer` → `biwenger-api`** refactor. Moves the daily-cron logic out of the Job into the new Service. The Job stays alive with the rest of the modes until PR 3 lands.

* **New endpoint** `POST /digests/daily` — sends "my team + market" PNGs to Telegram. Same logic as `teams_analyzer._run_daily()`, refactored into `packages/biwenger_tools/api/logic/digests.py` with the row builders extracted into `logic/rows.py` so they stay reusable for PR 3 and PR 4.
* **Helpers copied** into `packages/biwenger_tools/api/`:
  - `logic/image_formatter.py` (PNG rendering)
  - `logic/player_matching.py` (JP/Biwenger name matching)
  - `player_formatting.py` (status/position helpers)

  `teams_analyzer` keeps its own copy until PR 5 deletes the package. Mild duplication during the transition beats forcing one package to import from the other.
* **Secrets in CI** — `deploy.yml` binds `BIWENGER_CREDENTIALS_JSON` and `TELEGRAM_BOT_CONFIG_JSON` to `biwenger-api` so the new endpoint can talk to Biwenger/JP/Telegram.
* **`/healthz` → `/health`** — Google Frontend on `*.run.app` reserves `/healthz` and returns its own 404 before the request reaches the container (confirmed empirically: `/version` works, `/HEALTHZ` uppercase works, `/healthz` is intercepted). `/health` works because Cloud Run does not reserve any path.

## Why duplicate the helpers vs import from `teams_analyzer`

Either direction creates a temporary cross-package import. Copying decouples PR 2 from any teams_analyzer change and lets PR 5 simply delete `teams_analyzer/` without coordination. The duplication lifetime is 3 PRs.

## Verification

```bash
python3 -m flake8 core/ packages/
python3 -m black --check core/ packages/
bazel test //packages/biwenger_tools/api:api_tests //packages/biwenger_tools/teams_analyzer:teams_analyzer_tests //packages/biwenger_tools/telegram_bot:telegram_bot_tests //core:core_tests //packages/biwenger_tools/web:web_tests //packages/biwenger_tools/scraper_job:scraper_job_tests //packages/chucknorris_bot/bot:bot_tests
bazel build //packages/biwenger_tools/api:api_image_gcp --platforms=//platforms:linux_amd64
```

All green locally. 8 tests on `api_tests` (was 4); other packages unchanged.

## Test plan

- [ ] CI green
- [ ] `gcloud run services describe biwenger-api --region europe-southwest1` shows the two secrets bound
- [ ] `curl POST /digests/daily` (with OIDC token) returns 200 and sends 2 PNGs to Telegram
- [ ] `curl /health` returns 200 with `{"status":"ok"}`
- [ ] After merge: manually update Cloud Scheduler `biwenger-teams-analyzer-trigger` to POST to the new endpoint with OIDC. Verify next 16:00 fire (or trigger immediately). teams_analyzer Job stays in place until PR 3.

## Rollback

`teams_analyzer` Job is untouched. The Scheduler still points at it. If the new endpoint misbehaves, do not switch the Scheduler — the cron keeps running on the old Job. Worst case, revert the PR; the new endpoint and the duplicate helpers disappear; nothing in production depends on them yet.