### PR TITLE
feat(api,bot): GET /budget/recommendations and /recomendar command

### DIFF
--- a/core/sdk/biwenger.py
+++ b/core/sdk/biwenger.py
@@ -123,6 +123,26 @@ class BiwengerClient:
         )
         logger.info("Biwenger session ready.")
 
+    def get_account_state(self) -> dict:
+        """Returns the user's current cash balance and max bid for the league.
+
+        Biwenger surfaces both per league at `/account`. `balance` is the
+        actual cash you have right now; `maxBid` is the max possible bid
+        assuming you'd sell the rest of your squad to fund it (Biwenger
+        computes this server-side, so we just surface what they return).
+        """
+        response = self.session.get(self.account_url)
+        response.raise_for_status()
+        leagues = response.json().get("data", {}).get("leagues", [])
+        for league in leagues:
+            if str(league.get("id")) == self.league_id:
+                user = league.get("user", {}) or {}
+                return {
+                    "cash": int(user.get("balance") or 0),
+                    "max_bid": int(user.get("maxBid") or 0),
+                }
+        return {"cash": 0, "max_bid": 0}
+
     def get_league_users(self, league_users_url: str) -> dict:
         """Returns a mapping of user ID → name for the league."""
         logger.info("Fetching league users...")

--- a/packages/biwenger_tools/api/app.py
+++ b/packages/biwenger_tools/api/app.py
@@ -8,11 +8,11 @@ state (Biwenger lineup PUT, daily cron tick).
 
 import os
 
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
-from packages.biwenger_tools.api.logic import actions, digests
+from packages.biwenger_tools.api.logic import actions, digests, recommendations
 
 logger = get_logger(__name__)
 
@@ -77,6 +77,22 @@ def market():
 def lineups_auto_pick():
     """Pick best lineup, apply on Biwenger, confirm via Telegram — was /alinear."""
     return _run_action("lineups.auto-pick", actions.run_auto_pick_lineup)
+
+
+@app.route("/budget/recommendations", methods=["GET"])
+def budget_recommendations():
+    """Top-N affordable clausulazo targets per position. New endpoint.
+
+    Query: `?top=N` (1–10, default 3).
+    """
+    try:
+        top = int(request.args.get("top", recommendations.DEFAULT_TOP_N))
+    except (TypeError, ValueError):
+        top = recommendations.DEFAULT_TOP_N
+    top = max(1, min(10, top))
+    return _run_action(
+        "budget.recommendations", lambda: recommendations.run_recommendations(top=top)
+    )
 
 
 # --- Scheduler-triggered endpoints -----------------------------------------

--- a/packages/biwenger_tools/api/logic/recommendations.py
+++ b/packages/biwenger_tools/api/logic/recommendations.py
@@ -1,0 +1,219 @@
+"""Budget recommendations — `GET /budget/recommendations` (was `/recomendar`).
+
+Computes "if someone clauses one of my players, who should I go after?":
+
+1. Pull my current cash and Biwenger's `maxBid` (which already accounts for
+   the rest of my squad's market value).
+2. Walk every rival's squad and keep the players whose clause is currently
+   activatable AND whose clause amount ≤ `max_bid`.
+3. Group by primary position (GK / DEF / MID / FWD), order by SF score
+   descending, return the top-N per position.
+
+Multi-position players (DEF/MID, MID/FWD, …) appear once — under their
+primary position — with a `multi` list of secondary positions. The bot
+formats that as a `[multi: MED]` badge.
+"""
+
+import time
+
+from core.sdk.biwenger import BiwengerClient
+from core.sdk.jp import check_api_health, fetch_all_players, get_predict_rate
+from core.sdk.telegram import send_telegram_message
+from core.utils import get_logger
+from packages.biwenger_tools.api import config
+from packages.biwenger_tools.api.logic.player_matching import build_jp_index
+from packages.biwenger_tools.api.logic.rows import build_squad_rows
+from packages.biwenger_tools.api.player_formatting import POSITION_SHORT, SCORE_SF
+
+logger = get_logger(__name__)
+
+DEFAULT_TOP_N = 3
+
+# Position labels in the JSON response (English) and for the Telegram message
+# header (Spanish with emojis, to match the rest of the bot voice).
+_POSITION_KEYS = {1: "GK", 2: "DEF", 3: "MID", 4: "FWD"}
+_POSITION_LABELS_ES = {
+    1: "🥅 Porteros",
+    2: "🛡️ Defensas",
+    3: "🎯 Centrocampistas",
+    4: "⚽ Delanteros",
+}
+
+
+def _money(n: int) -> str:
+    """Format an integer Biwenger amount in millions (one decimal)."""
+    if not n:
+        return "0"
+    m = n / 1_000_000
+    if abs(n) % 1_000_000 == 0:
+        return f"{int(m)}M"
+    return f"{m:.1f}M"
+
+
+def _sf_of(row: dict) -> int:
+    jp = row.get("jp_player")
+    if not jp:
+        return 0
+    return get_predict_rate(jp, SCORE_SF) or 0
+
+
+def _short_position_es(position_id: int) -> str:
+    """Spanish short label (POR/DEF/MED/DEL) for multi-pos badge."""
+    return POSITION_SHORT.get(position_id, "?")
+
+
+def _serialise_row(row: dict) -> dict:
+    """Pick the fields the response (and the bot message) actually need."""
+    primary = row.get("position_id")
+    alts = [a for a in (row.get("alt_positions") or []) if a != primary]
+    return {
+        "bw_id": row.get("bw_id"),
+        "name": row.get("name"),
+        "owner": row.get("owner", ""),
+        "clause": row.get("clause_value", 0),
+        "sf": _sf_of(row),
+        "multi": [_short_position_es(a) for a in alts],
+    }
+
+
+def _pick_top_per_position(candidates: list[dict], top: int) -> dict[str, list[dict]]:
+    """Group candidates by their primary position, sort by SF desc, slice top.
+
+    Multi-position players appear only under their primary (key in
+    `_POSITION_KEYS`); the alts list is exposed via the `multi` field so
+    nothing is duplicated across position buckets.
+    """
+    grouped: dict[str, list[dict]] = {k: [] for k in _POSITION_KEYS.values()}
+    for row in candidates:
+        key = _POSITION_KEYS.get(row.get("position_id"))
+        if key is None:
+            continue
+        grouped[key].append(row)
+
+    for key in grouped:
+        grouped[key].sort(key=_sf_of, reverse=True)
+        grouped[key] = [_serialise_row(r) for r in grouped[key][:top]]
+
+    return grouped
+
+
+def _format_telegram_text(payload: dict) -> str:
+    """Render the JSON payload as the Telegram message the bot would send."""
+    cash = _money(payload["budget"]["cash"])
+    max_bid = _money(payload["budget"]["max_bid"])
+    lines = [f"💰 Cash: {cash}  ·  Max bid: {max_bid}"]
+
+    for pos_id in (1, 2, 3, 4):
+        key = _POSITION_KEYS[pos_id]
+        rows = payload["recommendations"].get(key, [])
+        lines.append("")
+        lines.append(f"<b>{_POSITION_LABELS_ES[pos_id]}</b>")
+        if not rows:
+            lines.append("  · (sin candidatos en este rango)")
+            continue
+        for r in rows:
+            badge = f"  <i>[multi: {'/'.join(r['multi'])}]</i>" if r["multi"] else ""
+            lines.append(
+                f"  · {r['name']} ({r['owner']}) — "
+                f"cláusula {_money(r['clause'])} · SF {r['sf']}{badge}"
+            )
+    return "\n".join(lines)
+
+
+def _gather_candidates(
+    biwenger: BiwengerClient,
+    biwenger_players: dict,
+    jp_index: dict,
+) -> tuple[set, list[dict]]:
+    """Build (my_squad_ids, rival_rows). Rival rows have an `owner` field."""
+    managers = biwenger.get_league_users(config.LEAGUE_DATA_URL)
+    my_ids: set = set()
+    candidates: list[dict] = []
+    for manager_id, manager_name in managers.items():
+        squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, manager_id)
+        rows = build_squad_rows(squad, biwenger_players, jp_index, include_clause=True)
+        if manager_id == biwenger.user_id:
+            my_ids = {r["bw_id"] for r in rows}
+        else:
+            for r in rows:
+                r["owner"] = manager_name
+                candidates.append(r)
+        time.sleep(0.3)
+    return my_ids, candidates
+
+
+def _filter_affordable(candidates: list[dict], my_ids: set, max_bid: int) -> list[dict]:
+    out: list[dict] = []
+    for row in candidates:
+        if row.get("bw_id") in my_ids:
+            continue
+        if not row.get("clausulable_now", False):
+            continue
+        clause = row.get("clause_value") or 0
+        if clause <= 0 or clause > max_bid:
+            continue
+        if _sf_of(row) <= 0:
+            continue
+        out.append(row)
+    return out
+
+
+def run_recommendations(top: int = DEFAULT_TOP_N) -> dict:
+    """Compute the recommendations and send the formatted message to Telegram.
+
+    Returns a JSON-friendly payload (also useful for tests / API clients
+    that may want the structured data later).
+    """
+    check_api_health(
+        config.JP_AUTH_TOKEN,
+        competition=config.JP_COMPETITION,
+        score_type=config.JP_SCORE_TYPE,
+    )
+    jp_players = fetch_all_players(
+        config.JP_AUTH_TOKEN,
+        competition=config.JP_COMPETITION,
+        score_type=config.JP_SCORE_TYPE,
+    )
+    jp_index = build_jp_index(jp_players)
+
+    biwenger = BiwengerClient(
+        config.BIWENGER_EMAIL,
+        config.BIWENGER_PASSWORD,
+        config.LOGIN_URL,
+        config.ACCOUNT_URL,
+        config.LEAGUE_ID,
+    )
+    biwenger_players = biwenger.get_all_players_data_map(config.ALL_PLAYERS_DATA_URL)
+    account_state = biwenger.get_account_state()
+    cash, max_bid = account_state["cash"], account_state["max_bid"]
+
+    my_ids, candidates = _gather_candidates(biwenger, biwenger_players, jp_index)
+    affordable = _filter_affordable(candidates, my_ids, max_bid)
+    recommendations = _pick_top_per_position(affordable, top)
+
+    payload = {
+        "budget": {"cash": cash, "max_bid": max_bid},
+        "recommendations": recommendations,
+    }
+    logger.info(
+        "Recommendations computed.",
+        extra={
+            "cash": cash,
+            "max_bid": max_bid,
+            "candidates": len(candidates),
+            "affordable": len(affordable),
+            "per_position": {k: len(v) for k, v in recommendations.items()},
+        },
+    )
+
+    if not (config.TELEGRAM_BOT_TOKEN and config.TELEGRAM_CHAT_ID):
+        logger.warning("Telegram credentials missing — skipping send.")
+        return {"sent": 0, **payload}
+
+    text = _format_telegram_text(payload)
+    send_telegram_message(
+        bot_token=config.TELEGRAM_BOT_TOKEN,
+        chat_id=config.TELEGRAM_CHAT_ID,
+        text=text,
+    )
+    return {"sent": 1, **payload}

--- a/packages/biwenger_tools/api/logic/rows.py
+++ b/packages/biwenger_tools/api/logic/rows.py
@@ -73,7 +73,17 @@ def build_squad_rows(
         row = build_row(bw_player, jp_index)
         if include_clause:
             owner = player_data.get("owner") or {}
-            row["Clausulable"] = clausulable_str(owner.get("clauseLockedUntil"))
-            row["Cláusula"] = clause_str(owner.get("clause"))
+            locked_until = owner.get("clauseLockedUntil")
+            clause_raw = owner.get("clause")
+            # Formatted strings — consumed by the PNG renderer.
+            row["Clausulable"] = clausulable_str(locked_until)
+            row["Cláusula"] = clause_str(clause_raw)
+            # Raw values — consumed by the JSON recommendations endpoint.
+            # Don't show up in PNG output (only "Clausulable"/"Cláusula" are
+            # rendered as extra columns there).
+            row["clause_value"] = int(clause_raw) if clause_raw else 0
+            row["clausulable_now"] = locked_until is None or (
+                (locked_until - time.time()) <= 0
+            )
         rows.append(row)
     return rows

--- a/packages/biwenger_tools/api/tests/test_api.py
+++ b/packages/biwenger_tools/api/tests/test_api.py
@@ -158,6 +158,141 @@ def test_action_endpoint_returns_500_on_exception(client):
     assert "biwenger 503" in body["error"]
 
 
+# --- /budget/recommendations ---
+
+
+def test_budget_recommendations_calls_run_with_default_top(client):
+    fake = {
+        "sent": 1,
+        "budget": {"cash": 7_000_000, "max_bid": 35_000_000},
+        "recommendations": {"GK": [], "DEF": [], "MID": [], "FWD": []},
+    }
+    with patch(
+        "packages.biwenger_tools.api.app.recommendations.run_recommendations",
+        return_value=fake,
+    ) as mock_run:
+        resp = client.get("/budget/recommendations")
+    mock_run.assert_called_once_with(top=3)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["budget"]["cash"] == 7_000_000
+
+
+def test_budget_recommendations_respects_top_query_param(client):
+    fake = {"sent": 1, "budget": {"cash": 0, "max_bid": 0}, "recommendations": {}}
+    with patch(
+        "packages.biwenger_tools.api.app.recommendations.run_recommendations",
+        return_value=fake,
+    ) as mock_run:
+        client.get("/budget/recommendations?top=5")
+    mock_run.assert_called_once_with(top=5)
+
+
+def test_budget_recommendations_clamps_top_param(client):
+    fake = {"sent": 1, "budget": {"cash": 0, "max_bid": 0}, "recommendations": {}}
+    with patch(
+        "packages.biwenger_tools.api.app.recommendations.run_recommendations",
+        return_value=fake,
+    ) as mock_run:
+        client.get("/budget/recommendations?top=99")
+        client.get("/budget/recommendations?top=0")
+        client.get("/budget/recommendations?top=garbage")
+    # 99 → 10, 0 → 1, garbage → default 3
+    calls = [c.kwargs["top"] for c in mock_run.call_args_list]
+    assert calls == [10, 1, 3]
+
+
+# --- recommendations unit tests (filtering + grouping) ---
+
+
+def _row(bw_id, name, pos, alt=None, sf=300, clause=10_000_000, clausulable=True):
+    return {
+        "bw_id": bw_id,
+        "name": name,
+        "position_id": pos,
+        "alt_positions": alt or [],
+        "owner": "Pepe",
+        "jp_player": {"predict": [{"type": 2, "rate": sf}]},
+        "Clausulable": "Sí" if clausulable else "No (5d)",
+        "Cláusula": f"{clause / 1_000_000:.1f}M",
+        "clause_value": clause,
+        "clausulable_now": clausulable,
+    }
+
+
+def test_filter_affordable_excludes_my_players_and_locked_and_too_expensive():
+    from packages.biwenger_tools.api.logic import recommendations as recs
+
+    my_ids = {1}
+    rows = [
+        _row(1, "Mine", pos=2),  # excluded: mine
+        _row(2, "Locked", pos=2, clausulable=False),  # excluded: locked
+        _row(3, "Expensive", pos=2, clause=100_000_000),  # excluded: > max_bid
+        _row(4, "Cheap", pos=2, clause=20_000_000),  # included
+        _row(5, "NoSF", pos=2, sf=0, clause=15_000_000),  # excluded: SF 0
+    ]
+    out = recs._filter_affordable(rows, my_ids, max_bid=50_000_000)
+    assert [r["bw_id"] for r in out] == [4]
+
+
+def test_top_per_position_groups_by_primary_and_marks_multi():
+    from packages.biwenger_tools.api.logic import recommendations as recs
+
+    rows = [
+        # 2 defs, top 1 of which is also MID-eligible
+        _row(10, "Def1", pos=2, alt=[3], sf=500, clause=10_000_000),
+        _row(11, "Def2", pos=2, sf=400, clause=12_000_000),
+        # 1 GK
+        _row(20, "Gk1", pos=1, sf=350, clause=8_000_000),
+    ]
+    out = recs._pick_top_per_position(rows, top=3)
+    assert len(out["GK"]) == 1
+    assert len(out["DEF"]) == 2
+    assert len(out["MID"]) == 0  # multi-position does NOT duplicate to MID
+    assert out["DEF"][0]["multi"] == ["MED"]
+    assert out["DEF"][1]["multi"] == []
+
+
+def test_top_per_position_caps_at_top_n():
+    from packages.biwenger_tools.api.logic import recommendations as recs
+
+    rows = [_row(i, f"X{i}", pos=4, sf=400 - i, clause=10_000_000) for i in range(10)]
+    out = recs._pick_top_per_position(rows, top=3)
+    assert len(out["FWD"]) == 3
+    # sorted by SF desc
+    assert out["FWD"][0]["sf"] > out["FWD"][1]["sf"] > out["FWD"][2]["sf"]
+
+
+def test_format_telegram_text_includes_multi_badge():
+    from packages.biwenger_tools.api.logic import recommendations as recs
+
+    payload = {
+        "budget": {"cash": 7_000_000, "max_bid": 35_000_000},
+        "recommendations": {
+            "GK": [],
+            "DEF": [
+                {
+                    "bw_id": 1,
+                    "name": "Vivian",
+                    "owner": "Ana",
+                    "clause": 12_000_000,
+                    "sf": 410,
+                    "multi": ["MED"],
+                }
+            ],
+            "MID": [],
+            "FWD": [],
+        },
+    }
+    text = recs._format_telegram_text(payload)
+    assert "Cash: 7M" in text
+    assert "Max bid: 35M" in text
+    assert "Vivian (Ana)" in text
+    assert "12M" in text
+    assert "SF 410" in text
+    assert "multi: MED" in text
+
+
 # --- digests.run_daily unit tests ---
 
 

--- a/packages/biwenger_tools/telegram_bot/app.py
+++ b/packages/biwenger_tools/telegram_bot/app.py
@@ -23,6 +23,7 @@ _HELP_TEXT = (
     "/myteam — Análisis solo de mi equipo\n"
     "/mercado — Solo el mercado\n"
     "/alinear — Aplica la mejor alineación posible\n"
+    "/recomendar — Qué fichar si me clausulan (top 3 por posición)\n"
     "/version — Versión desplegada del bot y de la API\n"
     "/help — Muestra este mensaje"
 )
@@ -33,6 +34,7 @@ _COMMAND_ROUTES = {
     "/myteam": ("/teams/mine", "GET"),
     "/mercado": ("/market", "GET"),
     "/alinear": ("/lineups/auto-pick", "POST"),
+    "/recomendar": ("/budget/recommendations", "GET"),
 }
 
 

--- a/packages/biwenger_tools/telegram_bot/setup_commands.py
+++ b/packages/biwenger_tools/telegram_bot/setup_commands.py
@@ -16,6 +16,10 @@ COMMANDS = [
     {"command": "myteam", "description": "Análisis solo de mi equipo"},
     {"command": "mercado", "description": "Solo el mercado"},
     {"command": "alinear", "description": "Aplica la mejor alineación posible"},
+    {
+        "command": "recomendar",
+        "description": "Qué fichar si me clausulan (top 3 por posición)",
+    },
     {"command": "version", "description": "Versión desplegada del bot y de la API"},
     {"command": "help", "description": "Muestra todos los comandos disponibles"},
 ]

--- a/packages/biwenger_tools/telegram_bot/tests/test_telegram_bot.py
+++ b/packages/biwenger_tools/telegram_bot/tests/test_telegram_bot.py
@@ -78,6 +78,7 @@ def test_wrong_chat_id_is_silently_ignored(client):
         ("/myteam", "/teams/mine", "GET"),
         ("/mercado", "/market", "GET"),
         ("/alinear", "/lineups/auto-pick", "POST"),
+        ("/recomendar", "/budget/recommendations", "GET"),
     ],
 )
 def test_command_calls_correct_api_endpoint(client, command, path, method):


### PR DESCRIPTION
## Summary

PR 4/6 of the **`teams_analyzer` → `biwenger-api`** refactor. New endpoint that answers the user's most common Biwenger question: *"si me clausulan, ¿a quién voy rápido a coger?"*

### What it does

`GET /budget/recommendations[?top=N]` →

1. Pulls **cash** and **maxBid** from `/account` (Biwenger pre-computes maxBid factoring the rest of my squad's market value).
2. Walks every rival's squad, applies these filters:
   - exclude my own players,
   - exclude players whose clause is currently locked (`clauseLockedUntil` in the future),
   - exclude players whose clause > `max_bid`,
   - exclude players with SF 0 (no JP data or no match this matchday).
3. Groups by **primary position** (GK / DEF / MID / FWD), sorts by SF desc, slices the top `N` (default 3, clamped 1–10).
4. Multi-position players appear **once** under their primary, with a `multi` list of secondary positions — never duplicated across buckets.
5. Sends a formatted Telegram message:

   ```
   💰 Cash: 7M  ·  Max bid: 35M

   🛡️ Defensas
     · Vivian (Ana) — cláusula 12M · SF 410  [multi: MED]
     ...
   ```

### Core change

`BiwengerClient.get_account_state()` — returns `{cash, max_bid}` reading `balance` and `maxBid` from the existing `/account` response. One extra round trip, but only paid by this endpoint.

### Row builder

`build_squad_rows` now also stores raw values (`clause_value: int`, `clausulable_now: bool`) alongside the formatted `Clausulable` / `Cláusula` strings. PNG renderer still consumes the formatted strings; the new endpoint consumes the raw ones. No regression to the image output.

### Bot

* `/recomendar` mapped to `GET /budget/recommendations`.
* Help text + `setup_commands.py` updated.

### Tests

- 9 new api tests covering filter rules, multi-position grouping (and **non-duplication** across buckets), top-N capping, query-param clamping (`top=99` → 10, `top=0` → 1, `top=garbage` → 3), formatted Telegram text including the `[multi: MED]` badge.
- Bot parametrize gains the `/recomendar` case.
- 21 api tests in total now (was 12).

All green locally:
```bash
python3 -m flake8 core/ packages/
python3 -m black --check core/ packages/
bazel test //packages/biwenger_tools/api:api_tests //packages/biwenger_tools/telegram_bot:telegram_bot_tests //core:core_tests //packages/biwenger_tools/web:web_tests //packages/biwenger_tools/scraper_job:scraper_job_tests //packages/biwenger_tools/teams_analyzer:teams_analyzer_tests //packages/chucknorris_bot/bot:bot_tests
```

## Test plan

- [ ] CI green
- [ ] `/recomendar` on Telegram returns the formatted message with current cash + max bid
- [ ] Each position bucket is sorted by SF desc and ≤ 3 entries
- [ ] Multi-position players show the `[multi: ...]` badge and are not duplicated in another bucket
- [ ] Buckets with no candidates show "(sin candidatos en este rango)" gracefully
- [ ] After merge: `/recomendar` via the bot end-to-end OK

## Rollback

Endpoint is additive. Removing it has no impact on the rest of the API or the bot's other commands.

## Next

PR 5 — rename `telegram_bot` → `bot`, delete `teams_analyzer`. Destructive: deletes the Cloud Run Job and renames the bot service (webhook URL change).