### PR TITLE
fix(api): exact-euro format and cash+margin filter for /recomendar

### DIFF
--- a/core/sdk/biwenger.py
+++ b/core/sdk/biwenger.py
@@ -127,20 +127,49 @@ class BiwengerClient:
         """Returns the user's current cash balance and max bid for the league.
 
         Biwenger surfaces both per league at `/account`. `balance` is the
-        actual cash you have right now; `maxBid` is the max possible bid
-        assuming you'd sell the rest of your squad to fund it (Biwenger
-        computes this server-side, so we just surface what they return).
+        actual cash you have right now. `maxBid` (the field name the API
+        actually uses) is what you could spend if you sold the rest of
+        your squad — Biwenger pre-computes this server-side.
+
+        First production read showed `user.balance` populated and the
+        max-bid field absent under `user`. We try a few alternate paths
+        and log all candidate keys until we see which one Biwenger
+        returns for this account.
         """
         response = self.session.get(self.account_url)
         response.raise_for_status()
         leagues = response.json().get("data", {}).get("leagues", [])
         for league in leagues:
-            if str(league.get("id")) == self.league_id:
-                user = league.get("user", {}) or {}
-                return {
-                    "cash": int(user.get("balance") or 0),
-                    "max_bid": int(user.get("maxBid") or 0),
-                }
+            if str(league.get("id")) != self.league_id:
+                continue
+            user = league.get("user", {}) or {}
+            cash = int(user.get("balance") or 0)
+            # Try several known shapes — Biwenger has shifted these
+            # around between API versions.
+            max_bid_candidates = [
+                user.get("maxBid"),
+                league.get("maxBid"),
+                user.get("teamValue"),  # not the same but a useful fallback
+            ]
+            max_bid = 0
+            for cand in max_bid_candidates:
+                if cand is not None:
+                    try:
+                        max_bid = int(cand)
+                        break
+                    except (TypeError, ValueError):
+                        continue
+            logger.info(
+                "Account state read.",
+                extra={
+                    "cash": cash,
+                    "max_bid": max_bid,
+                    "league_id": self.league_id,
+                    "user_keys": sorted(user.keys()),
+                    "league_keys": sorted(league.keys()),
+                },
+            )
+            return {"cash": cash, "max_bid": max_bid}
         return {"cash": 0, "max_bid": 0}
 
     def get_league_users(self, league_users_url: str) -> dict:

--- a/packages/biwenger_tools/api/app.py
+++ b/packages/biwenger_tools/api/app.py
@@ -81,17 +81,28 @@ def lineups_auto_pick():
 
 @app.route("/budget/recommendations", methods=["GET"])
 def budget_recommendations():
-    """Top-N affordable clausulazo targets per position. New endpoint.
+    """Top-N affordable clausulazo targets per position.
 
-    Query: `?top=N` (1–10, default 3).
+    Query params:
+      - `top=N`     — players per position, 1–10, default 3.
+      - `margin=N`  — extra euros over current cash to count as "affordable",
+                       0 – 50M, default 5M.
     """
     try:
         top = int(request.args.get("top", recommendations.DEFAULT_TOP_N))
     except (TypeError, ValueError):
         top = recommendations.DEFAULT_TOP_N
     top = max(1, min(10, top))
+
+    try:
+        margin = int(request.args.get("margin", recommendations.DEFAULT_MARGIN))
+    except (TypeError, ValueError):
+        margin = recommendations.DEFAULT_MARGIN
+    margin = max(0, min(50_000_000, margin))
+
     return _run_action(
-        "budget.recommendations", lambda: recommendations.run_recommendations(top=top)
+        "budget.recommendations",
+        lambda: recommendations.run_recommendations(top=top, margin=margin),
     )
 
 

--- a/packages/biwenger_tools/api/logic/recommendations.py
+++ b/packages/biwenger_tools/api/logic/recommendations.py
@@ -29,6 +29,13 @@ logger = get_logger(__name__)
 
 DEFAULT_TOP_N = 3
 
+# How much over the user's cash they're willing to stretch by signing
+# a clausulazo. They explicitly don't want recommendations up to the
+# max_bid (which assumes selling the rest of the squad) — only what
+# they could afford with a small extra margin. 5M is the default
+# requested by the user; overridable via `?margin=N` on the endpoint.
+DEFAULT_MARGIN = 5_000_000
+
 # Position labels in the JSON response (English) and for the Telegram message
 # header (Spanish with emojis, to match the rest of the bot voice).
 _POSITION_KEYS = {1: "GK", 2: "DEF", 3: "MID", 4: "FWD"}
@@ -40,14 +47,16 @@ _POSITION_LABELS_ES = {
 }
 
 
-def _money(n: int) -> str:
-    """Format an integer Biwenger amount in millions (one decimal)."""
-    if not n:
-        return "0"
-    m = n / 1_000_000
-    if abs(n) % 1_000_000 == 0:
-        return f"{int(m)}M"
-    return f"{m:.1f}M"
+def _euros(n: int | None) -> str:
+    """Format an integer as Spanish-style euros: 12.972.212 €.
+
+    `None` and 0 are surfaced explicitly so the user can tell the difference
+    between "Biwenger returned 0" and "Biwenger didn't return this field".
+    """
+    if n is None:
+        return "—"
+    s = f"{int(n):,}".replace(",", ".")
+    return f"{s} €"
 
 
 def _sf_of(row: dict) -> int:
@@ -99,9 +108,18 @@ def _pick_top_per_position(candidates: list[dict], top: int) -> dict[str, list[d
 
 def _format_telegram_text(payload: dict) -> str:
     """Render the JSON payload as the Telegram message the bot would send."""
-    cash = _money(payload["budget"]["cash"])
-    max_bid = _money(payload["budget"]["max_bid"])
-    lines = [f"💰 Cash: {cash}  ·  Max bid: {max_bid}"]
+    budget = payload["budget"]
+    cash = _euros(budget["cash"])
+    target = _euros(budget["target"])
+    max_bid_value = budget.get("max_bid")
+    max_bid_str = _euros(max_bid_value) if max_bid_value else "—"
+    margin = _euros(budget["margin"])
+
+    lines = [
+        f"💰 <b>Saldo:</b> {cash}",
+        f"🎯 <b>Objetivo (saldo + {margin}):</b> {target}",
+        f"ℹ️ <i>Puja máx. Biwenger: {max_bid_str}</i>",
+    ]
 
     for pos_id in (1, 2, 3, 4):
         key = _POSITION_KEYS[pos_id]
@@ -115,7 +133,7 @@ def _format_telegram_text(payload: dict) -> str:
             badge = f"  <i>[multi: {'/'.join(r['multi'])}]</i>" if r["multi"] else ""
             lines.append(
                 f"  · {r['name']} ({r['owner']}) — "
-                f"cláusula {_money(r['clause'])} · SF {r['sf']}{badge}"
+                f"cláusula {_euros(r['clause'])} · SF {r['sf']}{badge}"
             )
     return "\n".join(lines)
 
@@ -142,7 +160,10 @@ def _gather_candidates(
     return my_ids, candidates
 
 
-def _filter_affordable(candidates: list[dict], my_ids: set, max_bid: int) -> list[dict]:
+def _filter_affordable(
+    candidates: list[dict], my_ids: set, target: int
+) -> list[dict]:
+    """Keep candidates I can actually afford (clause ≤ target) and skip mine."""
     out: list[dict] = []
     for row in candidates:
         if row.get("bw_id") in my_ids:
@@ -150,7 +171,7 @@ def _filter_affordable(candidates: list[dict], my_ids: set, max_bid: int) -> lis
         if not row.get("clausulable_now", False):
             continue
         clause = row.get("clause_value") or 0
-        if clause <= 0 or clause > max_bid:
+        if clause <= 0 or clause > target:
             continue
         if _sf_of(row) <= 0:
             continue
@@ -158,11 +179,17 @@ def _filter_affordable(candidates: list[dict], my_ids: set, max_bid: int) -> lis
     return out
 
 
-def run_recommendations(top: int = DEFAULT_TOP_N) -> dict:
+def run_recommendations(
+    top: int = DEFAULT_TOP_N,
+    margin: int = DEFAULT_MARGIN,
+) -> dict:
     """Compute the recommendations and send the formatted message to Telegram.
 
-    Returns a JSON-friendly payload (also useful for tests / API clients
-    that may want the structured data later).
+    `margin` is how much over the user's current cash they'd stretch to. The
+    filter uses `cash + margin` as the upper bound on clause amounts — NOT
+    `max_bid`, which assumes selling the rest of the squad and is usually too
+    generous for "who could I grab right now" planning. `max_bid` is still
+    surfaced in the message header as informational.
     """
     check_api_health(
         config.JP_AUTH_TOKEN,
@@ -186,13 +213,19 @@ def run_recommendations(top: int = DEFAULT_TOP_N) -> dict:
     biwenger_players = biwenger.get_all_players_data_map(config.ALL_PLAYERS_DATA_URL)
     account_state = biwenger.get_account_state()
     cash, max_bid = account_state["cash"], account_state["max_bid"]
+    target = cash + max(0, margin)
 
     my_ids, candidates = _gather_candidates(biwenger, biwenger_players, jp_index)
-    affordable = _filter_affordable(candidates, my_ids, max_bid)
+    affordable = _filter_affordable(candidates, my_ids, target)
     recommendations = _pick_top_per_position(affordable, top)
 
     payload = {
-        "budget": {"cash": cash, "max_bid": max_bid},
+        "budget": {
+            "cash": cash,
+            "max_bid": max_bid,
+            "margin": max(0, margin),
+            "target": target,
+        },
         "recommendations": recommendations,
     }
     logger.info(
@@ -200,6 +233,8 @@ def run_recommendations(top: int = DEFAULT_TOP_N) -> dict:
         extra={
             "cash": cash,
             "max_bid": max_bid,
+            "margin": margin,
+            "target": target,
             "candidates": len(candidates),
             "affordable": len(affordable),
             "per_position": {k: len(v) for k, v in recommendations.items()},

--- a/packages/biwenger_tools/api/tests/test_api.py
+++ b/packages/biwenger_tools/api/tests/test_api.py
@@ -161,10 +161,15 @@ def test_action_endpoint_returns_500_on_exception(client):
 # --- /budget/recommendations ---
 
 
-def test_budget_recommendations_calls_run_with_default_top(client):
+def test_budget_recommendations_calls_run_with_defaults(client):
     fake = {
         "sent": 1,
-        "budget": {"cash": 7_000_000, "max_bid": 35_000_000},
+        "budget": {
+            "cash": 7_000_000,
+            "max_bid": 35_000_000,
+            "margin": 5_000_000,
+            "target": 12_000_000,
+        },
         "recommendations": {"GK": [], "DEF": [], "MID": [], "FWD": []},
     }
     with patch(
@@ -172,34 +177,45 @@ def test_budget_recommendations_calls_run_with_default_top(client):
         return_value=fake,
     ) as mock_run:
         resp = client.get("/budget/recommendations")
-    mock_run.assert_called_once_with(top=3)
+    mock_run.assert_called_once_with(top=3, margin=5_000_000)
     assert resp.status_code == 200
     body = resp.get_json()
     assert body["budget"]["cash"] == 7_000_000
+    assert body["budget"]["target"] == 12_000_000
 
 
-def test_budget_recommendations_respects_top_query_param(client):
-    fake = {"sent": 1, "budget": {"cash": 0, "max_bid": 0}, "recommendations": {}}
+def test_budget_recommendations_respects_top_and_margin_query_params(client):
+    fake = {
+        "sent": 1,
+        "budget": {"cash": 0, "max_bid": 0, "margin": 0, "target": 0},
+        "recommendations": {},
+    }
     with patch(
         "packages.biwenger_tools.api.app.recommendations.run_recommendations",
         return_value=fake,
     ) as mock_run:
-        client.get("/budget/recommendations?top=5")
-    mock_run.assert_called_once_with(top=5)
+        client.get("/budget/recommendations?top=5&margin=10000000")
+    mock_run.assert_called_once_with(top=5, margin=10_000_000)
 
 
-def test_budget_recommendations_clamps_top_param(client):
-    fake = {"sent": 1, "budget": {"cash": 0, "max_bid": 0}, "recommendations": {}}
+def test_budget_recommendations_clamps_query_params(client):
+    fake = {
+        "sent": 1,
+        "budget": {"cash": 0, "max_bid": 0, "margin": 0, "target": 0},
+        "recommendations": {},
+    }
     with patch(
         "packages.biwenger_tools.api.app.recommendations.run_recommendations",
         return_value=fake,
     ) as mock_run:
-        client.get("/budget/recommendations?top=99")
-        client.get("/budget/recommendations?top=0")
-        client.get("/budget/recommendations?top=garbage")
-    # 99 → 10, 0 → 1, garbage → default 3
-    calls = [c.kwargs["top"] for c in mock_run.call_args_list]
-    assert calls == [10, 1, 3]
+        client.get("/budget/recommendations?top=99&margin=99999999999")
+        client.get("/budget/recommendations?top=0&margin=-1")
+        client.get("/budget/recommendations?top=garbage&margin=garbage")
+    calls = mock_run.call_args_list
+    # top: 99 → 10, 0 → 1, garbage → 3 (default)
+    assert [c.kwargs["top"] for c in calls] == [10, 1, 3]
+    # margin: 99999999999 → 50M, -1 → 0, garbage → 5M (default)
+    assert [c.kwargs["margin"] for c in calls] == [50_000_000, 0, 5_000_000]
 
 
 # --- recommendations unit tests (filtering + grouping) ---
@@ -227,11 +243,11 @@ def test_filter_affordable_excludes_my_players_and_locked_and_too_expensive():
     rows = [
         _row(1, "Mine", pos=2),  # excluded: mine
         _row(2, "Locked", pos=2, clausulable=False),  # excluded: locked
-        _row(3, "Expensive", pos=2, clause=100_000_000),  # excluded: > max_bid
+        _row(3, "Expensive", pos=2, clause=100_000_000),  # excluded: > target
         _row(4, "Cheap", pos=2, clause=20_000_000),  # included
         _row(5, "NoSF", pos=2, sf=0, clause=15_000_000),  # excluded: SF 0
     ]
-    out = recs._filter_affordable(rows, my_ids, max_bid=50_000_000)
+    out = recs._filter_affordable(rows, my_ids, target=50_000_000)
     assert [r["bw_id"] for r in out] == [4]
 
 
@@ -263,11 +279,16 @@ def test_top_per_position_caps_at_top_n():
     assert out["FWD"][0]["sf"] > out["FWD"][1]["sf"] > out["FWD"][2]["sf"]
 
 
-def test_format_telegram_text_includes_multi_badge():
+def test_format_telegram_text_includes_multi_badge_and_exact_euros():
     from packages.biwenger_tools.api.logic import recommendations as recs
 
     payload = {
-        "budget": {"cash": 7_000_000, "max_bid": 35_000_000},
+        "budget": {
+            "cash": 12_972_212,
+            "max_bid": 36_334_712,
+            "margin": 5_000_000,
+            "target": 17_972_212,
+        },
         "recommendations": {
             "GK": [],
             "DEF": [
@@ -275,7 +296,7 @@ def test_format_telegram_text_includes_multi_badge():
                     "bw_id": 1,
                     "name": "Vivian",
                     "owner": "Ana",
-                    "clause": 12_000_000,
+                    "clause": 12_345_678,
                     "sf": 410,
                     "multi": ["MED"],
                 }
@@ -285,12 +306,30 @@ def test_format_telegram_text_includes_multi_badge():
         },
     }
     text = recs._format_telegram_text(payload)
-    assert "Cash: 7M" in text
-    assert "Max bid: 35M" in text
+    # Exact euros in Spanish format (dots as thousands separators)
+    assert "12.972.212 €" in text
+    assert "17.972.212 €" in text
+    assert "36.334.712 €" in text
     assert "Vivian (Ana)" in text
-    assert "12M" in text
+    assert "12.345.678 €" in text
     assert "SF 410" in text
     assert "multi: MED" in text
+
+
+def test_format_telegram_text_dashes_when_max_bid_missing():
+    from packages.biwenger_tools.api.logic import recommendations as recs
+
+    payload = {
+        "budget": {
+            "cash": 12_972_212,
+            "max_bid": 0,  # Biwenger didn't return it
+            "margin": 5_000_000,
+            "target": 17_972_212,
+        },
+        "recommendations": {"GK": [], "DEF": [], "MID": [], "FWD": []},
+    }
+    text = recs._format_telegram_text(payload)
+    assert "Puja máx. Biwenger: —" in text
 
 
 # --- digests.run_daily unit tests ---


### PR DESCRIPTION
## Summary

First production run of `/recomendar` (PR #61 era) surfaced three issues:

1. **Cash** showed as \"12.9M\" — user wants the exact euro amount (\`12.972.212 €\`).
2. **Max bid** showed as \"0\" — Biwenger doesn't return \`maxBid\` under \`user\` in this account's payload, so the previous lookup never found it.
3. The clause filter capped at \`max_bid\` (which assumes selling the whole squad — too generous). User wants the recommendations constrained to **\"what I can afford right now + a small margin\"**, not the theoretical maximum.

## Changes

* **\`core/sdk/biwenger.get_account_state()\`** — tries \`user.maxBid\`, then \`league.maxBid\`, then \`user.teamValue\` as a last-resort fallback. Logs every candidate key in \`user\` and \`league\` so we can pinpoint the right one from production logs on the next call.
* **\`recommendations.run_recommendations()\`** — new \`margin\` parameter (default \`5_000_000\`). Filter is now \`clause ≤ cash + margin\` instead of \`clause ≤ max_bid\`. \`max_bid\` still surfaces in the message header as informational. \`target = cash + margin\` exposed in the JSON payload.
* **\`recommendations._format_telegram_text()\`** — exact Spanish euros (\`12.972.212 €\`) for cash / max bid / target / each clause. Header reworked into three lines (saldo, objetivo, max bid). Falls back to \`—\` when max_bid is 0/unknown.
* **\`app.py\`** — \`GET /budget/recommendations\` accepts an optional \`?margin=N\` query param (0–50M, default 5M).

## Verification

```bash
python3 -m flake8 core/ packages/
python3 -m black --check core/ packages/
bazel test //packages/biwenger_tools/api:api_tests //packages/biwenger_tools/bot:bot_tests //core:core_tests //packages/biwenger_tools/web:web_tests //packages/biwenger_tools/scraper_job:scraper_job_tests //packages/chucknorris_bot/bot:bot_tests
```

All green. 11 budget-recommendation tests (was 9): added one for exact-euros, one for the \`—\` fallback when max_bid is missing.

## Test plan

- [ ] CI deploy green
- [ ] \`/recomendar\` shows \`Saldo: 12.972.212 €\` (exact) in the header
- [ ] \`/recomendar\` shows \`Objetivo (saldo + 5.000.000 €): 17.972.212 €\` in the header
- [ ] \`/recomendar\` shows \`Puja máx. Biwenger: 36.334.712 €\` (or \`—\` if Biwenger still doesn't return it — the diagnostic log will tell us which key holds it)
- [ ] Buckets now contain players whose clause ≤ \`17.972.212 €\` (was empty before because max_bid=0)
- [ ] If max_bid is still 0 in logs, inspect \`user_keys\` / \`league_keys\` to find the correct field and follow up