### PR TITLE
fix(api,core): compute Biwenger maxBid client-side + dynamic margin

### DIFF
--- a/core/sdk/biwenger.py
+++ b/core/sdk/biwenger.py
@@ -123,18 +123,27 @@ class BiwengerClient:
         )
         logger.info("Biwenger session ready.")
 
-    def get_account_state(self) -> dict:
+    def get_account_state(
+        self,
+        squad: Optional[list] = None,
+        all_players: Optional[dict] = None,
+    ) -> dict:
         """Returns the user's current cash balance and max bid for the league.
 
-        Biwenger surfaces both per league at `/account`. `balance` is the
-        actual cash you have right now. `maxBid` (the field name the API
-        actually uses) is what you could spend if you sold the rest of
-        your squad — Biwenger pre-computes this server-side.
+        Biwenger's `/account` endpoint exposes `balance` (cash) per league but
+        NOT `maxBid` — the "Puja máxima" the mobile app displays is computed
+        client-side. Empirically verified against the displayed value
+        (2026-05-18):
 
-        First production read showed `user.balance` populated and the
-        max-bid field absent under `user`. We try a few alternate paths
-        and log all candidate keys until we see which one Biwenger
-        returns for this account.
+            puja_maxima = cash + 0.25 * sum(player.price for player in squad)
+
+        The 25% factor matched my account to the euro. If a future league has
+        a different setting and the factor drifts, the discrepancy will be
+        visible in the bot's `/recomendar` header next to `Saldo`.
+
+        Pass `squad` (list from `get_manager_squad`) and `all_players`
+        (dict from `get_all_players_data_map`) to compute max_bid. Without
+        them, max_bid is 0 (only cash is returned).
         """
         response = self.session.get(self.account_url)
         response.raise_for_status()
@@ -144,31 +153,13 @@ class BiwengerClient:
                 continue
             user = league.get("user", {}) or {}
             cash = int(user.get("balance") or 0)
-            # Try several known shapes — Biwenger has shifted these
-            # around between API versions.
-            max_bid_candidates = [
-                user.get("maxBid"),
-                league.get("maxBid"),
-                user.get("teamValue"),  # not the same but a useful fallback
-            ]
             max_bid = 0
-            for cand in max_bid_candidates:
-                if cand is not None:
-                    try:
-                        max_bid = int(cand)
-                        break
-                    except (TypeError, ValueError):
-                        continue
-            logger.info(
-                "Account state read.",
-                extra={
-                    "cash": cash,
-                    "max_bid": max_bid,
-                    "league_id": self.league_id,
-                    "user_keys": sorted(user.keys()),
-                    "league_keys": sorted(league.keys()),
-                },
-            )
+            if squad is not None and all_players is not None:
+                squad_value = sum(
+                    int(all_players.get(p.get("id"), {}).get("price") or 0)
+                    for p in squad
+                )
+                max_bid = cash + squad_value // 4  # 25% factor
             return {"cash": cash, "max_bid": max_bid}
         return {"cash": 0, "max_bid": 0}
 

--- a/core/tests/data/account_response.json
+++ b/core/tests/data/account_response.json
@@ -6,7 +6,8 @@
         "name": "MiLiga de Prueba",
         "user": {
           "id": 98765,
-          "name": "Usuario de Prueba"
+          "name": "Usuario de Prueba",
+          "balance": 10000000
         }
       }
     ]

--- a/core/tests/test_biwenger_client.py
+++ b/core/tests/test_biwenger_client.py
@@ -214,3 +214,61 @@ def test_get_all_clausulazos_stops_on_empty(biwenger_client_authenticated):
     result = client.get_all_clausulazos("http://api/board?type=transfer")
     assert result == {"data": []}
     assert len(calls) == 1
+
+
+def test_get_account_state_cash_only(biwenger_client_authenticated, load_json_fixture):
+    """Without squad+all_players, only cash is returned (max_bid=0)."""
+    client = biwenger_client_authenticated
+    with requests_mock.Mocker() as m:
+        m.get(TEST_ACCOUNT_URL, json=load_json_fixture("account_response.json"))
+        state = client.get_account_state()
+    assert state == {"cash": 10_000_000, "max_bid": 0}
+
+
+def test_get_account_state_computes_max_bid_with_squad_and_prices(
+    biwenger_client_authenticated, load_json_fixture
+):
+    """max_bid = cash + 25% of squad_value (sum of player.price).
+
+    Verified empirically against Biwenger's displayed "Puja máxima":
+    12,972,212 € cash + 25% * 93,450,000 € squad = 36,334,712 € (matches
+    Biwenger UI to the euro).
+    """
+    client = biwenger_client_authenticated
+    squad = [{"id": 1}, {"id": 2}, {"id": 3}]
+    all_players = {
+        1: {"price": 20_000_000},
+        2: {"price": 10_000_000},
+        3: {"price": 5_000_000},
+    }
+    with requests_mock.Mocker() as m:
+        m.get(TEST_ACCOUNT_URL, json=load_json_fixture("account_response.json"))
+        state = client.get_account_state(squad=squad, all_players=all_players)
+    # 35M squad value * 25% = 8.75M; cash 10M -> max_bid 18.75M
+    assert state["cash"] == 10_000_000
+    assert state["max_bid"] == 18_750_000
+
+
+def test_get_account_state_handles_missing_prices(
+    biwenger_client_authenticated, load_json_fixture
+):
+    """Players not present in all_players don't crash; they contribute 0."""
+    client = biwenger_client_authenticated
+    squad = [{"id": 1}, {"id": 999}]  # 999 not in lookup
+    all_players = {1: {"price": 4_000_000}}
+    with requests_mock.Mocker() as m:
+        m.get(TEST_ACCOUNT_URL, json=load_json_fixture("account_response.json"))
+        state = client.get_account_state(squad=squad, all_players=all_players)
+    assert state["max_bid"] == 10_000_000 + 4_000_000 // 4  # cash + 1M
+
+
+def test_get_account_state_unknown_league_returns_zeros(
+    biwenger_client_authenticated, load_json_fixture
+):
+    """When the league_id isn't found in the response, both fields are 0."""
+    client = biwenger_client_authenticated
+    client.league_id = "doesnotexist"
+    with requests_mock.Mocker() as m:
+        m.get(TEST_ACCOUNT_URL, json=load_json_fixture("account_response.json"))
+        state = client.get_account_state()
+    assert state == {"cash": 0, "max_bid": 0}

--- a/packages/biwenger_tools/api/app.py
+++ b/packages/biwenger_tools/api/app.py
@@ -85,8 +85,9 @@ def budget_recommendations():
 
     Query params:
       - `top=N`     — players per position, 1–10, default 3.
-      - `margin=N`  — extra euros over current cash to count as "affordable",
-                       0 – 50M, default 5M.
+      - `margin=N`  — fixed extra euros over current cash to count as
+                       "affordable", 0–50M. **If omitted, a dynamic margin
+                       is computed from cash** (see compute_dynamic_margin).
     """
     try:
         top = int(request.args.get("top", recommendations.DEFAULT_TOP_N))
@@ -94,11 +95,14 @@ def budget_recommendations():
         top = recommendations.DEFAULT_TOP_N
     top = max(1, min(10, top))
 
-    try:
-        margin = int(request.args.get("margin", recommendations.DEFAULT_MARGIN))
-    except (TypeError, ValueError):
-        margin = recommendations.DEFAULT_MARGIN
-    margin = max(0, min(50_000_000, margin))
+    margin_arg = request.args.get("margin")
+    if margin_arg is None:
+        margin = None  # dynamic
+    else:
+        try:
+            margin = max(0, min(50_000_000, int(margin_arg)))
+        except (TypeError, ValueError):
+            margin = None  # fall back to dynamic on garbage
 
     return _run_action(
         "budget.recommendations",

--- a/packages/biwenger_tools/api/logic/recommendations.py
+++ b/packages/biwenger_tools/api/logic/recommendations.py
@@ -15,6 +15,7 @@ formats that as a `[multi: MED]` badge.
 """
 
 import time
+from typing import Optional
 
 from core.sdk.biwenger import BiwengerClient
 from core.sdk.jp import check_api_health, fetch_all_players, get_predict_rate
@@ -29,12 +30,30 @@ logger = get_logger(__name__)
 
 DEFAULT_TOP_N = 3
 
-# How much over the user's cash they're willing to stretch by signing
-# a clausulazo. They explicitly don't want recommendations up to the
-# max_bid (which assumes selling the rest of the squad) — only what
-# they could afford with a small extra margin. 5M is the default
-# requested by the user; overridable via `?margin=N` on the endpoint.
-DEFAULT_MARGIN = 5_000_000
+# Dynamic margin coefficients. When the user does not pass `?margin=N`, we
+# compute a margin proportional to their cash so a poor balance doesn't get
+# overshadowed by huge-clause players, and a rich balance gets a sensible
+# (but bounded) stretch. Rounded to nearest 500k for readability.
+_MARGIN_PCT = 0.40
+_MARGIN_MIN = 2_000_000
+_MARGIN_MAX = 10_000_000
+_MARGIN_ROUND = 500_000
+
+
+def compute_dynamic_margin(cash: int) -> int:
+    """Margin proportional to cash, clamped and rounded.
+
+    cash=  5M → 2.0M
+    cash= 13M → 5.0M (0.40 * 13M = 5.2M → round to 5.0M)
+    cash= 20M → 8.0M
+    cash= 30M → 10M (capped)
+    """
+    if cash <= 0:
+        return _MARGIN_MIN
+    raw = cash * _MARGIN_PCT
+    rounded = round(raw / _MARGIN_ROUND) * _MARGIN_ROUND
+    return int(max(_MARGIN_MIN, min(rounded, _MARGIN_MAX)))
+
 
 # Position labels in the JSON response (English) and for the Telegram message
 # header (Spanish with emojis, to match the rest of the bot voice).
@@ -114,10 +133,12 @@ def _format_telegram_text(payload: dict) -> str:
     max_bid_value = budget.get("max_bid")
     max_bid_str = _euros(max_bid_value) if max_bid_value else "—"
     margin = _euros(budget["margin"])
+    margin_source = budget.get("margin_source", "auto")
+    margin_label = "auto" if margin_source == "auto" else "fijo"
 
     lines = [
         f"💰 <b>Saldo:</b> {cash}",
-        f"🎯 <b>Objetivo (saldo + {margin}):</b> {target}",
+        f"🎯 <b>Objetivo (saldo + {margin}, {margin_label}):</b> {target}",
         f"ℹ️ <i>Puja máx. Biwenger: {max_bid_str}</i>",
     ]
 
@@ -138,26 +159,28 @@ def _format_telegram_text(payload: dict) -> str:
     return "\n".join(lines)
 
 
-def _gather_candidates(
+def _gather_rivals(
     biwenger: BiwengerClient,
     biwenger_players: dict,
     jp_index: dict,
-) -> tuple[set, list[dict]]:
-    """Build (my_squad_ids, rival_rows). Rival rows have an `owner` field."""
+) -> list[dict]:
+    """Build the rival_rows list, tagged with `owner = manager_name`.
+
+    Skips the logged-in user's own squad. My own squad is fetched separately
+    in `run_recommendations` so we can compute Biwenger's max_bid from it.
+    """
     managers = biwenger.get_league_users(config.LEAGUE_DATA_URL)
-    my_ids: set = set()
-    candidates: list[dict] = []
+    rivals: list[dict] = []
     for manager_id, manager_name in managers.items():
+        if manager_id == biwenger.user_id:
+            continue
         squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, manager_id)
         rows = build_squad_rows(squad, biwenger_players, jp_index, include_clause=True)
-        if manager_id == biwenger.user_id:
-            my_ids = {r["bw_id"] for r in rows}
-        else:
-            for r in rows:
-                r["owner"] = manager_name
-                candidates.append(r)
+        for r in rows:
+            r["owner"] = manager_name
+            rivals.append(r)
         time.sleep(0.3)
-    return my_ids, candidates
+    return rivals
 
 
 def _filter_affordable(candidates: list[dict], my_ids: set, target: int) -> list[dict]:
@@ -179,15 +202,19 @@ def _filter_affordable(candidates: list[dict], my_ids: set, target: int) -> list
 
 def run_recommendations(
     top: int = DEFAULT_TOP_N,
-    margin: int = DEFAULT_MARGIN,
+    margin: Optional[int] = None,
 ) -> dict:
     """Compute the recommendations and send the formatted message to Telegram.
 
     `margin` is how much over the user's current cash they'd stretch to. The
     filter uses `cash + margin` as the upper bound on clause amounts — NOT
-    `max_bid`, which assumes selling the rest of the squad and is usually too
-    generous for "who could I grab right now" planning. `max_bid` is still
-    surfaced in the message header as informational.
+    `max_bid`, which assumes selling 100% of the squad and is too generous
+    for "who could I grab right now" planning.
+
+    When `margin` is `None` (the default — what the bot sends), it is
+    computed dynamically from cash (`compute_dynamic_margin`). When the
+    caller passes an explicit value, that value wins (after clamping
+    happens in the route handler).
     """
     check_api_health(
         config.JP_AUTH_TOKEN,
@@ -209,19 +236,32 @@ def run_recommendations(
         config.LEAGUE_ID,
     )
     biwenger_players = biwenger.get_all_players_data_map(config.ALL_PLAYERS_DATA_URL)
-    account_state = biwenger.get_account_state()
-    cash, max_bid = account_state["cash"], account_state["max_bid"]
-    target = cash + max(0, margin)
 
-    my_ids, candidates = _gather_candidates(biwenger, biwenger_players, jp_index)
-    affordable = _filter_affordable(candidates, my_ids, target)
+    # Fetch my squad once: needed to compute max_bid AND to mark my players
+    # as excluded from the rival pool. We hit /user/{me}?fields=players(*)
+    # via the same paginated client method as the rest.
+    my_squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, biwenger.user_id)
+    my_ids = {p.get("id") for p in my_squad if p.get("id") is not None}
+
+    account_state = biwenger.get_account_state(my_squad, biwenger_players)
+    cash, max_bid = account_state["cash"], account_state["max_bid"]
+
+    margin_source = "auto" if margin is None else "manual"
+    if margin is None:
+        margin = compute_dynamic_margin(cash)
+    margin = max(0, margin)
+    target = cash + margin
+
+    rivals = _gather_rivals(biwenger, biwenger_players, jp_index)
+    affordable = _filter_affordable(rivals, my_ids, target)
     recommendations = _pick_top_per_position(affordable, top)
 
     payload = {
         "budget": {
             "cash": cash,
             "max_bid": max_bid,
-            "margin": max(0, margin),
+            "margin": margin,
+            "margin_source": margin_source,
             "target": target,
         },
         "recommendations": recommendations,
@@ -233,7 +273,7 @@ def run_recommendations(
             "max_bid": max_bid,
             "margin": margin,
             "target": target,
-            "candidates": len(candidates),
+            "rivals": len(rivals),
             "affordable": len(affordable),
             "per_position": {k: len(v) for k, v in recommendations.items()},
         },

--- a/packages/biwenger_tools/api/tests/test_api.py
+++ b/packages/biwenger_tools/api/tests/test_api.py
@@ -161,14 +161,15 @@ def test_action_endpoint_returns_500_on_exception(client):
 # --- /budget/recommendations ---
 
 
-def test_budget_recommendations_calls_run_with_defaults(client):
+def test_budget_recommendations_defaults_to_dynamic_margin(client):
     fake = {
         "sent": 1,
         "budget": {
             "cash": 7_000_000,
             "max_bid": 35_000_000,
-            "margin": 5_000_000,
-            "target": 12_000_000,
+            "margin": 2_500_000,
+            "margin_source": "auto",
+            "target": 9_500_000,
         },
         "recommendations": {"GK": [], "DEF": [], "MID": [], "FWD": []},
     }
@@ -177,17 +178,21 @@ def test_budget_recommendations_calls_run_with_defaults(client):
         return_value=fake,
     ) as mock_run:
         resp = client.get("/budget/recommendations")
-    mock_run.assert_called_once_with(top=3, margin=5_000_000)
+    # No `margin` query param → dynamic (None passed through).
+    mock_run.assert_called_once_with(top=3, margin=None)
     assert resp.status_code == 200
-    body = resp.get_json()
-    assert body["budget"]["cash"] == 7_000_000
-    assert body["budget"]["target"] == 12_000_000
 
 
-def test_budget_recommendations_respects_top_and_margin_query_params(client):
+def test_budget_recommendations_respects_explicit_top_and_margin(client):
     fake = {
         "sent": 1,
-        "budget": {"cash": 0, "max_bid": 0, "margin": 0, "target": 0},
+        "budget": {
+            "cash": 0,
+            "max_bid": 0,
+            "margin": 10_000_000,
+            "margin_source": "manual",
+            "target": 10_000_000,
+        },
         "recommendations": {},
     }
     with patch(
@@ -201,7 +206,13 @@ def test_budget_recommendations_respects_top_and_margin_query_params(client):
 def test_budget_recommendations_clamps_query_params(client):
     fake = {
         "sent": 1,
-        "budget": {"cash": 0, "max_bid": 0, "margin": 0, "target": 0},
+        "budget": {
+            "cash": 0,
+            "max_bid": 0,
+            "margin": 0,
+            "margin_source": "manual",
+            "target": 0,
+        },
         "recommendations": {},
     }
     with patch(
@@ -214,8 +225,22 @@ def test_budget_recommendations_clamps_query_params(client):
     calls = mock_run.call_args_list
     # top: 99 → 10, 0 → 1, garbage → 3 (default)
     assert [c.kwargs["top"] for c in calls] == [10, 1, 3]
-    # margin: 99999999999 → 50M, -1 → 0, garbage → 5M (default)
-    assert [c.kwargs["margin"] for c in calls] == [50_000_000, 0, 5_000_000]
+    # margin: 99999999999 → 50M, -1 → 0, garbage → None (fall back to dynamic)
+    assert [c.kwargs["margin"] for c in calls] == [50_000_000, 0, None]
+
+
+def test_compute_dynamic_margin_scales_with_cash():
+    from packages.biwenger_tools.api.logic import recommendations as recs
+
+    # cash ≤ 0 → minimum
+    assert recs.compute_dynamic_margin(0) == 2_000_000
+    assert recs.compute_dynamic_margin(-100) == 2_000_000
+    # 40% of cash, rounded to nearest 500k, clamped [2M, 10M]
+    assert recs.compute_dynamic_margin(5_000_000) == 2_000_000  # 0.4*5M=2M (floor)
+    assert recs.compute_dynamic_margin(12_972_212) == 5_000_000  # ~5.19M → round 5.0
+    assert recs.compute_dynamic_margin(20_000_000) == 8_000_000
+    assert recs.compute_dynamic_margin(30_000_000) == 10_000_000  # cap
+    assert recs.compute_dynamic_margin(100_000_000) == 10_000_000  # cap
 
 
 # --- recommendations unit tests (filtering + grouping) ---
@@ -287,6 +312,7 @@ def test_format_telegram_text_includes_multi_badge_and_exact_euros():
             "cash": 12_972_212,
             "max_bid": 36_334_712,
             "margin": 5_000_000,
+            "margin_source": "auto",
             "target": 17_972_212,
         },
         "recommendations": {
@@ -306,14 +332,32 @@ def test_format_telegram_text_includes_multi_badge_and_exact_euros():
         },
     }
     text = recs._format_telegram_text(payload)
-    # Exact euros in Spanish format (dots as thousands separators)
+    # Exact euros in Spanish format (dots as thousands separators).
     assert "12.972.212 €" in text
     assert "17.972.212 €" in text
     assert "36.334.712 €" in text
+    assert "auto" in text  # margin_source label
     assert "Vivian (Ana)" in text
     assert "12.345.678 €" in text
     assert "SF 410" in text
     assert "multi: MED" in text
+
+
+def test_format_telegram_text_marks_manual_margin():
+    from packages.biwenger_tools.api.logic import recommendations as recs
+
+    payload = {
+        "budget": {
+            "cash": 10_000_000,
+            "max_bid": 30_000_000,
+            "margin": 8_000_000,
+            "margin_source": "manual",
+            "target": 18_000_000,
+        },
+        "recommendations": {"GK": [], "DEF": [], "MID": [], "FWD": []},
+    }
+    text = recs._format_telegram_text(payload)
+    assert "fijo" in text
 
 
 def test_format_telegram_text_dashes_when_max_bid_missing():
@@ -322,8 +366,9 @@ def test_format_telegram_text_dashes_when_max_bid_missing():
     payload = {
         "budget": {
             "cash": 12_972_212,
-            "max_bid": 0,  # Biwenger didn't return it
+            "max_bid": 0,  # max_bid couldn't be computed (no squad data)
             "margin": 5_000_000,
+            "margin_source": "auto",
             "target": 17_972_212,
         },
         "recommendations": {"GK": [], "DEF": [], "MID": [], "FWD": []},


### PR DESCRIPTION
## Summary

Two issues left from the previous /recomendar fix:

1. **Max bid was still 0.** Biwenger's \`/account\`, \`/user\`, \`/user/{id}\`, \`/league/{id}\` and their \`?fields=*\` variants do **not** expose a \`maxBid\` field. The mobile app's \"Puja máxima\" is computed client-side. Reverse-engineered the formula against the displayed value:
   - Cash: 12.972.212 €
   - Squad value (sum of player.price): 93.450.000 €
   - Displayed Puja máxima: 36.334.712 € → factor = 25.00%
   - Displayed Saldo futuro: 106.422.212 € → factor = 100.00%
2. **The 5M margin was static.** User wants it proportional to cash so small balances don't get overwhelmed by big-clause players and large balances don't get capped too tight.

## Changes

- **\`core/sdk/biwenger.get_account_state(squad, all_players)\`** — accepts optional squad and player-price dict; computes max_bid as \`cash + 0.25 * sum(player.price)\` when both provided. Falls back to cash-only (max_bid=0) without them. Diagnostic logging removed.
- **\`recommendations.compute_dynamic_margin(cash)\`** — 40% of cash, rounded to nearest 500k, clamped to [2M, 10M]:
  | cash | margin |
  |---|---|
  | 5M | 2.0M (floor) |
  | 13M | 5.0M |
  | 20M | 8.0M |
  | 30M+ | 10M (cap) |
- **\`run_recommendations(margin=None)\`** — None = dynamic, explicit value = manual. Payload carries \`margin_source: auto | manual\`; the Telegram header surfaces which one ran.
- **\`?margin=N\`** — omitted → dynamic; passed → clamped to [0, 50M]; garbage → falls back to dynamic.
- **\`_gather_candidates\` → \`_gather_rivals\`**: skip my own squad in the loop (we already fetched it for max_bid). One fewer request per call.

## Tests

- 4 new on \`BiwengerClient.get_account_state\` covering the formula, cash-only path, missing-price safety, unknown-league.
- New on \`compute_dynamic_margin\` with floor/scaling/cap.
- Updated existing endpoint tests for the new None-default semantics.
- New on \"auto\" vs \"fijo\" margin label in the formatted message.

26 api tests + 22 core tests, all green.

## Verification

```bash
python3 -m flake8 core/ packages/
python3 -m black --check core/ packages/
bazel test //core:core_tests //packages/biwenger_tools/api:api_tests //packages/biwenger_tools/bot:bot_tests //packages/biwenger_tools/web:web_tests //packages/biwenger_tools/scraper_job:scraper_job_tests //packages/chucknorris_bot/bot:bot_tests
```

## Test plan

- [ ] After merge, \`/recomendar\` in Telegram shows:
  - \`Saldo: 12.972.212 €\` (exact)
  - \`Objetivo (saldo + 5.000.000 €, auto): 17.972.212 €\` (dynamic margin scaling from 12.97M)
  - \`Puja máx. Biwenger: 36.334.712 €\` (matches the value shown in the Biwenger app, not \`—\`)
- [ ] Bucket(s) populated with affordable clausulable rivals
- [ ] \`?margin=10000000\` (manual) → header says \"fijo\"