### PR TITLE
chore(lint): hermetic black/flake8 via bazel + docs sweep

### DIFF
--- a/.claude/plans/next_phases.md
+++ b/.claude/plans/next_phases.md
@@ -14,7 +14,7 @@ are already taken.
   - `chucknorris-bot` — unchanged ✅
   - `biwenger-scraper-data` (Job, weekly Sun 22:00) ✅
 - **Deleted**: `biwenger-teams-analyzer` Job. Its modes are now HTTP endpoints on `biwenger-api`.
-- **Cloud Scheduler `biwenger-teams-analyzer-trigger`**: points at `biwenger-api/digests/daily` (daily 16:00 Madrid). Name is legacy; cosmetic rename is optional.
+- **Cloud Scheduler `biwenger-daily-digest-trigger`**: points at `biwenger-api/digests/daily` (daily 16:00 Madrid). Renamed from `biwenger-teams-analyzer-trigger` on 2026-05-18.
 - **JP API**: alive, token unchanged. Read from `BIWENGER_CREDENTIALS_JSON.jp_auth_token`.
 - **Python**: 3.13.
 - **`python-base` image**: 275 MB (inside the 500 MB Artifact Registry free tier).
@@ -59,17 +59,14 @@ Attack order when resumed:
 3. `web` — read from Firestore instead of Drive CSVs
 4. Delete secret `biwenger-tools-sa-regional` (Drive SA no longer needed)
 
-### 2. (cosmetic) rename `biwenger-teams-analyzer-trigger` Scheduler
-Currently points at `biwenger-api/digests/daily` but keeps the legacy name. Pure cosmetic — works as-is.
-
-### 3. (cosmetic) rename bot display name in Telegram to "Biwenger Bot"
-Done via BotFather (interactive). Optional.
-
-### 4. New GCP project for photos (no spec yet)
+### 2. New GCP project for photos (no spec yet)
 Mentioned as TODO. Waiting for spec.
 
-### 5. Move Drive/Sheets IDs out of BUILD.bazel
+### 3. Move Drive/Sheets IDs out of BUILD.bazel
 Currently hardcoded in `packages/biwenger_tools/web/BUILD.bazel`. Dies naturally with Firestore migration.
+
+### 4. Bot display name in Telegram set to "Biwenger Tools Bot"
+Done via BotFather on 2026-05-18.
 
 ---
 
@@ -113,8 +110,8 @@ bazel test //core:core_tests \
   //packages/biwenger_tools/bot:bot_tests \
   //packages/chucknorris_bot/bot:bot_tests
 
-# Lint (same as CI)
-python3 -m flake8 core/ packages/ && python3 -m black --check core/ packages/
+# Lint (same Python 3.13 toolchain CI uses)
+bash scripts/lint.sh
 
 # Cost + drift check
 bash scripts/check-gcp-costs.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,29 +21,26 @@ env:
 
 jobs:
   # -------------------------------------------------------
-  # 0. Lint Python code (flake8 + black --check)
+  # 0. Lint Python code (flake8 + black --check) via the Bazel toolchain
   # -------------------------------------------------------
+  # Black and flake8 are run via `bazel run //tools/lint:...` using the
+  # repository's hermetic Python 3.13 toolchain. The exact same command is
+  # what `scripts/lint.sh` invokes locally — no Python-version drift between
+  # devs and CI.
   lint:
     name: Lint Python
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          python-version: "3.13"
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
 
-      - name: Install lint tools
-        # Pinned to match versions resolved in requirements_lock.txt;
-        # bump both files in sync if you upgrade.
-        run: pip install flake8==7.3.0 black==26.3.1
-
-      - name: Run flake8
-        run: flake8 core/ packages/
-
-      - name: Check formatting with black
-        run: black --check core/ packages/
+      - name: Lint
+        run: bash scripts/lint.sh
 
   # -------------------------------------------------------
   # 0b. Detect which modules have changed

--- a/docs/gcp.md
+++ b/docs/gcp.md
@@ -12,7 +12,7 @@ Project: `biwenger-tools` · Region: `europe-southwest1` (Madrid)
 | Cloud Run (Services) | `chucknorris-bot` | Chuck Norris jokes Telegram bot |
 | Cloud Run (Jobs) | `biwenger-scraper-data` | Scrapes league messages → CSV → Google Drive |
 | Cloud Scheduler | `biwenger-scraper-data-scheduler-trigger` (`europe-west1`) | Triggers scraper job (cron weekly Sun 22:00) |
-| Cloud Scheduler | `biwenger-teams-analyzer-trigger` (`europe-west1`) | Triggers `biwenger-api/digests/daily` (daily 16:00 Madrid); name is legacy — points at the api now |
+| Cloud Scheduler | `biwenger-daily-digest-trigger` (`europe-west1`) | Triggers `biwenger-api/digests/daily` (daily 16:00 Madrid) |
 | Secret Manager | 4 secrets (see below) | Credentials and bot tokens |
 | Artifact Registry | `biwenger-docker` | Docker images for all Cloud Run services/jobs |
 | Cloud Logging | — | Automatic, structured logs via `get_logger()` |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -420,13 +420,17 @@ the `lint` job in `.github/workflows/deploy.yml`. A lint failure blocks
 Editor and CLI usage, pinned versions, and how to upgrade live in
 [`setup/linter.md`](setup/linter.md).
 
-Quick local invocation (same versions as CI):
+Quick local invocation (same hermetic Python 3.13 toolchain as CI — no
+version drift, no pip install needed):
 
 ```bash
-pip3 install flake8==7.3.0 black==25.1.0
-flake8 core/ packages/
-black --check core/ packages/    # CI runs this
+bash scripts/lint.sh         # check
+bash scripts/lint.sh --fix   # apply black in place
 ```
+
+Under the hood: `bazel run //tools/lint:black -- ...` and `//tools/lint:flake8`.
+The first invocation is slow (Bazel resolves the lint targets); subsequent
+calls are cached.
 
 
 ## 🧹 GCP Cleanup and Cost Control

--- a/docs/setup/linter.md
+++ b/docs/setup/linter.md
@@ -4,57 +4,53 @@ This repo uses **flake8** (linter) and **black** (formatter). Both run as a
 GitHub Actions job on every push to `master`; the build fails if either
 reports issues.
 
-## What was already in the repo
+## How it works
 
-- **`.flake8`** at repo root — `max-line-length = 88`, ignores `E203, W503`
-  (Black-compatible defaults).
-- **`.vscode/settings.json`** — enables flake8 + Black-on-save in the editor.
-- **`core/requirements.txt`** lists `flake8` and `black` as dev tooling, so
-  both are pinned in `requirements_lock.txt`.
+Lint runs through Bazel's hermetic Python 3.13 toolchain so local devs and
+CI are guaranteed to use the same interpreter and the same `black` /
+`flake8` versions resolved by `requirements_lock.txt`.
 
-The editor side worked out of the box because the VS Code extensions ship
-their own bundled tools; what was missing was a CLI / CI path.
+Two thin Bazel targets in `tools/lint/BUILD.bazel`:
 
-## What was added
+```python
+py_console_script_binary(name = "black",  pkg = "@pypi//black")
+py_console_script_binary(name = "flake8", pkg = "@pypi//flake8")
+```
 
-| Change | Where |
-|--------|-------|
-| New CI job `lint` (flake8 + `black --check`) before `test` | `.github/workflows/deploy.yml` |
-| Pinned tool versions documented and aligned with `requirements_lock.txt` | this file + workflow comment |
-| Cleanup pass (E501 line-length, F401 unused imports, F541 empty f-strings) so the lint step starts green | various files |
+A wrapper script `scripts/lint.sh` runs both with the right paths:
+
+```bash
+bash scripts/lint.sh         # check (what CI runs)
+bash scripts/lint.sh --fix   # apply black in place
+```
+
+CI calls the same script (`.github/workflows/deploy.yml` → `lint` job).
+
+## Why hermetic
+
+Before this setup, the maintainer ran lint on Python 3.12 locally while CI
+used 3.13. Black 26.3.1's wrapping heuristics shift subtly across Python
+versions, which caused multiple "passes locally, fails on CI" fixup
+commits during the v6.0 refactor. The hermetic Bazel toolchain removes
+the drift entirely.
 
 ## Pinned versions
 
 The lockfile is the source of truth. As of this writing:
 
 ```
+black==26.3.1
 flake8==7.3.0
-black==25.1.0
 ```
 
-The CI step pins these explicitly. **Bump both the workflow and the
-lockfile in the same PR** when upgrading; otherwise a regen of
-`requirements_lock.txt` will drift from CI.
-
-## Running locally
-
-```bash
-# One-time install (matches CI versions)
-pip3 install flake8==7.3.0 black==25.1.0
-
-# Lint
-flake8 core/ packages/
-
-# Format check (read-only — same as CI)
-black --check core/ packages/
-
-# Format in place
-black core/ packages/
-```
+To upgrade: edit `core/requirements.txt`, regenerate `requirements.in` and
+`requirements_lock.txt` (see [`operations.md`](../operations.md)), and
+push. Bazel will pick up the new versions automatically on the next lint
+invocation. No manual `pip install` step anywhere.
 
 ## Editor integration
 
-The `.vscode/settings.json` already shipped enables:
+The shipped `.vscode/settings.json` enables:
 
 - `python.linting.flake8Enabled: true` — flake8 squiggles in the gutter.
 - `editor.defaultFormatter: ms-python.black-formatter` + `formatOnSave` —
@@ -67,26 +63,16 @@ Required VS Code extensions:
 - `ms-python.python`
 - `ms-python.black-formatter`
 
-## CI behavior
-
-`.github/workflows/deploy.yml` runs the workflow only when paths under
-`core/`, `packages/biwenger_tools/{web,scraper_job}/`, `tools/` or the
-workflow itself change. Within that scope the dependency chain is:
-
-```
-lint ──► test ──► deploy-web / deploy-scraper
-```
-
-A lint failure blocks `test`, which in turn blocks the deploy. Lint
-finishes in seconds (no Bazel needed), so it acts as a fast pre-flight.
+Editor extensions use their own bundled tools, so they may drift from
+`scripts/lint.sh` slightly — the final word is what CI says.
 
 ## Known gotchas
 
 - **Line-length 88** is the only deviation from PEP 8. Any longer line
   needs to be either reformatted or split — Black handles most cases, but
-  long mocked attribute chains in tests (e.g. `mock.x.y.z.return_value...`)
-  are best refactored to an intermediate variable rather than suppressed.
+  long mocked attribute chains in tests are best refactored to an
+  intermediate variable rather than suppressed.
 - **Don't add `# noqa`** unless there is no clean alternative. Document
   the reason on the same line if you must.
 - The repo uses `flake8`'s default ruleset minus `E203` and `W503` (both
-  conflict with Black). Adding new ignores should be discussed in the PR.
+  conflict with Black).

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Run black --check and flake8 hermetically with the same Python (3.13) CI uses.
+#
+# Why: black 26.3.1 produces slightly different output across Python versions
+# (3.12 on the maintainer's Mac vs 3.13 on CI), which caused multiple CI
+# fixup commits. Running both linters through Bazel's hermetic toolchain
+# removes the drift.
+#
+# Usage: bash scripts/lint.sh           # check core/ and packages/
+#        bash scripts/lint.sh --fix     # format with black (in place) instead
+#
+# First invocation is slow (Bazel resolves the lint targets); later ones use
+# the cache.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+TARGETS=("core/" "packages/")
+
+if [[ "${1:-}" == "--fix" ]]; then
+    echo "==> black (writing changes)…"
+    bazel run --ui_event_filters=-info,-stdout,-stderr //tools/lint:black -- \
+        "${TARGETS[@]/#/$REPO_ROOT/}"
+    echo "==> flake8…"
+    bazel run --ui_event_filters=-info,-stdout,-stderr //tools/lint:flake8 -- \
+        "${TARGETS[@]/#/$REPO_ROOT/}"
+    exit 0
+fi
+
+echo "==> black --check…"
+bazel run --ui_event_filters=-info,-stdout,-stderr //tools/lint:black -- \
+    --check "${TARGETS[@]/#/$REPO_ROOT/}"
+
+echo "==> flake8…"
+bazel run --ui_event_filters=-info,-stdout,-stderr //tools/lint:flake8 -- \
+    "${TARGETS[@]/#/$REPO_ROOT/}"
+
+echo "==> lint OK"

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -1,0 +1,27 @@
+"""Hermetic lint binaries — black and flake8 via Bazel's Python 3.13 toolchain.
+
+Why these exist:
+- CI uses Python 3.13 (see `MODULE.bazel`).
+- Local devs may have a different system Python (3.12 on the maintainer's Mac).
+- Black 26.3.1's tokenizer behaviour shifts subtly between Python versions, so
+  running `python3 -m black` locally can produce output that CI rejects.
+- These targets run with the exact same toolchain CI uses, removing the drift.
+
+Usage:
+  bazel run //tools/lint:black -- --check core/ packages/
+  bazel run //tools/lint:flake8 -- core/ packages/
+
+Most callers should use the wrapper script `scripts/lint.sh` instead.
+"""
+
+load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
+
+py_console_script_binary(
+    name = "black",
+    pkg = "@pypi//black",
+)
+
+py_console_script_binary(
+    name = "flake8",
+    pkg = "@pypi//flake8",
+)


### PR DESCRIPTION
## Summary

Two follow-ups from the v6.0 refactor:

### 1. Hermetic lint (kills the python 3.12 vs 3.13 drift)

Black 26.3.1 wraps lines slightly differently across Python versions. The maintainer ran lint on system python 3.12; CI uses 3.13. That gap caused several \"passes locally, fails on CI\" fixup commits during the refactor.

* **\`tools/lint/BUILD.bazel\`** — two \`py_console_script_binary\` targets wrapping the lockfile-resolved \`black\` and \`flake8\`. They run under Bazel's hermetic Python 3.13 toolchain (the same one used for tests).
* **\`scripts/lint.sh\`** — wrapper that runs both with the right paths (\`bazel run\` uses a sandbox cwd, not the workspace root, so the script passes absolute paths).
* **\`.github/workflows/deploy.yml\`** — the \`lint\` job now calls \`bash scripts/lint.sh\` instead of \`pip install\` + raw flake8/black commands. Identical command to local. No way to drift.
* **\`docs/setup/linter.md\`**, **\`docs/operations.md\`**, **\`.claude/plans/next_phases.md\`** — updated to point at \`scripts/lint.sh\`.

```bash
bash scripts/lint.sh         # check (what CI runs)
bash scripts/lint.sh --fix   # apply black in place
```

### 2. Doc sweep (legacy scheduler name)

Cloud Scheduler was renamed from \`biwenger-teams-analyzer-trigger\` to \`biwenger-daily-digest-trigger\` on 2026-05-18, but a few docs still mentioned the old name.

* **\`docs/gcp.md\`** — services table updated.
* **\`.claude/plans/next_phases.md\`** — state-of-master entry corrected, \"pending cosmetics\" cleared (scheduler renamed + Telegram bot display name set to \"Biwenger Tools Bot\" via BotFather).

## Verification

```bash
bash scripts/lint.sh
bazel test //core:core_tests //packages/biwenger_tools/api:api_tests //packages/biwenger_tools/bot:bot_tests //packages/biwenger_tools/web:web_tests //packages/biwenger_tools/scraper_job:scraper_job_tests //packages/chucknorris_bot/bot:bot_tests
```

All green locally.

## Test plan

- [ ] CI lint job green (uses \`bash scripts/lint.sh\` now)
- [ ] No CI step regressions — only the lint job command changes; test + deploy unchanged