### PR TITLE
docs: daily digest schedule moved to 09:00 Madrid

### DIFF
--- a/.claude/plans/next_phases.md
+++ b/.claude/plans/next_phases.md
@@ -14,7 +14,7 @@ are already taken.
   - `chucknorris-bot` — unchanged ✅
   - `biwenger-scraper-data` (Job, weekly Sun 22:00) ✅
 - **Deleted**: `biwenger-teams-analyzer` Job. Its modes are now HTTP endpoints on `biwenger-api`.
-- **Cloud Scheduler `biwenger-daily-digest-trigger`**: points at `biwenger-api/digests/daily` (daily 16:00 Madrid). Renamed from `biwenger-teams-analyzer-trigger` on 2026-05-18.
+- **Cloud Scheduler `biwenger-daily-digest-trigger`**: points at `biwenger-api/digests/daily` (daily 09:00 Madrid, was 16:00 — moved on 2026-05-19 so the user sees the digest in the morning). Renamed from `biwenger-teams-analyzer-trigger` on 2026-05-18.
 - **JP API**: alive, token unchanged. Read from `BIWENGER_CREDENTIALS_JSON.jp_auth_token`.
 - **Python**: 3.13.
 - **`python-base` image**: 275 MB (inside the 500 MB Artifact Registry free tier).

--- a/docs/gcp.md
+++ b/docs/gcp.md
@@ -12,7 +12,7 @@ Project: `biwenger-tools` · Region: `europe-southwest1` (Madrid)
 | Cloud Run (Services) | `chucknorris-bot` | Chuck Norris jokes Telegram bot |
 | Cloud Run (Jobs) | `biwenger-scraper-data` | Scrapes league messages → CSV → Google Drive |
 | Cloud Scheduler | `biwenger-scraper-data-scheduler-trigger` (`europe-west1`) | Triggers scraper job (cron weekly Sun 22:00) |
-| Cloud Scheduler | `biwenger-daily-digest-trigger` (`europe-west1`) | Triggers `biwenger-api/digests/daily` (daily 16:00 Madrid) |
+| Cloud Scheduler | `biwenger-daily-digest-trigger` (`europe-west1`) | Triggers `biwenger-api/digests/daily` (daily 09:00 Madrid) |
 | Secret Manager | 4 secrets (see below) | Credentials and bot tokens |
 | Artifact Registry | `biwenger-docker` | Docker images for all Cloud Run services/jobs |
 | Cloud Logging | — | Automatic, structured logs via `get_logger()` |


### PR DESCRIPTION
User asked to move the daily digest from 16:00 to 09:00 so they see it in the morning before games. Scheduler updated out-of-band via `gcloud scheduler jobs update`; this PR brings the docs in line.