### PR TITLE
feat: scraper notifies Telegram + /scrapper command from bot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -215,7 +215,7 @@ jobs:
             --region ${{ env.REGION }} \
             --project ${{ env.PROJECT_ID }} \
             --update-env-vars TEMPORADA_ACTUAL=${{ env.TEMPORADA_ACTUAL }} \
-            --update-secrets="BIWENGER_CREDENTIALS_JSON=biwenger-credentials-regional:latest"
+            --update-secrets="BIWENGER_CREDENTIALS_JSON=biwenger-credentials-regional:latest,TELEGRAM_BOT_CONFIG_JSON=telegram-bot-config-regional:latest"
 
   # -------------------------------------------------------
   # 2c. Build and deploy bot Cloud Run Service

--- a/core/sdk/gcp.py
+++ b/core/sdk/gcp.py
@@ -2,6 +2,10 @@ import csv
 import io
 from datetime import datetime
 
+import google.auth
+import google.auth.exceptions
+import google.auth.transport.requests
+import requests as http_requests
 from dateutil import parser
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
@@ -22,6 +26,45 @@ def get_google_service(api_name, api_version, service_account_file, scopes):
         service_account_file, scopes=scopes
     )
     return build(api_name, api_version, credentials=credentials)
+
+
+# --- CLOUD RUN JOBS ---
+
+_CLOUD_RUN_JOBS_API = (
+    "https://run.googleapis.com/v2/projects/{project}/locations/{region}"
+    "/jobs/{job}:run"
+)
+
+
+def trigger_cloud_run_job(project: str, region: str, job_name: str) -> str:
+    """Trigger a Cloud Run Job via the Cloud Run Admin API.
+
+    Uses Application Default Credentials — works in Cloud Run when the
+    runtime service account has `roles/run.developer` (or a narrower
+    role with `run.executions.create`).
+
+    Returns the execution name (short form) on success. Raises
+    `requests.HTTPError` on non-2xx and `google.auth.exceptions.GoogleAuthError`
+    if credentials can't be obtained.
+    """
+    credentials, _ = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"]
+    )
+    credentials.refresh(google.auth.transport.requests.Request())
+    url = _CLOUD_RUN_JOBS_API.format(project=project, region=region, job=job_name)
+    resp = http_requests.post(
+        url,
+        headers={"Authorization": f"Bearer {credentials.token}"},
+        json={},
+        timeout=15,
+    )
+    resp.raise_for_status()
+    execution_name = resp.json().get("name", "").split("/")[-1]
+    logger.info(
+        "Cloud Run Job triggered.",
+        extra={"job": job_name, "execution": execution_name},
+    )
+    return execution_name
 
 
 # --- GOOGLE DRIVE ---

--- a/packages/biwenger_tools/api/app.py
+++ b/packages/biwenger_tools/api/app.py
@@ -12,7 +12,12 @@ from flask import Flask, jsonify, request
 
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
-from packages.biwenger_tools.api.logic import actions, digests, recommendations
+from packages.biwenger_tools.api.logic import (
+    actions,
+    digests,
+    recommendations,
+    scraper,
+)
 
 logger = get_logger(__name__)
 
@@ -108,6 +113,12 @@ def budget_recommendations():
         "budget.recommendations",
         lambda: recommendations.run_recommendations(top=top, margin=margin),
     )
+
+
+@app.route("/scraper/trigger", methods=["POST"])
+def scraper_trigger():
+    """Queue an execution of the scraper Cloud Run Job — bot's /scrapper."""
+    return _run_action("scraper.trigger", scraper.run_trigger_scraper)
 
 
 # --- Scheduler-triggered endpoints -----------------------------------------

--- a/packages/biwenger_tools/api/config.py
+++ b/packages/biwenger_tools/api/config.py
@@ -43,6 +43,11 @@ JP_AUTH_TOKEN = _BIWENGER_CFG.get("jp_auth_token") or os.getenv("JP_AUTH_TOKEN",
 JP_COMPETITION = 1  # LaLiga
 JP_SCORE_TYPE = 2  # SofaScore (Automanager system)
 
+# --- GCP TARGETS (the api needs to trigger the scraper Cloud Run Job) ---
+GCP_PROJECT_ID = os.getenv("GCP_PROJECT_ID", "biwenger-tools")
+CLOUD_RUN_REGION = os.getenv("CLOUD_RUN_REGION", "europe-southwest1")
+SCRAPER_JOB_NAME = os.getenv("SCRAPER_JOB_NAME", "biwenger-scraper-data")
+
 # Deployed version metadata (set by CI, see deploy.yml). Used by /version.
 GIT_COMMIT = os.getenv("GIT_COMMIT", "local")
 DEPLOY_TIME = os.getenv("DEPLOY_TIME", "")

--- a/packages/biwenger_tools/api/logic/scraper.py
+++ b/packages/biwenger_tools/api/logic/scraper.py
@@ -1,0 +1,29 @@
+"""Trigger the scraper Cloud Run Job from the bot.
+
+Thin wrapper over `core.sdk.gcp.trigger_cloud_run_job`. The bot calls
+`POST /scraper/trigger`; this returns immediately with the queued
+execution name. The scraper itself notifies Telegram when it finishes
+(see `packages/biwenger_tools/scraper_job/main.py`).
+"""
+
+from core.sdk.gcp import trigger_cloud_run_job
+from core.utils import get_logger
+from packages.biwenger_tools.api import config
+
+logger = get_logger(__name__)
+
+
+def run_trigger_scraper() -> dict:
+    """Queue an execution of the scraper Cloud Run Job. Returns a summary.
+
+    Does NOT wait for the job to finish — Cloud Run Jobs API returns
+    once the execution is queued (a couple of seconds). The scraper's
+    own Telegram notify (success or error) closes the loop later.
+    """
+    execution = trigger_cloud_run_job(
+        config.GCP_PROJECT_ID,
+        config.CLOUD_RUN_REGION,
+        config.SCRAPER_JOB_NAME,
+    )
+    logger.info("Scraper triggered via api.", extra={"execution": execution})
+    return {"queued": True, "execution": execution, "job": config.SCRAPER_JOB_NAME}

--- a/packages/biwenger_tools/api/tests/test_api.py
+++ b/packages/biwenger_tools/api/tests/test_api.py
@@ -52,6 +52,39 @@ def test_version_tolerates_missing_metadata(client):
     assert body["commit"] == "unknown"
 
 
+# --- /scraper/trigger ---
+
+
+def test_scraper_trigger_queues_job(client):
+    fake = {"queued": True, "execution": "abc-123", "job": "biwenger-scraper-data"}
+    with patch(
+        "packages.biwenger_tools.api.app.scraper.run_trigger_scraper",
+        return_value=fake,
+    ) as mock_run:
+        resp = client.post("/scraper/trigger")
+    mock_run.assert_called_once()
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "ok"
+    assert body["queued"] is True
+    assert body["execution"] == "abc-123"
+
+
+def test_scraper_trigger_returns_500_on_exception(client):
+    with patch(
+        "packages.biwenger_tools.api.app.scraper.run_trigger_scraper",
+        side_effect=RuntimeError("perm denied"),
+    ):
+        resp = client.post("/scraper/trigger")
+    assert resp.status_code == 500
+    assert "perm denied" in resp.get_json()["error"]
+
+
+def test_scraper_trigger_rejects_get(client):
+    resp = client.get("/scraper/trigger")
+    assert resp.status_code == 405
+
+
 # --- /digests/daily ---
 
 

--- a/packages/biwenger_tools/bot/app.py
+++ b/packages/biwenger_tools/bot/app.py
@@ -24,6 +24,7 @@ _HELP_TEXT = (
     "/mercado — Solo el mercado\n"
     "/alinear — Aplica la mejor alineación posible\n"
     "/recomendar — Qué fichar si me clausulan (top 3 por posición)\n"
+    "/scrapper — Lanza el scraper a demanda (te avisa al acabar)\n"
     "/version — Versión desplegada del bot y de la API\n"
     "/help — Muestra este mensaje"
 )
@@ -35,6 +36,7 @@ _COMMAND_ROUTES = {
     "/mercado": ("/market", "GET"),
     "/alinear": ("/lineups/auto-pick", "POST"),
     "/recomendar": ("/budget/recommendations", "GET"),
+    "/scrapper": ("/scraper/trigger", "POST"),
 }
 
 

--- a/packages/biwenger_tools/bot/setup_commands.py
+++ b/packages/biwenger_tools/bot/setup_commands.py
@@ -20,6 +20,10 @@ COMMANDS = [
         "command": "recomendar",
         "description": "Qué fichar si me clausulan (top 3 por posición)",
     },
+    {
+        "command": "scrapper",
+        "description": "Lanza el scraper a demanda (te avisa al acabar)",
+    },
     {"command": "version", "description": "Versión desplegada del bot y de la API"},
     {"command": "help", "description": "Muestra todos los comandos disponibles"},
 ]

--- a/packages/biwenger_tools/bot/tests/test_bot.py
+++ b/packages/biwenger_tools/bot/tests/test_bot.py
@@ -77,6 +77,7 @@ def test_wrong_chat_id_is_silently_ignored(client):
         ("/mercado", "/market", "GET"),
         ("/alinear", "/lineups/auto-pick", "POST"),
         ("/recomendar", "/budget/recommendations", "GET"),
+        ("/scrapper", "/scraper/trigger", "POST"),
     ],
 )
 def test_command_calls_correct_api_endpoint(client, command, path, method):

--- a/packages/biwenger_tools/scraper_job/config.py
+++ b/packages/biwenger_tools/scraper_job/config.py
@@ -24,6 +24,18 @@ GDRIVE_FOLDER_ID = _BIWENGER_CFG.get("gdrive_folder_id") or os.getenv(
     "GDRIVE_FOLDER_ID"
 )
 
+# --- TELEGRAM (notificación al acabar) ---
+# Both keys live in TELEGRAM_BOT_CONFIG_JSON which we bind to the job in CI.
+# If neither is set (e.g. local dev without secret), the scraper still runs;
+# the notification just gets skipped.
+_TELEGRAM_CFG = load_json_secret("TELEGRAM_BOT_CONFIG_JSON")
+TELEGRAM_BOT_TOKEN = (
+    _TELEGRAM_CFG.get("bot_token") or os.getenv("TELEGRAM_BOT_TOKEN", "")
+).strip()
+TELEGRAM_CHAT_ID = (
+    _TELEGRAM_CFG.get("chat_id") or os.getenv("TELEGRAM_CHAT_ID", "")
+).strip()
+
 # --- CONFIGURACIÓN NO CRÍTICA (valores fijos) ---
 # LEAGUE_ID re-exported from core.constants at the top of the file.
 SCOPES = ["https://www.googleapis.com/auth/drive"]

--- a/packages/biwenger_tools/scraper_job/main.py
+++ b/packages/biwenger_tools/scraper_job/main.py
@@ -18,6 +18,7 @@ from core.sdk.gcp import (
     get_google_service,
     upload_csv_to_drive,
 )
+from core.sdk.telegram import send_telegram_message
 from core.utils import get_logger
 from packages.biwenger_tools.scraper_job import config
 from packages.biwenger_tools.scraper_job.logic.processing import (
@@ -156,8 +157,32 @@ def _upload_clausulazos(
     logger.info("Clausulazos and tabla_justicia CSVs uploaded.")
 
 
+def _notify(text: str) -> None:
+    """Send a Telegram message to the configured chat. No-op without creds.
+
+    Notification failures are swallowed — they should never mask the
+    scraper result. The Telegram SDK already logs its own errors.
+    """
+    if not (config.TELEGRAM_BOT_TOKEN and config.TELEGRAM_CHAT_ID):
+        logger.warning("Telegram creds missing — skipping scraper notify.")
+        return
+    send_telegram_message(
+        bot_token=config.TELEGRAM_BOT_TOKEN,
+        chat_id=config.TELEGRAM_CHAT_ID,
+        text=text,
+    )
+
+
 def main() -> None:
-    """Orchestrate message scraping, processing, and Drive upload."""
+    """Orchestrate message scraping, processing, and Drive upload.
+
+    Sends a Telegram message to the configured chat at the end (success or
+    failure). On failure, re-raises so Cloud Run marks the execution as
+    failed — silent failure used to leave dead executions looking green.
+    """
+    started_at = datetime.now(timezone.utc)
+    new_count = 0
+
     try:
         logger.info("Scraper started.", extra={"temporada": config.TEMPORADA_ACTUAL})
 
@@ -177,8 +202,9 @@ def main() -> None:
         user_map = biwenger.get_league_users(config.LEAGUE_USERS_URL)
 
         new_messages = _process_new_messages(board_messages, existing_ids, user_map)
+        new_count = len(new_messages)
         if new_messages:
-            logger.info("New messages found.", extra={"count": len(new_messages)})
+            logger.info("New messages found.", extra={"count": new_count})
             all_messages = sort_messages(all_messages + new_messages)
             _write_and_upload_csv(
                 drive_service,
@@ -205,8 +231,22 @@ def main() -> None:
 
         _upload_clausulazos(drive_service, biwenger, config, folder_id)
 
-    except Exception:
+    except Exception as exc:
         logger.exception("Unexpected error in scraper.")
+        elapsed = (datetime.now(timezone.utc) - started_at).total_seconds()
+        _notify(
+            "❌ <b>Scraper falló</b>\n"
+            f"<code>{type(exc).__name__}: {exc}</code>\n"
+            f"⏱️ {elapsed:.0f}s · ver logs en Cloud Run"
+        )
+        raise  # let Cloud Run mark the execution as failed
+
+    elapsed = (datetime.now(timezone.utc) - started_at).total_seconds()
+    if new_count > 0:
+        body = f"🧹 <b>Scraper OK</b> · {new_count} mensajes nuevos · {elapsed:.0f}s"
+    else:
+        body = f"🧹 <b>Scraper OK</b> · sin mensajes nuevos · {elapsed:.0f}s"
+    _notify(body)
 
 
 if __name__ == "__main__":

--- a/packages/biwenger_tools/scraper_job/tests/test_main.py
+++ b/packages/biwenger_tools/scraper_job/tests/test_main.py
@@ -30,6 +30,10 @@ def mock_external_deps():
             "CLAUSULAZOS_URL": "https://fake-clausulazos",
             "BOARD_MESSAGES_URL": "https://fake-board",
             "LEAGUE_ID": "340703",
+            # Empty by default → _notify becomes a no-op in tests that don't
+            # explicitly enable it. Avoids accidental real HTTP calls.
+            "TELEGRAM_BOT_TOKEN": "",
+            "TELEGRAM_CHAT_ID": "",
         },
     ), patch(
         "packages.biwenger_tools.scraper_job.main.get_google_service"
@@ -129,3 +133,56 @@ def test_main_no_new_messages(mock_external_deps):
     ]
     assert any("clausulazos" in name for name in uploaded_names)
     assert any("tabla_justicia" in name for name in uploaded_names)
+
+
+# --- Telegram notify on completion ---
+
+
+def _enable_notify(monkeypatch_config) -> None:
+    """Flip the config mock so _notify actually sends."""
+    cfg = monkeypatch_config["config"] if "config" in monkeypatch_config else None
+    if cfg is None:
+        # The fixture patches the `config` symbol module-wide; we set the
+        # values via module attribute access.
+        from packages.biwenger_tools.scraper_job import main as scraper_main
+
+        scraper_main.config.TELEGRAM_BOT_TOKEN = "test-token"
+        scraper_main.config.TELEGRAM_CHAT_ID = "test-chat"
+
+
+def test_main_sends_telegram_on_success(mock_external_deps):
+    """On success, the scraper notifies the configured chat."""
+    _enable_notify(mock_external_deps)
+    mock_external_deps["biwenger"].get_league_users.return_value = {}
+    mock_external_deps["biwenger"].get_all_board_messages.return_value = []
+    mock_external_deps["find_file"].return_value = None
+
+    with patch(
+        "packages.biwenger_tools.scraper_job.main.send_telegram_message"
+    ) as mock_send:
+        main()
+
+    mock_send.assert_called_once()
+    text = mock_send.call_args.kwargs.get("text", "")
+    assert "Scraper OK" in text
+    assert "sin mensajes nuevos" in text
+
+
+def test_main_sends_telegram_and_reraises_on_error(mock_external_deps):
+    """On error, the scraper notifies AND re-raises so Cloud Run marks failed."""
+    _enable_notify(mock_external_deps)
+    mock_external_deps["biwenger"].get_all_board_messages.side_effect = RuntimeError(
+        "biwenger 503"
+    )
+    mock_external_deps["find_file"].return_value = None
+
+    with patch(
+        "packages.biwenger_tools.scraper_job.main.send_telegram_message"
+    ) as mock_send:
+        with pytest.raises(RuntimeError, match="biwenger 503"):
+            main()
+
+    mock_send.assert_called_once()
+    text = mock_send.call_args.kwargs.get("text", "")
+    assert "Scraper falló" in text
+    assert "biwenger 503" in text

--- a/packages/biwenger_tools/web/routes/admin.py
+++ b/packages/biwenger_tools/web/routes/admin.py
@@ -2,9 +2,7 @@
 
 from datetime import datetime
 
-import google.auth
 import google.auth.exceptions
-import google.auth.transport.requests
 import requests as http_requests
 from dateutil import parser
 from flask import (
@@ -20,17 +18,13 @@ from flask import (
 )
 
 from core.constants import DRIVE_STALE_THRESHOLD, MADRID_TZ
-from core.sdk.gcp import get_file_metadata
+from core.sdk.gcp import get_file_metadata, trigger_cloud_run_job
 from core.utils import get_logger
 from packages.biwenger_tools.web import config, services
 from packages.biwenger_tools.web.csrf import verify_csrf_token
 
 bp = Blueprint("admin", __name__)
 logger = get_logger(__name__)
-
-_CLOUD_RUN_JOBS_API = (
-    "https://run.googleapis.com/v2/projects/{project}/locations/{region}/jobs/{job}:run"
-)
 
 
 def _get_sheet_file_status(sheet_id: str) -> dict:
@@ -70,32 +64,11 @@ def _build_file_statuses() -> list:
 
 
 def _trigger_scraper_job() -> tuple[bool, str]:
-    """
-    Trigger the scraper Cloud Run Job via the Cloud Run API v2.
-    Returns (success, message).
-    Uses ADC — works in Cloud Run if the service SA has roles/run.developer.
-    """
+    """Trigger the scraper Cloud Run Job. Returns (success, message)."""
     try:
-        credentials, _ = google.auth.default(
-            scopes=["https://www.googleapis.com/auth/cloud-platform"]
+        execution_name = trigger_cloud_run_job(
+            config.GCP_PROJECT_ID, config.CLOUD_RUN_REGION, config.CLOUD_RUN_JOB_NAME
         )
-        auth_req = google.auth.transport.requests.Request()
-        credentials.refresh(auth_req)
-
-        url = _CLOUD_RUN_JOBS_API.format(
-            project=config.GCP_PROJECT_ID,
-            region=config.CLOUD_RUN_REGION,
-            job=config.CLOUD_RUN_JOB_NAME,
-        )
-        resp = http_requests.post(
-            url,
-            headers={"Authorization": f"Bearer {credentials.token}"},
-            json={},
-            timeout=15,
-        )
-        resp.raise_for_status()
-        execution_name = resp.json().get("name", "").split("/")[-1]
-        logger.info("Scraper job triggered.", extra={"execution": execution_name})
         return True, f"Job lanzado correctamente (ejecución: {execution_name})."
     except (
         google.auth.exceptions.GoogleAuthError,


### PR DESCRIPTION
## Summary

Two follow-ups requested by the user after the v6.0 refactor:

1. **Scraper Cloud Run Job notifies the chat at end of execution** — until now a silent failure looked like a clean run.
2. **\`/scrapper\` from the bot** — same behaviour as the web admin button, but available without leaving Telegram.

## #1 — Scraper Telegram notify

* \`packages/biwenger_tools/scraper_job/main.py\` — \`main()\` wraps the orchestration in try/except:
  - **Success**: \`🧹 Scraper OK · N mensajes nuevos · Xs\` (or \`sin mensajes nuevos\` when nothing changed).
  - **Failure**: \`❌ Scraper falló: <ExcType: message>\` then **re-raises** so Cloud Run marks the execution as failed (was being swallowed silently).
  - Notify is a no-op without \`TELEGRAM_BOT_TOKEN\`/\`CHAT_ID\` (e.g. local dev).
* \`scraper_job/config.py\` — loads \`TELEGRAM_BOT_CONFIG_JSON\` the same way every other package does.
* \`.github/workflows/deploy.yml\` (\`deploy-scraper\`) — binds \`TELEGRAM_BOT_CONFIG_JSON\` to the job alongside the existing \`BIWENGER_CREDENTIALS_JSON\`.

## #2 — \`/scrapper\` bot command

* **\`core/sdk/gcp.trigger_cloud_run_job(project, region, job_name)\`** — new helper extracted from \`web/routes/admin._trigger_scraper_job\`. ADC-based auth, returns the queued execution name.
* **\`web/routes/admin.py\`** — wraps the new helper; the duplicate Cloud Run Jobs API code is gone.
* **\`packages/biwenger_tools/api\`** — new \`POST /scraper/trigger\` backed by \`api/logic/scraper.run_trigger_scraper()\`. The api runtime SA already has the needed permissions via ADC (web admin proves this path works).
* **\`packages/biwenger_tools/bot\`** — \`/scrapper\` mapped to \`(POST /scraper/trigger)\`. Help text + \`setup_commands.py\` updated.

## Closed loop

After this PR:
1. User types \`/scrapper\` → bot acks \`⏳ /scrapper recibido…\` → bot calls \`POST /scraper/trigger\` → api queues the Cloud Run Job → api returns 200.
2. Scraper runs (anywhere between seconds and minutes).
3. Scraper sends Telegram message announcing the outcome.

No need to look at Cloud Run logs to know if it worked.

## Verification

```bash
bash scripts/lint.sh
bazel test //core:core_tests //packages/biwenger_tools/api:api_tests //packages/biwenger_tools/bot:bot_tests //packages/biwenger_tools/web:web_tests //packages/biwenger_tools/scraper_job:scraper_job_tests //packages/chucknorris_bot/bot:bot_tests
bazel build //packages/biwenger_tools/{api,bot,scraper_job,web}:*_image_gcp --platforms=//platforms:linux_amd64
```

All green locally.

## Test plan

- [ ] CI green
- [ ] Run \`bash packages/biwenger_tools/bot/setup_commands.py\` (one-shot) to register \`/scrapper\` in the Telegram menu after deploy
- [ ] \`/scrapper\` returns an ack within 1–2 s
- [ ] A success notification arrives a few seconds later (\`🧹 Scraper OK · N mensajes nuevos · Xs\`)
- [ ] If the scraper genuinely fails (force an error to test), the failure notification arrives and the Cloud Run execution shows red
- [ ] Web admin's \"Forzar scraper\" button still works (regression check — the helper got refactored)