### PR TITLE
fix(alinear): use live per-league MV for captain cap, PUT without captain when none fits

### DIFF
--- a/core/sdk/biwenger.py
+++ b/core/sdk/biwenger.py
@@ -308,9 +308,14 @@ class BiwengerClient:
         formation: str,
         players_id: list,
         reserves_id: list,
-        captain: int,
+        captain: Optional[int],
     ) -> dict:
         """Sets the lineup via PUT. Returns the API response dict.
+
+        `captain=None` (or 0) tells Biwenger to apply the lineup without a
+        captain — used when no starter clears the 3M MV cap. Internally we
+        send `0`, which matches the "no captain selected" convention the
+        Biwenger payload accepts.
 
         Retries the PUT on transient network errors (Connection reset, read
         timeout, etc.) with the backoff schedule in `_LINEUP_RETRY_BACKOFFS`.
@@ -322,7 +327,7 @@ class BiwengerClient:
                 "type": formation,
                 "playersID": players_id,
                 "reservesID": reserves_id,
-                "captain": captain,
+                "captain": captain if captain else 0,
             }
         }
         logger.info(

--- a/packages/biwenger_tools/api/logic/actions.py
+++ b/packages/biwenger_tools/api/logic/actions.py
@@ -236,13 +236,23 @@ def run_auto_pick_lineup() -> dict:
         r["bw_id"] for r, _ in sorted(result["starters"], key=lambda rp: rp[1])
     ]
     reserves_ids = [r["bw_id"] if r else None for r in result["reserves"]]
+    captain = result.get("captain")
+    captain_id = captain["bw_id"] if captain else None
+    if captain is None:
+        # No starter clears Biwenger's 3M cap on captain MV. Send the lineup
+        # anyway with no captain — Biwenger accepts `captain=0` and applies
+        # the rest; better than skipping the whole PUT.
+        logger.warning(
+            "No eligible captain under Biwenger's MV cap — applying without one.",
+            extra={"formation": result["formation"], "total_sf": result["total_sf"]},
+        )
     try:
         biwenger.set_lineup(
             config.LINEUP_URL,
             result["formation"],
             starters_ids,
             reserves_ids,
-            result["captain"]["bw_id"],
+            captain_id,
         )
     except requests.RequestException as exc:
         # Biwenger PUT retries internally on transient failures. If we land

--- a/packages/biwenger_tools/api/logic/lineup.py
+++ b/packages/biwenger_tools/api/logic/lineup.py
@@ -32,7 +32,10 @@ FORMATIONS = [
 # Position IDs as Biwenger reports them.
 GK, DEF, MID, FWD = 1, 2, 3, 4
 
-# Biwenger refuses to set a captain whose market value is ≥ 3M.
+# Biwenger refuses (HTTP 403, "Captain over max MV") any captain whose
+# per-league live market value is ≥ 3M. Rows fed into the picker carry the
+# live MV (see `build_squad_rows`, which pulls `owner.price` from the
+# user's squad endpoint), so the cap can be applied exactly — no margin.
 _CAPTAIN_MAX_PRICE = 3_000_000
 
 # Score we attribute to a player JP has explicitly marked as not in the lineup.
@@ -107,7 +110,8 @@ def format_lineup_message(result: dict) -> str:
     formation = result["formation"]
     starters = result["starters"]
     reserves = result["reserves"]
-    captain = result["captain"]
+    captain = result.get("captain")
+    captain_bw_id = captain["bw_id"] if captain else None
     total_sf = result["total_sf"]
 
     pos_name = {GK: "POR", DEF: "DEF", MID: "MED", FWD: "DEL"}
@@ -118,8 +122,14 @@ def format_lineup_message(result: dict) -> str:
         group.sort(key=lambda rp: _sf(rp[0]), reverse=True)
         for row, _ in group:
             sf = _sf(row)
-            cap = " ©" if row["bw_id"] == captain["bw_id"] else ""
+            cap = " ©" if captain_bw_id and row["bw_id"] == captain_bw_id else ""
             lines.append(f"{pos_name[pos_id]} {escape(row['name'])} (SF:{sf}){cap}")
+
+    if captain is None:
+        lines.append(
+            "\n⚠️ <b>Sin capitán</b>: ningún titular cabe bajo el tope de 3M de MV. "
+            "Asigna capitán manualmente en la app."
+        )
 
     filled = [(pos_name[pos], r) for pos, r in zip((GK, DEF, MID, FWD), reserves) if r]
     if filled:
@@ -367,26 +377,18 @@ def _pick_reserves(available: list, starter_ids: set) -> list:
     return reserves
 
 
-def _pick_captain(starters: list) -> dict:
-    """Captain must have price strictly < 3M (Biwenger API hard limit).
+def _pick_captain(starters: list) -> dict | None:
+    """Pick the highest-SF starter strictly below the 3M MV cap, or `None`.
 
-    Among eligible players, pick the highest SF (all cheap players double
-    their score as captain, so relative SF ranking is the ordering criterion).
+    Biwenger rejects any captain whose live per-league MV is ≥ 3M. The
+    `price` on the row is the live MV (sourced from `owner.price` in the
+    squad endpoint, see `build_squad_rows`), so the cap is applied exactly.
 
-    If price is 0 (unknown / not set in API), treat as unknown and exclude —
-    a 0-price player could be any value according to the API.
-
-    If no player has a known price < 3M, fall back to the cheapest player
-    with a known price (price > 0) to minimise the risk of an API rejection.
+    A `price` of 0 means "unknown" and is excluded — gambling a 403 on a
+    player whose MV could be anything is worse than returning `None` and
+    letting the caller apply the lineup without a captain.
     """
-    known_cheap = [r for r in starters if 0 < r.get("price", 0) < _CAPTAIN_MAX_PRICE]
-    if known_cheap:
-        return max(known_cheap, key=_sf)
-
-    # No player with a known cheap price — pick the cheapest non-zero-price player
-    with_price = [r for r in starters if r.get("price", 0) > 0]
-    if with_price:
-        return min(with_price, key=lambda r: r.get("price", 0))
-
-    # All prices unknown — fall back to best SF
-    return max(starters, key=_sf)
+    eligible = [r for r in starters if 0 < r.get("price", 0) < _CAPTAIN_MAX_PRICE]
+    if not eligible:
+        return None
+    return max(eligible, key=_sf)

--- a/packages/biwenger_tools/api/logic/rows.py
+++ b/packages/biwenger_tools/api/logic/rows.py
@@ -71,6 +71,17 @@ def build_squad_rows(
         if not bw_player:
             continue
         row = build_row(bw_player, jp_index)
+        # Override the competition-level `price` from cf.biwenger.com with
+        # the per-league live market value when the squad endpoint gives us
+        # one (`owner.price`). Biwenger's server-side checks (the 3M cap on
+        # captain MV, plus the maxBid math) evaluate against this live MV —
+        # and it drifts wildly from the cf-base price (observed +56% on a
+        # real player). Market/other flows that hit `build_row` directly
+        # without an `owner` block keep the cf-base price.
+        owner = player_data.get("owner") or {}
+        live_price = owner.get("price")
+        if live_price is not None:
+            row["price"] = int(live_price)
         if include_clause:
             owner = player_data.get("owner") or {}
             locked_until = owner.get("clauseLockedUntil")

--- a/packages/biwenger_tools/api/tests/test_lineup.py
+++ b/packages/biwenger_tools/api/tests/test_lineup.py
@@ -1,0 +1,139 @@
+"""Tests for `_pick_captain`, `format_lineup_message`, and the live-MV
+override in `build_squad_rows`.
+
+`_pick_captain` operates on rows whose `price` is already the per-league
+live market value (see `build_squad_rows`), so the 3M cap is exact — no
+margin needed. A row with `price=0` ("unknown") is excluded; the caller
+applies the lineup without a captain when nobody qualifies.
+"""
+
+from packages.biwenger_tools.api.logic.lineup import (
+    DEF,
+    FWD,
+    GK,
+    MID,
+    _CAPTAIN_MAX_PRICE,
+    _pick_captain,
+    format_lineup_message,
+)
+from packages.biwenger_tools.api.logic.rows import build_squad_rows
+
+
+def _row(bw_id: int, price: int, sf: int) -> dict:
+    """Minimal starter row: bw_id + price + a JP predict with SF type=2."""
+    return {
+        "bw_id": bw_id,
+        "price": price,
+        "jp_player": {"predict": [{"type": 2, "rate": sf}]},
+    }
+
+
+def test_pick_captain_picks_highest_sf_under_cap():
+    starters = [
+        _row(1, 1_000_000, sf=10),
+        _row(2, 2_500_000, sf=80),  # highest SF under cap — picked
+        _row(3, 2_900_000, sf=70),
+        _row(4, 4_000_000, sf=200),  # over cap, excluded
+    ]
+    captain = _pick_captain(starters)
+    assert captain is not None
+    assert captain["bw_id"] == 2
+
+
+def test_pick_captain_cap_is_strict():
+    """A starter at exactly the cap is excluded (strict `<`)."""
+    starters = [
+        _row(1, _CAPTAIN_MAX_PRICE, sf=200),  # == cap, excluded
+        _row(2, _CAPTAIN_MAX_PRICE - 1, sf=10),  # qualifies, picked
+    ]
+    captain = _pick_captain(starters)
+    assert captain is not None
+    assert captain["bw_id"] == 2
+
+
+def test_pick_captain_returns_none_when_every_starter_over_cap():
+    """No starter qualifies → None. The caller PUTs with captain=0."""
+    starters = [
+        _row(1, _CAPTAIN_MAX_PRICE, sf=100),
+        _row(2, 5_000_000, sf=300),
+    ]
+    assert _pick_captain(starters) is None
+
+
+def test_pick_captain_returns_none_when_all_prices_unknown():
+    """Unknown price (0) is excluded — won't gamble a 403 on an unknown MV."""
+    assert _pick_captain([_row(1, 0, sf=100), _row(2, 0, sf=200)]) is None
+
+
+def test_pick_captain_ignores_unknown_price_when_known_options_exist():
+    """A price-0 starter must not win even with the highest SF."""
+    starters = [
+        _row(1, 0, sf=500),  # unknown price, excluded
+        _row(2, 1_500_000, sf=50),  # qualifies, picked
+    ]
+    captain = _pick_captain(starters)
+    assert captain is not None
+    assert captain["bw_id"] == 2
+
+
+def _named(bw_id: int, name: str, price: int = 1_000_000, sf: int = 10) -> dict:
+    row = _row(bw_id, price, sf)
+    row["name"] = name
+    return row
+
+
+def test_format_lineup_message_renders_no_captain_warning():
+    """With captain=None the rendered message must omit the © marker and
+    add the manual-pick warning, but still announce the lineup as applied."""
+    result = {
+        "formation": "4-4-2",
+        "starters": [(_named(1, "Keeper"), GK)] * 1
+        + [(_named(2, "Defender"), DEF)] * 4
+        + [(_named(3, "Midfielder"), MID)] * 4
+        + [(_named(4, "Forward"), FWD)] * 2,
+        "reserves": [None, None, None, None],
+        "captain": None,
+        "total_sf": 0,
+    }
+    msg = format_lineup_message(result)
+    assert "Alineación aplicada" in msg
+    assert "©" not in msg
+    assert "Sin capitán" in msg
+    assert "tope de 3M" in msg
+
+
+# --- build_squad_rows: live-MV override ----------------------------------
+
+
+def test_build_squad_rows_uses_live_mv_from_owner():
+    """The squad row's `price` must come from `owner.price` (the per-league
+    live MV) when present, not from the cf-base value — Biwenger's caps
+    evaluate against the live MV and cf-base can drift wildly (observed
+    +56% on a real player)."""
+    biwenger_players = {
+        42: {
+            "id": 42,
+            "name": "Test",
+            "position": 4,
+            "altPositions": [],
+            "price": 9_230_000,
+        },
+    }
+    squad = [{"id": 42, "owner": {"price": 14_425_012}}]
+    rows = build_squad_rows(
+        squad, biwenger_players, jp_index={"by_name": {}, "by_slug": {}}
+    )
+    assert len(rows) == 1
+    assert rows[0]["price"] == 14_425_012
+
+
+def test_build_squad_rows_falls_back_to_cf_price_without_owner():
+    """When the squad entry lacks an `owner` (older payloads, fixtures),
+    keep the cf-base price as before."""
+    biwenger_players = {
+        7: {"id": 7, "name": "T", "position": 2, "altPositions": [], "price": 500_000},
+    }
+    rows = build_squad_rows(
+        [{"id": 7}], biwenger_players, jp_index={"by_name": {}, "by_slug": {}}
+    )
+    assert rows[0]["price"] == 500_000


### PR DESCRIPTION
## Problem

`/alinear` in prod returns 403 from Biwenger:

```
status=403  body={"status":403,"message":"Captain over max MV: 3160000 > 3000000",
                  "userMessage":"El capitán seleccionado supera el máximo..."}
```

Biwenger has tightened its captain rule: the **live per-league MV** must be < 3M.
Our auto-pick was filtering by `price` from `cf.biwenger.com/...la-liga/data`
(competition-level listed value), which drifts hard from the per-league MV.
Observed in this league:

| Player | cf-base price | owner.price (live MV) | Drift |
|---|---|---|---|
| Toni Martínez | 9.23M | **14.43M** | +56% |
| David Costas | 960K | 900K | −6% |

A cheap pick by cf-base could be 56% higher in live MV — rejected at PUT time.
On top of that, the previous `_pick_captain` fallbacks could return a captain
≥ 3M anyway, guaranteeing the 403.

## Fix

1. **Use the live MV.** `build_squad_rows` now pisa `row["price"]` con
   `owner.price` cuando viene del endpoint del usuario (que ya pedíamos con
   `players(id,owner(*))`). Market y otros flujos sin owner siguen con el cf-base.
2. **Cap exacto de 3M sin margen.** `_CAPTAIN_MAX_PRICE = 3_000_000` estricto.
   `_pick_captain` devuelve `None` si nadie cabe; el fallback "cheapest" se elimina
   (era el que metía el capitán garantizado-rechazado).
3. **PUT sin capitán cuando no hay candidato.** `set_lineup` acepta
   `captain: Optional[int]` y envía `0` cuando es None — la convención
   estándar para "sin capitán seleccionado". El lineup se aplica igualmente;
   solo falta el ©.
4. **Mensaje de Telegram claro.** `format_lineup_message` quita el © y añade:
   `⚠️ Sin capitán: ningún titular cabe bajo el tope de 3M de MV. Asigna capitán manualmente en la app.`

## Tests

7 nuevos casos en `test_lineup.py`:

- `_pick_captain` con cap estricto: pick correcto bajo cap, exclusión en cap exacto, None si todos ≥ 3M, None si todos `price=0`, exclusión de `price=0` cuando hay alternativas.
- `format_lineup_message` con `captain=None`: sin ©, con aviso "Sin capitán".
- `build_squad_rows` con override de live MV y fallback al cf-base cuando no hay `owner`.

```
//core //api //bot //scraper //web   PASSED  (5/5)
scripts/lint.sh                       OK
```

Validado live contra Biwenger probando que `/user/{id}?fields=players(id,owner(*))`
devuelve `owner.price` con el MV vivo por-liga.
