### PR TITLE
chore(ci): nudge deploy workflow after GH event miss on PR #72 merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,9 @@
 name: Deploy to Cloud Run
 
+# 2026-05-20: nudge — the merge of PR #72 (the /alinear captain-MV fix)
+# updated master HEAD but GH Actions never received the push event, so the
+# deploy never ran. This single-line touch re-triggers the workflow.
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
The merge of #72 (the /alinear captain-MV fix) updated master HEAD to c64d9bd but no GH Actions push event ever fired, so the deploy workflow never ran. The fix is on master but Cloud Run is still serving the old revision.

This adds 3 lines of comment to .github/workflows/deploy.yml (which is in the workflow's own `paths:` filter) to force a push event and re-trigger the deploy. The deploy will pick up master HEAD (= the merge of #72) and ship the fix.