### PR TITLE
ci(deploy): add workflow_dispatch trigger to recover from missed pushes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,12 @@
 name: Deploy to Cloud Run
 
-# 2026-05-20: nudge — the merge of PR #72 (the /alinear captain-MV fix)
-# updated master HEAD but GH Actions never received the push event, so the
-# deploy never ran. This single-line touch re-triggers the workflow.
+# Triggers:
+# - push to master: auto-deploys modules whose code changed (via paths-filter).
+# - workflow_dispatch: manual trigger to redeploy when a push event was missed
+#   (e.g. PR #72 merged but GH never delivered the push event, so the api
+#   deploy never ran — see PR #73 nudge attempt that also failed because the
+#   per-module paths-filter only diffs the nudge commit, not the missed one).
+#   Manual runs deploy every module by default; toggle inputs to scope.
 
 on:
   push:
@@ -16,6 +20,28 @@ on:
       - "packages/chucknorris_bot/**"
       - "tools/**"
       - ".github/workflows/deploy.yml"
+  workflow_dispatch:
+    inputs:
+      deploy_api:
+        description: "Deploy biwenger-api"
+        type: boolean
+        default: true
+      deploy_web:
+        description: "Deploy web app"
+        type: boolean
+        default: true
+      deploy_bot:
+        description: "Deploy biwenger bot"
+        type: boolean
+        default: true
+      deploy_scraper:
+        description: "Deploy scraper job"
+        type: boolean
+        default: true
+      deploy_chucknorris_bot:
+        description: "Deploy Chuck Norris bot"
+        type: boolean
+        default: true
 
 env:
   REGION: europe-southwest1
@@ -129,7 +155,9 @@ jobs:
   deploy-web:
     name: Deploy web app
     needs: [detect-changes, test]
-    if: needs.detect-changes.outputs.web == 'true'
+    if: |
+      (github.event_name == 'push' && needs.detect-changes.outputs.web == 'true') ||
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_web)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -185,7 +213,9 @@ jobs:
   deploy-scraper:
     name: Deploy scraper job
     needs: [detect-changes, test]
-    if: needs.detect-changes.outputs.scraper == 'true'
+    if: |
+      (github.event_name == 'push' && needs.detect-changes.outputs.scraper == 'true') ||
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_scraper)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -227,7 +257,9 @@ jobs:
   deploy-bot:
     name: Deploy bot service
     needs: [detect-changes, test]
-    if: needs.detect-changes.outputs.bot == 'true'
+    if: |
+      (github.event_name == 'push' && needs.detect-changes.outputs.bot == 'true') ||
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_bot)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -286,7 +318,9 @@ jobs:
   deploy-api:
     name: Deploy biwenger API service
     needs: [detect-changes, test]
-    if: needs.detect-changes.outputs.api == 'true'
+    if: |
+      (github.event_name == 'push' && needs.detect-changes.outputs.api == 'true') ||
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_api)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -335,7 +369,9 @@ jobs:
   deploy-chucknorris-bot:
     name: Deploy Chuck Norris bot service
     needs: [detect-changes, test]
-    if: needs.detect-changes.outputs.chucknorris_bot == 'true'
+    if: |
+      (github.event_name == 'push' && needs.detect-changes.outputs.chucknorris_bot == 'true') ||
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_chucknorris_bot)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to `.github/workflows/deploy.yml` with per-module booleans (all default to `true`).
- Each deploy job's `if:` now fires on either `push` (current behavior, gated by `detect-changes`) or `workflow_dispatch` (gated by the module's input).

## Why
PR #72 merged the `/alinear` captain-MV fix on 2026-05-20. GitHub never delivered the `push` event for that merge, so no CI ran. PR #73 was a nudge that touched only `.github/workflows/deploy.yml` — the outer paths-filter accepted it but `dorny/paths-filter@v4` (which feeds the per-module `if:`) diffed only the nudge commit, so every deploy was skipped. The api fix `c2c3cfd` is in master but never reached Cloud Run.

With this in, the fix is: merge → `gh workflow run "Deploy to Cloud Run" --ref master -f deploy_api=true` → api redeploys.

## Test plan
- [ ] Workflow file parses (validated locally with PyYAML).
- [ ] After merge, manually trigger via `gh workflow run` with `deploy_api=true` and verify only the api job runs.
- [ ] Confirm new biwenger-api revision picks up `c2c3cfd` (live-MV captain cap fix).