### PR TITLE
fix(alinear): use cf-base price for captain MV cap

### DIFF
--- a/packages/biwenger_tools/api/logic/lineup.py
+++ b/packages/biwenger_tools/api/logic/lineup.py
@@ -32,10 +32,12 @@ FORMATIONS = [
 # Position IDs as Biwenger reports them.
 GK, DEF, MID, FWD = 1, 2, 3, 4
 
-# Biwenger refuses (HTTP 403, "Captain over max MV") any captain whose
-# per-league live market value is ≥ 3M. Rows fed into the picker carry the
-# live MV (see `build_squad_rows`, which pulls `owner.price` from the
-# user's squad endpoint), so the cap can be applied exactly — no margin.
+# Biwenger refuses (HTTP 403, "Captain over max MV: <X> > 3000000") any
+# captain whose cf-base price is ≥ 3M. The check is against the
+# competition-level `price` from cf.biwenger.com — NOT the per-league live
+# market value (`owner.price`), which can be much lower (Pablo Martínez:
+# owner.price 1.6M, cf-base 3.16M; server rejected when we picked him).
+# `row["price"]` is the cf-base value, so the cap applies exactly.
 _CAPTAIN_MAX_PRICE = 3_000_000
 
 # Score we attribute to a player JP has explicitly marked as not in the lineup.
@@ -380,12 +382,12 @@ def _pick_reserves(available: list, starter_ids: set) -> list:
 def _pick_captain(starters: list) -> dict | None:
     """Pick the highest-SF starter strictly below the 3M MV cap, or `None`.
 
-    Biwenger rejects any captain whose live per-league MV is ≥ 3M. The
-    `price` on the row is the live MV (sourced from `owner.price` in the
-    squad endpoint, see `build_squad_rows`), so the cap is applied exactly.
+    Biwenger rejects any captain whose cf-base price is ≥ 3M. The `price`
+    on the row is the cf-base value (from cf.biwenger.com via
+    `build_squad_rows` → `build_row`), so the cap is applied exactly.
 
     A `price` of 0 means "unknown" and is excluded — gambling a 403 on a
-    player whose MV could be anything is worse than returning `None` and
+    player whose price could be anything is worse than returning `None` and
     letting the caller apply the lineup without a captain.
     """
     eligible = [r for r in starters if 0 < r.get("price", 0) < _CAPTAIN_MAX_PRICE]

--- a/packages/biwenger_tools/api/logic/rows.py
+++ b/packages/biwenger_tools/api/logic/rows.py
@@ -71,17 +71,16 @@ def build_squad_rows(
         if not bw_player:
             continue
         row = build_row(bw_player, jp_index)
-        # Override the competition-level `price` from cf.biwenger.com with
-        # the per-league live market value when the squad endpoint gives us
-        # one (`owner.price`). Biwenger's server-side checks (the 3M cap on
-        # captain MV, plus the maxBid math) evaluate against this live MV —
-        # and it drifts wildly from the cf-base price (observed +56% on a
-        # real player). Market/other flows that hit `build_row` directly
-        # without an `owner` block keep the cf-base price.
-        owner = player_data.get("owner") or {}
-        live_price = owner.get("price")
-        if live_price is not None:
-            row["price"] = int(live_price)
+        # `row["price"]` stays as the cf.biwenger.com base price.
+        # Empirically verified (player 4245, Pablo Martínez, 2026-05-20):
+        #   - owner.price (per-league live MV) = 1.6M
+        #   - cf.biwenger.com price (cf-base)  = 3.16M
+        # Biwenger's server rejected the lineup with "Captain over max MV:
+        # 3160000 > 3000000" — i.e. the captain cap is checked against the
+        # cf-base price, NOT the per-league live MV. `core/sdk/biwenger.py`
+        # confirms the same: the maxBid math also reads cf-base (via
+        # `all_players[id].price`). The per-league `owner.price` is only used
+        # for the clause block below.
         if include_clause:
             owner = player_data.get("owner") or {}
             locked_until = owner.get("clauseLockedUntil")

--- a/packages/biwenger_tools/api/tests/test_lineup.py
+++ b/packages/biwenger_tools/api/tests/test_lineup.py
@@ -1,10 +1,10 @@
-"""Tests for `_pick_captain`, `format_lineup_message`, and the live-MV
-override in `build_squad_rows`.
+"""Tests for `_pick_captain`, `format_lineup_message`, and the cf-base
+price kept by `build_squad_rows`.
 
-`_pick_captain` operates on rows whose `price` is already the per-league
-live market value (see `build_squad_rows`), so the 3M cap is exact — no
-margin needed. A row with `price=0` ("unknown") is excluded; the caller
-applies the lineup without a captain when nobody qualifies.
+`_pick_captain` gates on `row["price"]`, which is the cf.biwenger.com base
+price — the same value Biwenger's server uses for its `Captain over max MV`
+check. A row with `price=0` ("unknown") is excluded; the caller applies the
+lineup without a captain when nobody qualifies.
 """
 
 from packages.biwenger_tools.api.logic.lineup import (
@@ -102,34 +102,37 @@ def test_format_lineup_message_renders_no_captain_warning():
     assert "tope de 3M" in msg
 
 
-# --- build_squad_rows: live-MV override ----------------------------------
+# --- build_squad_rows: keeps cf-base price -------------------------------
 
 
-def test_build_squad_rows_uses_live_mv_from_owner():
-    """The squad row's `price` must come from `owner.price` (the per-league
-    live MV) when present, not from the cf-base value — Biwenger's caps
-    evaluate against the live MV and cf-base can drift wildly (observed
-    +56% on a real player)."""
+def test_build_squad_rows_keeps_cf_base_price_ignoring_owner():
+    """`row["price"]` must stay as the cf.biwenger.com base price — that is
+    what Biwenger's server-side captain cap evaluates against.
+
+    Regression for Pablo Martínez (player 4245, 2026-05-20): owner.price
+    1.6M, cf-base 3.16M. We previously overrode `row["price"]` with
+    owner.price, picked him as captain (eligible at 1.6M < 3M), and the
+    server rejected with `Captain over max MV: 3160000 > 3000000`."""
     biwenger_players = {
-        42: {
-            "id": 42,
-            "name": "Test",
-            "position": 4,
+        4245: {
+            "id": 4245,
+            "name": "Pablo Martínez",
+            "position": 3,
             "altPositions": [],
-            "price": 9_230_000,
+            "price": 3_160_000,
         },
     }
-    squad = [{"id": 42, "owner": {"price": 14_425_012}}]
+    squad = [{"id": 4245, "owner": {"price": 1_600_000}}]
     rows = build_squad_rows(
         squad, biwenger_players, jp_index={"by_name": {}, "by_slug": {}}
     )
     assert len(rows) == 1
-    assert rows[0]["price"] == 14_425_012
+    assert rows[0]["price"] == 3_160_000
 
 
-def test_build_squad_rows_falls_back_to_cf_price_without_owner():
-    """When the squad entry lacks an `owner` (older payloads, fixtures),
-    keep the cf-base price as before."""
+def test_build_squad_rows_keeps_cf_base_price_without_owner():
+    """When the squad entry lacks an `owner` block, `row["price"]` is still
+    the cf-base price."""
     biwenger_players = {
         7: {"id": 7, "name": "T", "position": 2, "altPositions": [], "price": 500_000},
     }


### PR DESCRIPTION
## Summary
- Reverts the `owner.price` override in `build_squad_rows`. `row[\"price\"]` is once again the cf.biwenger.com base price.
- Updates the `_pick_captain` / `_CAPTAIN_MAX_PRICE` comments to reflect what Biwenger's server actually checks.
- Replaces the test that asserted the live-MV override with one that asserts cf-base is kept (regression for Pablo Martínez).

## Why
The previous fix (#72, `c2c3cfd`) assumed Biwenger evaluated the 3M captain cap against the per-league live MV (`owner.price`). Empirically wrong:

| Player 4245 (Pablo Martínez) | Value |
| --- | --- |
| `owner.price` (per-league live MV) | 1,600,000 |
| `cf.biwenger.com` price (cf-base) | 3,160,000 |

The picker saw 1.6M (under the 3M cap), picked him, server rejected with `Captain over max MV: 3160000 > 3000000`. `core/sdk/biwenger.py` (`get_account_state`) already reads cf-base for the maxBid math — both caps are cf-base.

## Test plan
- [x] `bazel test //packages/biwenger_tools/api:api_tests` — green locally.
- [ ] After merge, deploy via `gh workflow run` and verify `/alinear` succeeds.