### PR TITLE
Firestore migration: dual-write scraper, web reads from Firestore

### DIFF
--- a/.claude/plans/firestore_pickup.md
+++ b/.claude/plans/firestore_pickup.md
@@ -1,0 +1,158 @@
+# Firestore migration — pickup notes
+
+Branch: **`feat/firestore-migration`** (pushed, no PR). Reading this means you
+came back from another task; here is exactly where we left off.
+
+## State (2026-05-19/20)
+
+Migration is **functionally validated** but not deployable yet. Five commits
+on the branch:
+
+1. `chore: add google-cloud-firestore (and restore matplotlib in api)`
+2. `feat: Firestore SDK + Palmares model + from/to_firestore helpers`
+3. `feat: backfill script to seed Firestore from existing CSVs`
+4. `feat: DATA_BACKEND flag enables Firestore reads in the web`
+5. `docs: pickup notes for the in-progress Firestore migration`
+
+### Firestore in GCP
+
+- `firestore.googleapis.com` enabled on `biwenger-tools`.
+- `(default)` database, Native mode, **`europe-southwest1`** (regional, free
+  tier, co-located with Cloud Run). No service-account key needed — ADC.
+- **Populated** with the real CSV data via `scripts/backfill_firestore.py`:
+  ```
+  comunicados/24-25:    1 doc           comunicados/25-26: 133 docs
+  participacion/24-25:  7 docs          participacion/25-26: 6 docs
+  clausulazos/25-26:    104 docs        tabla_justicia/25-26: 7 docs
+  palmares:             3 seasons
+  ```
+
+### Code
+
+- `core/sdk/firestore.py` — `get_client`, `get_document`, `set_document`,
+  `list_documents`, `query`, `count`, `batch_write` (500-op chunking),
+  `delete_collection`. ADC auth.
+- `core/domain/models.py` — added `Palmares` dataclass and
+  `from_firestore`/`to_firestore` on every model. `fecha` is stored as a
+  native Firestore timestamp; `from_firestore` formats it back to the
+  display string the templates expect (per-model `_FECHA_FMT`).
+- `packages/biwenger_tools/web/repository.py` — Firestore read helpers,
+  returning the same models the CSV path produces. Sorting preserved:
+  messages and clausulazos newest-first, tabla by `total_hechos` desc.
+- `packages/biwenger_tools/web/config.py` — `DATA_BACKEND` env var
+  (default `"csv"`). Route bodies in `routes/season.py` and
+  `routes/main.py` early-return to firestore companions when
+  `DATA_BACKEND == "firestore"`. **CSV branch left byte-identical** so the
+  19 existing web tests pass unchanged.
+- `scripts/backfill_firestore.py` — idempotent (delete-then-write each
+  collection), deterministic clausulazo doc ids (content hash), count
+  verification per collection.
+
+### Tests + lint
+
+- `//core:core_tests` green (10 new Firestore-related cases in
+  `test_domain_models.py`; `test_firestore_sdk.py` is module-skipped without
+  `FIRESTORE_EMULATOR_HOST`).
+- `//packages/biwenger_tools/web:web_tests` green (CSV default keeps them
+  on the unchanged path).
+- Full sweep + `bash scripts/lint.sh` clean.
+
+### Manual validation done
+
+- `python3 scripts/backfill_firestore.py --csv-dir ~/Downloads/Biwenger`
+  → every `cleared/wrote/count/expected` line matched.
+- `DATA_BACKEND=firestore FIRESTORE_PROJECT=biwenger-tools \
+  SESSION_COOKIE_SECURE=false PORT=8088 \
+  bazel run //packages/biwenger_tools/web:web_local`
+  + curl of `/version`, `/24-25/`, `/25-26/`, `/25-26/salseo`,
+  `/25-26/mercado`, `/25-26/participacion`, `/palmares` → all 200, no
+  error banners, content correct (fechas in display format, hechos
+  rendered, emojis preserved).
+
+## Pending before merge
+
+1. **Scraper dual-write** (task #10). Right now the scraper only writes to
+   CSV/Drive. After backfill, new messages would only land in CSV; once
+   `DATA_BACKEND=firestore` is flipped in prod, the Firestore copy goes
+   stale. Make `packages/biwenger_tools/scraper_job/main.py` write to
+   Firestore (alongside CSV for a transition, then CSV-only is deleted in
+   the cleanup PR). Models already have `to_firestore`; replicate the
+   collection layout in `_write_and_upload_csv`.
+
+2. **Rebuild + push `python-base`** (task #9). `docker/Dockerfile.base`
+   already updated with `google-cloud-firestore==2.27.0`,
+   `google-cloud-core==2.6.0`, `grpcio==1.80.0`, `grpcio-status==1.62.3`,
+   plus `fonttools 4.62→4.63` and `numpy 2.4.4→2.4.6` (pip-compile bumps
+   when the lock was regenerated). Needed before `DATA_BACKEND=firestore`
+   in Cloud Run — Bazel local tests don't use this image, but the deployed
+   container does.
+   ```bash
+   docker buildx build --platform linux/amd64,linux/arm64 \
+     -f docker/Dockerfile.base \
+     -t europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/python-base:latest \
+     --push .
+   # grab the manifest sha256 from the push output and update MODULE.bazel,
+   # then: bazel mod tidy
+   ```
+   Size budget: python-base was 275 MB; +grpcio ≈ 40 MB → ~315 MB, still
+   inside the 500 MB Artifact Registry free tier.
+
+3. **Flip the flag in deploy** (web only, after #2 lands). In
+   `packages/biwenger_tools/web/BUILD.bazel` `extra_env` add
+   `"DATA_BACKEND": "firestore"`. Default in `web/config.py` stays `csv`
+   so local runs and tests keep their current behaviour unless overridden.
+
+4. **Cleanup PR (separate, after #1–3 are stable)**. Plan step 6:
+   - Delete the CSV branches from `routes/main.py` and `routes/season.py`,
+     plus `_load_messages` and the `repository`-vs-inline duplication.
+   - Drop `biwenger-tools-sa-regional` secret (Drive SA no longer needed —
+     Firestore uses ADC).
+   - Empty the Drive folder.
+   - Retire `core.sdk.gcp.{find_file_on_drive, upload_csv_to_drive,
+     download_csv_as_dict, get_sheets_data}` only if no consumer remains
+     (Sheets reads for `lloros_awards` still need it for now).
+   - Re-trim the unused entries from `docker/Dockerfile.base`.
+
+## Quick resume commands
+
+```bash
+cd /Users/jorge/Projects/lillorepo
+git fetch && git checkout feat/firestore-migration && git pull --ff-only
+
+# Re-verify Firestore is still good
+gcloud auth application-default print-access-token >/dev/null  # ADC sanity
+python3 scripts/backfill_firestore.py --dry-run                # parses ok?
+
+# Full test sweep + lint (should pass)
+bazel test //core:core_tests \
+  //packages/biwenger_tools/web:web_tests \
+  //packages/biwenger_tools/scraper_job:scraper_job_tests \
+  //packages/biwenger_tools/api:api_tests \
+  //packages/biwenger_tools/bot:bot_tests \
+  //packages/chucknorris_bot/bot:bot_tests
+bash scripts/lint.sh
+
+# Re-validate web reads against Firestore
+DATA_BACKEND=firestore FIRESTORE_PROJECT=biwenger-tools \
+  SESSION_COOKIE_SECURE=false PORT=8088 \
+  bazel run //packages/biwenger_tools/web:web_local
+```
+
+## Decisions taken (don't reopen)
+
+- Database location: regional `europe-southwest1`. Free tier; co-located
+  with Cloud Run.
+- Default `DATA_BACKEND=csv` so master stays safe; flag flips in deploy
+  config, not in code.
+- `fecha` stored as native Firestore timestamp, rendered back to the
+  display string `from_firestore` so templates and sorting keep working.
+- Clausulazo doc ids are a content hash (deterministic, idempotent), not
+  Firestore auto-ids — strictly stronger than the plan's `auto_id`.
+- Sheets reads (`lloros_awards`) stay on Sheets in v1; not part of this
+  migration.
+
+## Delete this file when
+
+The migration ships to prod (`DATA_BACKEND=firestore` in `web/BUILD.bazel`)
+and the cleanup PR has landed. Until then, this file is the single source
+of truth for what is half-done.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,7 +32,7 @@ oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 # Imagen base CON TODAS las dependencias preinstaladas (para producción)
 oci.pull(
     name = "python_with_deps",
-    digest = "sha256:8d2946bb92128c6a4e9873852068c81db1671c21c0875cc74d4ff6a11f9cbaad",
+    digest = "sha256:be8076cf7fa41e717db9f15590dd5169138929e75d33bc1f9e26a5f2cdad85a9",
     image = "europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/python-base",
     platforms = [
         "linux/amd64",

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -67,6 +67,16 @@ py_library(
     visibility = ["//visibility:public"],
 )
 
+py_library(
+    name = "firestore",
+    srcs = ["sdk/firestore.py"],
+    deps = [
+        ":_init",
+        "@pypi//google_cloud_firestore",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 # ------------------------------------------------------------------
 # Umbrella target — backward compat for existing //core references
 # ------------------------------------------------------------------
@@ -74,6 +84,7 @@ py_library(
     name = "core",
     deps = [
         ":biwenger",
+        ":firestore",
         ":gcp",
         ":jp",
         ":telegram",

--- a/core/domain/__init__.py
+++ b/core/domain/__init__.py
@@ -1,3 +1,9 @@
-from core.domain.models import Clausulazo, JusticeEntry, LeagueMessage, Participation
+from core.domain.models import (
+    Clausulazo,
+    JusticeEntry,
+    LeagueMessage,
+    Palmares,
+    Participation,
+)
 
-__all__ = ["LeagueMessage", "Participation", "Clausulazo", "JusticeEntry"]
+__all__ = ["LeagueMessage", "Participation", "Clausulazo", "JusticeEntry", "Palmares"]

--- a/core/domain/models.py
+++ b/core/domain/models.py
@@ -2,19 +2,81 @@
 Domain models for Biwenger Tools.
 
 These dataclasses define the data contracts that flow between services
-(scraper_job → CSV → web). CSV_FIELDS on each class is the canonical
-field order; from_csv_row()/to_csv_row() handle (de)serialization for
-csv.DictReader/csv.DictWriter, including fields encoded as joined
-strings or JSON in the CSV format.
+(scraper_job → store → web). Two serialization formats are supported:
+
+- **CSV** — the legacy Google Drive format. ``CSV_FIELDS`` is the canonical
+  column order; ``from_csv_row``/``to_csv_row`` handle fields encoded as
+  joined strings or JSON.
+- **Firestore** — ``from_firestore``/``to_firestore`` map a model to a
+  Firestore document. Native types are used where the CSV had to encode
+  (arrays instead of ``;``-joined strings, nested maps instead of JSON
+  strings, real timestamps instead of ``dd-MM-YYYY`` text).
+
+The dataclass field types are the contract callers rely on; both formats
+(de)serialize to the *same* in-memory shape. In particular ``fecha`` is
+always a display string on the model — Firestore stores it as a native
+timestamp, but ``from_firestore`` renders it back to a string so templates
+and sorting code keep working unchanged.
 """
 
 import json
 from dataclasses import dataclass, field
-from typing import ClassVar, Tuple
+from datetime import datetime
+from typing import ClassVar, Optional, Tuple
+
+from core.constants import MADRID_TZ
+
+# Date formats seen across the legacy CSVs, most specific first.
+# comunicados uses seconds; clausulazos does not.
+_FECHA_FORMATS: Tuple[str, ...] = (
+    "%d-%m-%Y %H:%M:%S",
+    "%d-%m-%Y %H:%M",
+    "%d/%m/%Y",
+    "%Y-%m-%d",
+)
 
 
 def _split_ids(raw: str) -> list:
     return raw.split(";") if raw else []
+
+
+def _parse_fecha(raw) -> Optional[datetime]:
+    """Parse a legacy date string into a Madrid-tz datetime.
+
+    Returns None when the value is empty or matches no known format — the
+    caller decides what to store as a fallback.
+    """
+    if not raw or not isinstance(raw, str):
+        return None
+    for fmt in _FECHA_FORMATS:
+        try:
+            return datetime.strptime(raw, fmt).replace(tzinfo=MADRID_TZ)
+        except (ValueError, TypeError):
+            continue
+    return None
+
+
+def _format_fecha(value, fmt: str) -> str:
+    """Render a Firestore timestamp as a display string in Madrid time.
+
+    Passes strings through untouched so the function is safe to call on a
+    value that was never converted to a timestamp.
+    """
+    if not value:
+        return ""
+    if isinstance(value, str):
+        return value
+    return value.astimezone(MADRID_TZ).strftime(fmt)
+
+
+def _fecha_for_firestore(raw: str):
+    """Convert a display date string to a value for a Firestore document.
+
+    Returns a timezone-aware datetime when the string parses (Firestore
+    stores it as a native timestamp), otherwise the raw string so no data
+    is silently lost.
+    """
+    return _parse_fecha(raw) or raw
 
 
 @dataclass
@@ -36,6 +98,8 @@ class LeagueMessage:
         "contenido",
         "categoria",
     )
+    # Display format for `fecha` when read back from a Firestore timestamp.
+    _FECHA_FMT: ClassVar[str] = "%d-%m-%Y %H:%M:%S"
 
     @classmethod
     def from_csv_row(cls, row: dict) -> "LeagueMessage":
@@ -45,6 +109,28 @@ class LeagueMessage:
         return {
             "id_hash": self.id_hash,
             "fecha": self.fecha,
+            "autor": self.autor,
+            "titulo": self.titulo,
+            "contenido": self.contenido,
+            "categoria": self.categoria,
+        }
+
+    @classmethod
+    def from_firestore(cls, doc_id: str, data: dict) -> "LeagueMessage":
+        """Build from a Firestore doc. The doc id is the `id_hash`."""
+        return cls(
+            id_hash=doc_id,
+            fecha=_format_fecha(data.get("fecha"), cls._FECHA_FMT),
+            autor=data.get("autor", ""),
+            titulo=data.get("titulo", ""),
+            contenido=data.get("contenido", ""),
+            categoria=data.get("categoria", ""),
+        )
+
+    def to_firestore(self) -> dict:
+        """Document fields. The `id_hash` is the doc id, not a field."""
+        return {
+            "fecha": _fecha_for_firestore(self.fecha),
             "autor": self.autor,
             "titulo": self.titulo,
             "contenido": self.contenido,
@@ -89,6 +175,30 @@ class Participation:
             "cronicas": ";".join(self.cronicas),
         }
 
+    @classmethod
+    def from_firestore(cls, doc_id: str, data: dict) -> "Participation":
+        """Build from a Firestore doc. The doc id is the `autor`."""
+        return cls(
+            autor=doc_id,
+            comunicados=list(data.get("comunicados", [])),
+            datos=list(data.get("datos", [])),
+            cesiones=list(data.get("cesiones", [])),
+            cronicas=list(data.get("cronicas", [])),
+        )
+
+    def to_firestore(self) -> dict:
+        """Document fields — native arrays, plus a derived `total` for queries.
+
+        The `autor` is the doc id, not a field.
+        """
+        return {
+            "comunicados": self.comunicados,
+            "datos": self.datos,
+            "cesiones": self.cesiones,
+            "cronicas": self.cronicas,
+            "total": self.total,
+        }
+
     @property
     def total(self) -> int:
         return (
@@ -116,6 +226,8 @@ class Clausulazo:
         "equipo_comprador",
         "precio",
     )
+    # clausulazos timestamps carry no seconds.
+    _FECHA_FMT: ClassVar[str] = "%d-%m-%Y %H:%M"
 
     @classmethod
     def from_csv_row(cls, row: dict) -> "Clausulazo":
@@ -130,6 +242,27 @@ class Clausulazo:
     def to_csv_row(self) -> dict:
         return {
             "fecha": self.fecha,
+            "jugador": self.jugador,
+            "equipo_vendedor": self.equipo_vendedor,
+            "equipo_comprador": self.equipo_comprador,
+            "precio": self.precio,
+        }
+
+    @classmethod
+    def from_firestore(cls, doc_id: str, data: dict) -> "Clausulazo":
+        """Build from a Firestore doc. Clausulazos use auto-ids — `doc_id`
+        is not part of the model and is ignored."""
+        return cls(
+            fecha=_format_fecha(data.get("fecha"), cls._FECHA_FMT),
+            jugador=data.get("jugador", ""),
+            equipo_vendedor=data.get("equipo_vendedor", ""),
+            equipo_comprador=data.get("equipo_comprador", ""),
+            precio=int(data.get("precio", 0) or 0),
+        )
+
+    def to_firestore(self) -> dict:
+        return {
+            "fecha": _fecha_for_firestore(self.fecha),
             "jugador": self.jugador,
             "equipo_vendedor": self.equipo_vendedor,
             "equipo_comprador": self.equipo_comprador,
@@ -183,3 +316,103 @@ class JusticeEntry:
             "hechos": json.dumps(self.hechos, ensure_ascii=False),
             "recibidos": json.dumps(self.recibidos, ensure_ascii=False),
         }
+
+    @staticmethod
+    def _pairs_to_maps(pairs: list) -> list:
+        """[[team, count], ...] → [{"team": team, "count": count}, ...]."""
+        return [{"team": t, "count": int(c)} for t, c in pairs]
+
+    @staticmethod
+    def _maps_to_pairs(maps: list) -> list:
+        """[{"team": team, "count": count}, ...] → [[team, count], ...]."""
+        return [[m.get("team", ""), int(m.get("count", 0))] for m in maps]
+
+    @classmethod
+    def from_firestore(cls, doc_id: str, data: dict) -> "JusticeEntry":
+        """Build from a Firestore doc. The doc id is the `equipo`."""
+        return cls(
+            equipo=doc_id,
+            total_hechos=int(data.get("total_hechos", 0) or 0),
+            total_recibidos=int(data.get("total_recibidos", 0) or 0),
+            punto_de_mira=data.get("punto_de_mira", "—"),
+            mayor_agresor=data.get("mayor_agresor", "—"),
+            hechos=cls._maps_to_pairs(data.get("hechos", [])),
+            recibidos=cls._maps_to_pairs(data.get("recibidos", [])),
+        )
+
+    def to_firestore(self) -> dict:
+        """Document fields — `hechos`/`recibidos` as native arrays of maps
+        instead of the JSON-stringified mess the CSV needed. The `equipo`
+        is the doc id, not a field."""
+        return {
+            "total_hechos": self.total_hechos,
+            "total_recibidos": self.total_recibidos,
+            "punto_de_mira": self.punto_de_mira,
+            "mayor_agresor": self.mayor_agresor,
+            "hechos": self._pairs_to_maps(self.hechos),
+            "recibidos": self._pairs_to_maps(self.recibidos),
+        }
+
+
+@dataclass
+class Palmares:
+    """Historical honours for a single season.
+
+    The legacy ``palmares.csv`` stores one ``temporada,categoria,valor`` row
+    per honour, so a season spans several rows; ``multa`` in particular
+    appears more than once. This model collapses a season into one document
+    — the shape Firestore stores under ``palmares/{temporada}``.
+    """
+
+    temporada: str
+    campeon: str = ""
+    subcampeon: str = ""
+    tercero: str = ""
+    farolillo: str = ""
+    multas: list = field(default_factory=list)
+    puntuacion: str = ""
+    record_puntos: str = ""
+    jornadas_ganadas: str = ""
+
+    FIRESTORE_FIELDS: ClassVar[Tuple[str, ...]] = (
+        "campeon",
+        "subcampeon",
+        "tercero",
+        "farolillo",
+        "puntuacion",
+        "record_puntos",
+        "jornadas_ganadas",
+    )
+
+    @classmethod
+    def from_csv_rows(cls, rows: list) -> list["Palmares"]:
+        """Collapse the flat ``temporada,categoria,valor`` CSV into one
+        ``Palmares`` per season. Unknown categories are ignored by the
+        caller's discretion — log them at the call site if needed."""
+        by_season: dict[str, "Palmares"] = {}
+        for row in rows:
+            temporada = (row.get("temporada") or "").strip()
+            categoria = (row.get("categoria") or "").strip()
+            valor = (row.get("valor") or "").strip()
+            if not temporada or not categoria:
+                continue
+            entry = by_season.setdefault(temporada, cls(temporada=temporada))
+            if categoria == "multa":
+                entry.multas.append(valor)
+            elif categoria in cls.FIRESTORE_FIELDS:
+                setattr(entry, categoria, valor)
+        return list(by_season.values())
+
+    @classmethod
+    def from_firestore(cls, doc_id: str, data: dict) -> "Palmares":
+        """Build from a Firestore doc. The doc id is the `temporada`."""
+        entry = cls(temporada=doc_id, multas=list(data.get("multas", [])))
+        for f in cls.FIRESTORE_FIELDS:
+            setattr(entry, f, data.get(f, ""))
+        return entry
+
+    def to_firestore(self) -> dict:
+        """Document fields. The `temporada` is the doc id, not a field."""
+        doc = {f: getattr(self, f) for f in self.FIRESTORE_FIELDS}
+        doc["multas"] = self.multas
+        return doc

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -3,6 +3,7 @@ requests
 google-api-python-client
 google-auth-oauthlib
 google-auth
+google-cloud-firestore
 python-dateutil
 python-json-logger
 

--- a/core/sdk/firestore.py
+++ b/core/sdk/firestore.py
@@ -1,0 +1,154 @@
+"""Thin Firestore CRUD helpers.
+
+Wraps the ``google-cloud-firestore`` client with the minimal surface used
+across packages (scraper writes, web reads, the one-shot backfill script).
+
+Authentication is via Application Default Credentials:
+- In Cloud Run the runtime service account is picked up automatically.
+- Locally, run ``gcloud auth application-default login`` once.
+
+No service-account key file is needed — unlike the Drive SDK in
+``core/sdk/gcp.py``, which still mounts a key. That is the whole point of
+moving the data layer to Firestore: ADC removes the key-file dependency.
+
+Collection paths are passed as ``/``-joined strings, e.g.
+``comunicados/25-26/messages`` (a subcollection). Firestore requires an odd
+number of path segments for a collection reference; the helpers below do not
+validate that — callers build the paths.
+"""
+
+import os
+from typing import Iterable, Iterator, Optional
+
+from google.cloud import firestore
+
+from core.utils import get_logger
+
+logger = get_logger(__name__)
+
+# Firestore caps a single WriteBatch at 500 operations.
+_BATCH_LIMIT = 500
+
+_client: Optional[firestore.Client] = None
+
+
+def get_client() -> firestore.Client:
+    """Return a process-wide Firestore client, created lazily.
+
+    The GCP project is read from ``FIRESTORE_PROJECT`` or
+    ``GOOGLE_CLOUD_PROJECT`` when set; otherwise it is inferred from the
+    ambient ADC credentials (the normal case inside Cloud Run).
+    """
+    global _client
+    if _client is None:
+        project = os.getenv("FIRESTORE_PROJECT") or os.getenv("GOOGLE_CLOUD_PROJECT")
+        _client = firestore.Client(project=project) if project else firestore.Client()
+        logger.info("Firestore client initialised.", extra={"project": _client.project})
+    return _client
+
+
+def get_document(collection_path: str, doc_id: str) -> Optional[dict]:
+    """Return a single document as a dict, or None if it does not exist."""
+    snapshot = get_client().collection(collection_path).document(doc_id).get()
+    return snapshot.to_dict() if snapshot.exists else None
+
+
+def set_document(
+    collection_path: str, doc_id: str, data: dict, merge: bool = False
+) -> None:
+    """Create or overwrite a document. With ``merge=True`` only the given
+    fields are updated, leaving the rest of the document untouched."""
+    get_client().collection(collection_path).document(doc_id).set(data, merge=merge)
+
+
+def list_documents(collection_path: str) -> Iterator[tuple[str, dict]]:
+    """Stream every document in a collection as ``(doc_id, data)`` pairs."""
+    for snapshot in get_client().collection(collection_path).stream():
+        yield snapshot.id, (snapshot.to_dict() or {})
+
+
+def query(
+    collection_path: str,
+    field: Optional[str] = None,
+    op: str = "==",
+    value=None,
+    order_by: Optional[str] = None,
+    direction: str = "ASCENDING",
+    limit: Optional[int] = None,
+) -> list[dict]:
+    """Run a simple single-clause query and return the matching documents.
+
+    With no ``field`` this is just a (optionally ordered/limited) collection
+    scan. ``direction`` is ``"ASCENDING"`` or ``"DESCENDING"``.
+    """
+    ref = get_client().collection(collection_path)
+    if field is not None:
+        ref = ref.where(filter=firestore.FieldFilter(field, op, value))
+    if order_by is not None:
+        ref = ref.order_by(order_by, direction=direction)
+    if limit is not None:
+        ref = ref.limit(limit)
+    return [snapshot.to_dict() or {} for snapshot in ref.stream()]
+
+
+def count(collection_path: str) -> int:
+    """Return the document count of a collection via an aggregation query.
+
+    Aggregation counts are billed as a tiny fixed number of reads regardless
+    of collection size — cheap, and well inside the free tier. Used by the
+    backfill script to verify parity with the source CSVs.
+    """
+    result = get_client().collection(collection_path).count().get()
+    # The client returns a list of AggregationResult rows.
+    return int(result[0][0].value)
+
+
+def batch_write(collection_path: str, docs: Iterable[tuple[str, dict]]) -> int:
+    """Bulk-write ``(doc_id, data)`` pairs, chunked under the 500-op batch cap.
+
+    Each write is a ``set`` (full overwrite), so re-running with the same doc
+    ids is idempotent. Returns the number of documents written.
+    """
+    client = get_client()
+    collection = client.collection(collection_path)
+    written = 0
+    batch = client.batch()
+    pending = 0
+    for doc_id, data in docs:
+        batch.set(collection.document(doc_id), data)
+        pending += 1
+        written += 1
+        if pending >= _BATCH_LIMIT:
+            batch.commit()
+            batch = client.batch()
+            pending = 0
+    if pending:
+        batch.commit()
+    logger.info(
+        "Batch write committed.",
+        extra={"collection": collection_path, "count": written},
+    )
+    return written
+
+
+def delete_collection(collection_path: str, page_size: int = _BATCH_LIMIT) -> int:
+    """Delete every document in a collection. Returns the number deleted.
+
+    Used by tests and to make the backfill safely re-runnable. Note this does
+    not recurse into subcollections — Firestore keeps those independent.
+    """
+    client = get_client()
+    collection = client.collection(collection_path)
+    deleted = 0
+    while True:
+        snapshots = list(collection.limit(page_size).stream())
+        if not snapshots:
+            break
+        batch = client.batch()
+        for snapshot in snapshots:
+            batch.delete(snapshot.reference)
+        batch.commit()
+        deleted += len(snapshots)
+        if len(snapshots) < page_size:
+            break
+    return deleted

--- a/core/tests/test_domain_models.py
+++ b/core/tests/test_domain_models.py
@@ -1,6 +1,16 @@
-"""Round-trip tests for domain models (CSV serialization)."""
+"""Round-trip tests for domain models (CSV and Firestore serialization)."""
 
-from core.domain.models import Clausulazo, JusticeEntry, LeagueMessage, Participation
+from datetime import datetime
+
+from core.constants import MADRID_TZ
+from core.domain.models import (
+    Clausulazo,
+    JusticeEntry,
+    LeagueMessage,
+    Palmares,
+    Participation,
+    _parse_fecha,
+)
 
 
 def test_league_message_roundtrip():
@@ -91,3 +101,140 @@ def test_justice_entry_handles_missing_optional_fields():
     assert parsed.total_hechos == 5
     assert parsed.total_recibidos == 0
     assert parsed.hechos == []
+
+
+# --- Firestore serialization ---------------------------------------------
+
+
+def test_parse_fecha_known_formats():
+    """Both legacy date formats parse; unknown input yields None."""
+    assert _parse_fecha("01-06-2025 10:00:00") == datetime(
+        2025, 6, 1, 10, 0, 0, tzinfo=MADRID_TZ
+    )
+    assert _parse_fecha("11-05-2026 00:18") == datetime(
+        2026, 5, 11, 0, 18, tzinfo=MADRID_TZ
+    )
+    assert _parse_fecha("not a date") is None
+    assert _parse_fecha("") is None
+
+
+def test_league_message_firestore_roundtrip():
+    """`fecha` is stored as a native timestamp and rendered back to a string;
+    the doc id carries the `id_hash`, so it is not a document field."""
+    msg = LeagueMessage(
+        id_hash="abc123",
+        fecha="01-01-2025 10:00:00",
+        autor="Jorge",
+        titulo="Título",
+        contenido="<p>cuerpo</p>",
+        categoria="comunicado",
+    )
+    doc = msg.to_firestore()
+    assert "id_hash" not in doc
+    assert isinstance(doc["fecha"], datetime)
+    parsed = LeagueMessage.from_firestore("abc123", doc)
+    assert parsed == msg
+
+
+def test_league_message_from_firestore_handles_missing_fields():
+    parsed = LeagueMessage.from_firestore("h1", {})
+    assert parsed.id_hash == "h1"
+    assert parsed.fecha == ""
+    assert parsed.categoria == ""
+
+
+def test_participation_firestore_roundtrip():
+    """Firestore keeps native arrays plus a derived `total` for queries."""
+    p = Participation(
+        autor="Jorge",
+        comunicados=["id1", "id2"],
+        datos=["id3"],
+        cesiones=[],
+        cronicas=["id4"],
+    )
+    doc = p.to_firestore()
+    assert doc["comunicados"] == ["id1", "id2"]
+    assert doc["total"] == 4
+    assert "autor" not in doc
+    parsed = Participation.from_firestore("Jorge", doc)
+    assert parsed == p
+
+
+def test_clausulazo_firestore_roundtrip():
+    """clausulazos timestamps carry no seconds — the minute-precision format
+    must round-trip exactly."""
+    c = Clausulazo(
+        fecha="11-05-2026 00:18",
+        jugador="Ionut Radu",
+        equipo_vendedor="La Luceneta",
+        equipo_comprador="Ferraz fc",
+        precio=6_475_000,
+    )
+    doc = c.to_firestore()
+    assert isinstance(doc["fecha"], datetime)
+    parsed = Clausulazo.from_firestore("auto-id-ignored", doc)
+    assert parsed == c
+
+
+def test_justice_entry_firestore_roundtrip():
+    """hechos/recibidos move from JSON-stringified CSV cells to native arrays
+    of maps."""
+    entry = JusticeEntry(
+        equipo="Ferraz fc",
+        total_hechos=3,
+        total_recibidos=1,
+        punto_de_mira="Rayo Entrebirras",
+        mayor_agresor="Kairat FC",
+        hechos=[["Rayo Entrebirras", 2], ["Kairat FC", 1]],
+        recibidos=[["Kairat FC", 1]],
+    )
+    doc = entry.to_firestore()
+    assert doc["hechos"] == [
+        {"team": "Rayo Entrebirras", "count": 2},
+        {"team": "Kairat FC", "count": 1},
+    ]
+    assert "equipo" not in doc
+    parsed = JusticeEntry.from_firestore("Ferraz fc", doc)
+    assert parsed == entry
+
+
+def test_palmares_from_csv_rows_collapses_seasons():
+    """The flat temporada/categoria/valor CSV collapses to one model per
+    season; `multa` appears twice and lands in the `multas` array."""
+    rows = [
+        {"temporada": "2024-2025", "categoria": "campeon", "valor": "Fabio"},
+        {"temporada": "2024-2025", "categoria": "subcampeon", "valor": "Jorge"},
+        {"temporada": "2024-2025", "categoria": "multa", "valor": "Alberto"},
+        {"temporada": "2024-2025", "categoria": "multa", "valor": "Lucen"},
+        {"temporada": "2024-2025", "categoria": "farolillo", "valor": "Rubén"},
+        {"temporada": "2024-2025", "categoria": "record_puntos", "valor": "112 @fabio"},
+        {"temporada": "", "categoria": "campeon", "valor": "ignored"},
+    ]
+    seasons = Palmares.from_csv_rows(rows)
+    assert len(seasons) == 1
+    p = seasons[0]
+    assert p.temporada == "2024-2025"
+    assert p.campeon == "Fabio"
+    assert p.subcampeon == "Jorge"
+    assert p.farolillo == "Rubén"
+    assert p.multas == ["Alberto", "Lucen"]
+    assert p.record_puntos == "112 @fabio"
+
+
+def test_palmares_firestore_roundtrip():
+    p = Palmares(
+        temporada="2023-2024",
+        campeon="Jorge",
+        subcampeon="Fabio",
+        tercero="Albert",
+        farolillo="Javi",
+        multas=["Rubén", "Lucen"],
+        puntuacion="sofascore",
+        record_puntos="101 @fabio",
+        jornadas_ganadas="18 @jorge",
+    )
+    doc = p.to_firestore()
+    assert "temporada" not in doc
+    assert doc["multas"] == ["Rubén", "Lucen"]
+    parsed = Palmares.from_firestore("2023-2024", doc)
+    assert parsed == p

--- a/core/tests/test_firestore_sdk.py
+++ b/core/tests/test_firestore_sdk.py
@@ -1,0 +1,90 @@
+"""Tests for core/sdk/firestore.py.
+
+These exercise the real Firestore client against the local emulator, so the
+whole module is skipped unless ``FIRESTORE_EMULATOR_HOST`` is set. To run them:
+
+    gcloud emulators firestore start --host-port=localhost:8080
+    FIRESTORE_EMULATOR_HOST=localhost:8080 FIRESTORE_PROJECT=test-project \\
+        bazel test //core:core_tests --test_output=streamed
+
+In CI (no emulator) they skip cleanly — the SDK is a thin wrapper, and the
+model-level serialization it depends on is covered by test_domain_models.py.
+"""
+
+import os
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("FIRESTORE_EMULATOR_HOST"),
+    reason="requires the Firestore emulator (set FIRESTORE_EMULATOR_HOST)",
+)
+
+
+@pytest.fixture
+def collection():
+    """A unique, empty collection path; wiped after the test."""
+    from core.sdk import firestore
+
+    os.environ.setdefault("FIRESTORE_PROJECT", "test-project")
+    path = f"_it_{uuid.uuid4().hex}"
+    yield path
+    firestore.delete_collection(path)
+
+
+def test_set_and_get_document(collection):
+    from core.sdk import firestore
+
+    firestore.set_document(collection, "doc1", {"name": "Jorge", "n": 7})
+    assert firestore.get_document(collection, "doc1") == {"name": "Jorge", "n": 7}
+    assert firestore.get_document(collection, "missing") is None
+
+
+def test_set_document_merge(collection):
+    from core.sdk import firestore
+
+    firestore.set_document(collection, "d", {"a": 1, "b": 2})
+    firestore.set_document(collection, "d", {"b": 99}, merge=True)
+    assert firestore.get_document(collection, "d") == {"a": 1, "b": 99}
+
+
+def test_batch_write_and_count(collection):
+    from core.sdk import firestore
+
+    docs = [(f"d{i}", {"i": i}) for i in range(1100)]  # spans the 500-op cap
+    written = firestore.batch_write(collection, docs)
+    assert written == 1100
+    assert firestore.count(collection) == 1100
+
+
+def test_list_documents(collection):
+    from core.sdk import firestore
+
+    firestore.batch_write(collection, [("a", {"v": 1}), ("b", {"v": 2})])
+    got = dict(firestore.list_documents(collection))
+    assert got == {"a": {"v": 1}, "b": {"v": 2}}
+
+
+def test_query_filter_and_order(collection):
+    from core.sdk import firestore
+
+    firestore.batch_write(
+        collection,
+        [
+            ("a", {"team": "X", "n": 3}),
+            ("b", {"team": "X", "n": 1}),
+            ("c", {"team": "Y", "n": 2}),
+        ],
+    )
+    only_x = firestore.query(collection, "team", "==", "X", order_by="n")
+    assert [d["n"] for d in only_x] == [1, 3]
+
+
+def test_delete_collection(collection):
+    from core.sdk import firestore
+
+    firestore.batch_write(collection, [(f"d{i}", {"i": i}) for i in range(10)])
+    deleted = firestore.delete_collection(collection)
+    assert deleted == 10
+    assert firestore.count(collection) == 0

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -25,13 +25,17 @@ RUN pip install --no-cache-dir \
     cryptography==48.0.0 \
     cycler==0.12.1 \
     flask==3.1.3 \
-    fonttools==4.62.1 \
+    fonttools==4.63.0 \
     google-api-core==2.30.3 \
     google-api-python-client==2.195.0 \
     google-auth==2.50.0 \
     google-auth-httplib2==0.3.1 \
     google-auth-oauthlib==1.3.1 \
+    google-cloud-core==2.6.0 \
+    google-cloud-firestore==2.27.0 \
     googleapis-common-protos==1.74.0 \
+    grpcio==1.80.0 \
+    grpcio-status==1.62.3 \
     gunicorn==26.0.0 \
     httplib2==0.31.2 \
     idna==3.13 \
@@ -40,7 +44,7 @@ RUN pip install --no-cache-dir \
     kiwisolver==1.5.0 \
     markupsafe==3.0.3 \
     matplotlib==3.10.9 \
-    numpy==2.4.4 \
+    numpy==2.4.6 \
     oauthlib==3.3.1 \
     packaging==26.2 \
     pillow==12.2.0 \

--- a/packages/biwenger_tools/api/BUILD.bazel
+++ b/packages/biwenger_tools/api/BUILD.bazel
@@ -5,6 +5,7 @@ python_service(
     package = "biwenger_tools",
     main = "app.py",
     repository = "europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/api",
+    secrets = [".env"],
     deps = [
         "@pypi//matplotlib",
         "@pypi//requests",

--- a/packages/biwenger_tools/api/requirements.txt
+++ b/packages/biwenger_tools/api/requirements.txt
@@ -1,5 +1,7 @@
-# All deps (flask, gunicorn, python-dotenv) are already
-# present in requirements_lock.txt via core/. No new additions needed.
+# api/requirements.txt
+# flask, gunicorn, python-dotenv come in via core/; matplotlib is api-only
+# (logic/image_formatter.py renders PNG tables for Telegram).
 Flask
 gunicorn
 python-dotenv
+matplotlib

--- a/packages/biwenger_tools/scraper_job/main.py
+++ b/packages/biwenger_tools/scraper_job/main.py
@@ -1,4 +1,10 @@
-"""Scraper job: fetch Biwenger messages and upload CSVs to Google Drive."""
+"""Scraper job: fetch Biwenger messages and dual-write CSV + Firestore.
+
+CSVs are uploaded to Google Drive (legacy path, served when
+``DATA_BACKEND=csv``) and the same data is mirrored into Firestore
+(read by the web when ``DATA_BACKEND=firestore``). After the flag flip
+and cleanup PR, the CSV path goes away.
+"""
 
 import csv
 import hashlib
@@ -11,6 +17,7 @@ from bs4 import BeautifulSoup
 
 from core.constants import MADRID_TZ
 from core.domain.models import Clausulazo, JusticeEntry, LeagueMessage, Participation
+from core.sdk import firestore
 from core.sdk.biwenger import BiwengerClient
 from core.sdk.gcp import (
     download_csv_as_dict,
@@ -120,6 +127,35 @@ def _write_and_upload_csv(
     )
 
 
+def _clausulazo_doc_id(c: Clausulazo) -> str:
+    """Deterministic Firestore doc id for a clausulazo — content hash.
+
+    Must match ``scripts/backfill_firestore.py::_clausulazo_id`` so the
+    scraper and the one-shot backfill produce identical doc ids for the
+    same transfer.
+    """
+    raw = "|".join(
+        str(v)
+        for v in (c.fecha, c.jugador, c.equipo_vendedor, c.equipo_comprador, c.precio)
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:20]
+
+
+def _write_to_firestore(collection: str, pairs: list[tuple[str, dict]]) -> None:
+    """Wipe + bulk-write a Firestore collection.
+
+    Mirrors the CSV-overwrite semantics: every scraper run reflects the
+    full latest state, so deletions on Biwenger propagate (a board message
+    removed upstream disappears from Firestore on the next run).
+    """
+    deleted = firestore.delete_collection(collection)
+    written = firestore.batch_write(collection, pairs)
+    logger.info(
+        "Firestore collection rewritten.",
+        extra={"collection": collection, "deleted": deleted, "written": written},
+    )
+
+
 def _upload_clausulazos(
     drive_service, biwenger: BiwengerClient, cfg, folder_id: str
 ) -> None:
@@ -131,7 +167,8 @@ def _upload_clausulazos(
     tabla_justicia = build_tabla_justicia(clausulazos)
     logger.info("Clausulazos processed.", extra={"count": len(clausulazos)})
 
-    clausulazos_filename = f"{cfg.CLAUSULAZOS_FILENAME_BASE}_{cfg.TEMPORADA_ACTUAL}.csv"
+    season = cfg.TEMPORADA_ACTUAL
+    clausulazos_filename = f"{cfg.CLAUSULAZOS_FILENAME_BASE}_{season}.csv"
     clausulazos_meta = find_file_on_drive(
         drive_service, clausulazos_filename, folder_id
     )
@@ -143,8 +180,12 @@ def _upload_clausulazos(
         clausulazos,
         clausulazos_meta["id"] if clausulazos_meta else None,
     )
+    _write_to_firestore(
+        f"clausulazos/{season}/transfers",
+        [(_clausulazo_doc_id(c), c.to_firestore()) for c in clausulazos],
+    )
 
-    tabla_filename = f"{cfg.TABLA_JUSTICIA_FILENAME_BASE}_{cfg.TEMPORADA_ACTUAL}.csv"
+    tabla_filename = f"{cfg.TABLA_JUSTICIA_FILENAME_BASE}_{season}.csv"
     tabla_meta = find_file_on_drive(drive_service, tabla_filename, folder_id)
     _write_and_upload_csv(
         drive_service,
@@ -154,7 +195,11 @@ def _upload_clausulazos(
         tabla_justicia,
         tabla_meta["id"] if tabla_meta else None,
     )
-    logger.info("Clausulazos and tabla_justicia CSVs uploaded.")
+    _write_to_firestore(
+        f"tabla_justicia/{season}/teams",
+        [(e.equipo, e.to_firestore()) for e in tabla_justicia if e.equipo],
+    )
+    logger.info("Clausulazos and tabla_justicia written to CSV + Firestore.")
 
 
 def _notify(text: str) -> None:
@@ -205,6 +250,7 @@ def main() -> None:
         new_count = len(new_messages)
         if new_messages:
             logger.info("New messages found.", extra={"count": new_count})
+            season = config.TEMPORADA_ACTUAL
             all_messages = sort_messages(all_messages + new_messages)
             _write_and_upload_csv(
                 drive_service,
@@ -214,17 +260,26 @@ def main() -> None:
                 all_messages,
                 existing_file_id,
             )
-            participacion_filename = f"participacion_{config.TEMPORADA_ACTUAL}.csv"
+            _write_to_firestore(
+                f"comunicados/{season}/messages",
+                [(m.id_hash, m.to_firestore()) for m in all_messages if m.id_hash],
+            )
+            participacion_filename = f"participacion_{season}.csv"
             part_meta = find_file_on_drive(
                 drive_service, participacion_filename, folder_id
             )
+            participaciones = process_participation(all_messages, user_map)
             _write_and_upload_csv(
                 drive_service,
                 folder_id,
                 participacion_filename,
                 Participation,
-                process_participation(all_messages, user_map),
+                participaciones,
                 part_meta["id"] if part_meta else None,
+            )
+            _write_to_firestore(
+                f"participacion/{season}/authors",
+                [(p.autor, p.to_firestore()) for p in participaciones if p.autor],
             )
         else:
             logger.info("No new messages found.")

--- a/packages/biwenger_tools/scraper_job/tests/test_main.py
+++ b/packages/biwenger_tools/scraper_job/tests/test_main.py
@@ -46,6 +46,8 @@ def mock_external_deps():
     ) as mock_download_csv, patch(
         "packages.biwenger_tools.scraper_job.main.upload_csv_to_drive"
     ) as mock_upload_csv, patch(
+        "packages.biwenger_tools.scraper_job.main.firestore"
+    ) as mock_firestore, patch(
         "packages.biwenger_tools.scraper_job.main.os.path.exists",
         return_value=True,
     ):
@@ -55,12 +57,17 @@ def mock_external_deps():
         mock_biwenger_instance.get_all_players_data_map.return_value = {}
         mock_biwenger_instance.get_all_clausulazos.return_value = {"data": []}
 
+        # Firestore helpers return ints; tests inspect the call sites, not values.
+        mock_firestore.delete_collection.return_value = 0
+        mock_firestore.batch_write.side_effect = lambda _coll, pairs: len(pairs)
+
         yield {
             "gservice": mock_gservice,
             "biwenger": mock_biwenger_instance,
             "find_file": mock_find_file,
             "download_csv": mock_download_csv,
             "upload_csv": mock_upload_csv,
+            "firestore": mock_firestore,
         }
 
 
@@ -95,6 +102,25 @@ def test_main_with_new_messages(mock_external_deps):
     call_args = mock_external_deps["upload_csv"].call_args_list[0]
     uploaded_content = call_args[0][3]
     assert "Un nuevo comunicado" in uploaded_content
+
+    # Dual-write: same 4 collections also land in Firestore.
+    firestore_collections = [
+        call.args[0]
+        for call in mock_external_deps["firestore"].batch_write.call_args_list
+    ]
+    assert firestore_collections == [
+        "comunicados/25-26/messages",
+        "participacion/25-26/authors",
+        "clausulazos/25-26/transfers",
+        "tabla_justicia/25-26/teams",
+    ]
+    # Firestore wipe-then-write contract: every batch_write is paired with
+    # a delete_collection on the same collection, in the same order.
+    deleted_collections = [
+        call.args[0]
+        for call in mock_external_deps["firestore"].delete_collection.call_args_list
+    ]
+    assert deleted_collections == firestore_collections
 
 
 def test_main_no_new_messages(mock_external_deps):
@@ -133,6 +159,17 @@ def test_main_no_new_messages(mock_external_deps):
     ]
     assert any("clausulazos" in name for name in uploaded_names)
     assert any("tabla_justicia" in name for name in uploaded_names)
+
+    # Same parity in Firestore: only clausulazos + tabla_justicia get
+    # rewritten when there are no new messages.
+    firestore_collections = [
+        call.args[0]
+        for call in mock_external_deps["firestore"].batch_write.call_args_list
+    ]
+    assert firestore_collections == [
+        "clausulazos/25-26/transfers",
+        "tabla_justicia/25-26/teams",
+    ]
 
 
 # --- Telegram notify on completion ---

--- a/packages/biwenger_tools/web/BUILD.bazel
+++ b/packages/biwenger_tools/web/BUILD.bazel
@@ -17,5 +17,9 @@ python_service(
         "TROFEOS_SHEET_ID_25_26": "1-ahWDHUby8KRXUZPdJqI302gnNEQTBcr1MQgqJOlk5Y",
         "GDRIVE_FOLDER_ID": "1DEY5pzf0iyZi3uxAFsjnE0tgVf8YiYI7",
         "GOOGLE_APPLICATION_CREDENTIALS": "/app/packages/biwenger_tools/web/biwenger-tools-sa.json",
+        # Flips the web off CSVs/Drive and onto Firestore. `web/config.py`
+        # still defaults to "csv" so `bazel run //...:web_local` and the
+        # tests stay on the unchanged path unless this env var is set.
+        "DATA_BACKEND": "firestore",
     },
 )

--- a/packages/biwenger_tools/web/config.py
+++ b/packages/biwenger_tools/web/config.py
@@ -61,6 +61,13 @@ ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD")
 GIT_COMMIT = os.getenv("GIT_COMMIT", "local")
 DEPLOY_TIME = os.getenv("DEPLOY_TIME", "")
 
+# --- DATA BACKEND (feature flag: CSV/Drive → Firestore migration) ---
+# "csv"       → legacy reads from Google Drive CSVs (the proven path).
+# "firestore" → reads from Firestore via routes → repository.py.
+# Defaults to "csv" so master stays safe until Firestore is validated; flip
+# by setting DATA_BACKEND=firestore in deploy.yml (or .env for local dev).
+DATA_BACKEND = os.getenv("DATA_BACKEND", "csv").strip().lower()
+
 # --- CONFIGURACIÓN NO CRÍTICA (valores fijos) ---
 MESSAGES_PER_PAGE = 7
 

--- a/packages/biwenger_tools/web/repository.py
+++ b/packages/biwenger_tools/web/repository.py
@@ -1,0 +1,81 @@
+"""Firestore-backed reads for the web app.
+
+This module holds only the ``firestore`` branch of the ``DATA_BACKEND``
+feature flag. The legacy CSV/Drive reads stay inline in the route modules
+(``routes/season.py``, ``routes/main.py``) until the flag is removed — that
+keeps the existing CSV code, and the tests that patch it, untouched during
+the migration.
+
+Every function returns the same domain models the CSV path produces, so the
+routes are backend-agnostic once they have the data. Collections mirror the
+layout written by ``scripts/backfill_firestore.py`` and the scraper:
+
+    comunicados/{season}/messages/{id_hash}
+    participacion/{season}/authors/{autor}
+    clausulazos/{season}/transfers/{id}
+    tabla_justicia/{season}/teams/{equipo}
+    palmares/{temporada}
+"""
+
+from datetime import datetime
+
+from core.domain.models import (
+    Clausulazo,
+    JusticeEntry,
+    LeagueMessage,
+    Palmares,
+    Participation,
+    _parse_fecha,
+)
+from core.sdk import firestore
+
+
+def _fecha_sort_key(fecha: str) -> datetime:
+    """Naive datetime sort key for a display date string.
+
+    Returns ``datetime.min`` when the value is empty or unparseable, and
+    strips tzinfo so parsed and fallback values stay mutually comparable.
+    """
+    parsed = _parse_fecha(fecha)
+    return parsed.replace(tzinfo=None) if parsed else datetime.min
+
+
+def get_messages(season: str) -> list[LeagueMessage]:
+    """All league messages for a season, most recent first.
+
+    Firestore returns documents unordered; the scraper used to hand the web a
+    pre-sorted CSV, so we re-sort here to preserve that contract.
+    """
+    docs = firestore.list_documents(f"comunicados/{season}/messages")
+    messages = [LeagueMessage.from_firestore(doc_id, data) for doc_id, data in docs]
+    messages.sort(key=lambda m: _fecha_sort_key(m.fecha), reverse=True)
+    return messages
+
+
+def get_participaciones(season: str) -> list[Participation]:
+    """Participation aggregates for a season (unordered — the route sorts)."""
+    docs = firestore.list_documents(f"participacion/{season}/authors")
+    return [Participation.from_firestore(doc_id, data) for doc_id, data in docs]
+
+
+def get_clausulazos(season: str) -> list[Clausulazo]:
+    """Release-clause transfers for a season, most recent first."""
+    docs = firestore.list_documents(f"clausulazos/{season}/transfers")
+    clausulazos = [Clausulazo.from_firestore(doc_id, data) for doc_id, data in docs]
+    clausulazos.sort(key=lambda c: _fecha_sort_key(c.fecha), reverse=True)
+    return clausulazos
+
+
+def get_tabla_justicia(season: str) -> list[JusticeEntry]:
+    """Justice table for a season, ordered by attacks made (descending) —
+    the same order the scraper wrote into the CSV."""
+    docs = firestore.list_documents(f"tabla_justicia/{season}/teams")
+    tabla = [JusticeEntry.from_firestore(doc_id, data) for doc_id, data in docs]
+    tabla.sort(key=lambda e: e.total_hechos, reverse=True)
+    return tabla
+
+
+def get_palmares() -> list[Palmares]:
+    """All historical honours (unordered — the route sorts by season)."""
+    docs = firestore.list_documents("palmares")
+    return [Palmares.from_firestore(doc_id, data) for doc_id, data in docs]

--- a/packages/biwenger_tools/web/routes/main.py
+++ b/packages/biwenger_tools/web/routes/main.py
@@ -7,7 +7,7 @@ from flask import Blueprint, Response, g, jsonify, redirect, render_template, ur
 
 from core.sdk.gcp import download_csv_as_dict, find_file_on_drive, get_sheets_data
 from core.utils import get_logger
-from packages.biwenger_tools.web import config, services
+from packages.biwenger_tools.web import config, repository, services
 
 logger = get_logger(__name__)
 bp = Blueprint("main", __name__)
@@ -32,9 +32,50 @@ def home() -> Response:
     return redirect(url_for("season.comunicados", season=g.season))
 
 
+def _palmares_firestore() -> str:
+    """Firestore-backed version of the palmares route.
+
+    Reshapes each `Palmares` document into the dict the template expects:
+    direct keys for the podium/season data and an `otros` list for the
+    "les toca pagar a" block (multas + farolillo).
+    """
+    error = None
+    sorted_seasons: list = []
+    try:
+        seasons_data: dict = {}
+        for p in repository.get_palmares():
+            otros = [{"tipo": "multa", "valor": m} for m in p.multas]
+            if p.farolillo:
+                otros.append({"tipo": "farolillo", "valor": p.farolillo})
+            seasons_data[p.temporada] = {
+                "campeon": p.campeon,
+                "subcampeon": p.subcampeon,
+                "tercero": p.tercero,
+                "puntuacion": p.puntuacion,
+                "record_puntos": p.record_puntos,
+                "jornadas_ganadas": p.jornadas_ganadas,
+                "otros": otros,
+            }
+        sorted_seasons = sorted(
+            seasons_data.items(), key=lambda item: item[0], reverse=True
+        )
+    except Exception:
+        error = "Ocurrió un error al cargar el palmarés."
+        logger.exception("Error loading palmares from Firestore.")
+
+    return render_template(
+        "palmares.html",
+        seasons=sorted_seasons,
+        error=error,
+        active_page="palmares",
+    )
+
+
 @bp.route("/palmares")
 def palmares() -> str:
     """Display historical records and awards."""
+    if config.DATA_BACKEND == "firestore":
+        return _palmares_firestore()
     seasons: dict = defaultdict(lambda: defaultdict(list))
     error = None
     sorted_seasons: list = []

--- a/packages/biwenger_tools/web/routes/season.py
+++ b/packages/biwenger_tools/web/routes/season.py
@@ -10,7 +10,7 @@ from flask import Blueprint, Response, g, jsonify, render_template, request
 from core.domain.models import Clausulazo, JusticeEntry, LeagueMessage, Participation
 from core.sdk.gcp import download_csv_as_dict, find_file_on_drive, get_sheets_data
 from core.utils import get_logger
-from packages.biwenger_tools.web import config, services
+from packages.biwenger_tools.web import config, repository, services
 from packages.biwenger_tools.web.sanitize import safe_html
 
 logger = get_logger(__name__)
@@ -42,9 +42,172 @@ def _load_messages(filename: str) -> tuple[list, Optional[str]]:
     return messages, None
 
 
+# --- Firestore backend ----------------------------------------------------
+# These companions back the `DATA_BACKEND=firestore` branch. The CSV route
+# bodies below are left untouched so the existing tests keep passing; the
+# whole CSV path is removed once the migration flag is retired.
+
+
+def _firestore_messages_sanitized(season: str) -> list:
+    """Fetch league messages from Firestore with `contenido` sanitized.
+
+    Mirrors `_load_messages` — sanitization is a presentation concern, so it
+    happens on read regardless of which backend stored the HTML.
+    """
+    messages = repository.get_messages(season)
+    for m in messages:
+        m.contenido = str(safe_html(m.contenido))
+    return messages
+
+
+def _comunicados_firestore(season: str) -> str:
+    """Firestore-backed version of the comunicados route."""
+    error = None
+    paginated_messages: list = []
+    comunicados_only: list = []
+    page = 1
+    total_pages = 1
+    try:
+        all_messages = _firestore_messages_sanitized(season)
+        comunicados_only = [
+            m for m in all_messages if m.categoria.strip() == "comunicado"
+        ]
+        page = request.args.get("page", 1, type=int)
+        start = (page - 1) * config.MESSAGES_PER_PAGE
+        paginated_messages = comunicados_only[start : start + config.MESSAGES_PER_PAGE]
+        total_pages = max(
+            1,
+            (len(comunicados_only) + config.MESSAGES_PER_PAGE - 1)
+            // config.MESSAGES_PER_PAGE,
+        )
+    except Exception:
+        error = f"Ocurrió un error al cargar los comunicados de la temporada {season}."
+        logger.exception(
+            "Error loading comunicados from Firestore.", extra={"season": season}
+        )
+    return render_template(
+        "index.html",
+        messages=paginated_messages,
+        all_comunicados=comunicados_only,
+        error=error,
+        active_page="comunicados",
+        current_page=page,
+        total_pages=total_pages,
+    )
+
+
+def _salseo_firestore(season: str) -> str:
+    """Firestore-backed version of the salseo route."""
+    error = None
+    clausulazos_error = None
+    datos_curiosos: list = []
+    cronicas: list = []
+    clausulazos: list = []
+    tabla_justicia: list = []
+    try:
+        all_messages = _firestore_messages_sanitized(season)
+        datos_curiosos = [m for m in all_messages if m.categoria.strip() == "dato"]
+        cronicas = [m for m in all_messages if m.categoria.strip() == "cronica"]
+    except Exception:
+        error = f"Ocurrió un error al cargar los datos de la temporada {season}."
+        logger.exception(
+            "Error loading salseo from Firestore.", extra={"season": season}
+        )
+    try:
+        clausulazos = repository.get_clausulazos(season)
+        tabla_justicia = [asdict(e) for e in repository.get_tabla_justicia(season)]
+    except Exception:
+        clausulazos_error = "Error al cargar clausulazos."
+        logger.exception(
+            "Error loading clausulazos from Firestore.", extra={"season": season}
+        )
+    return render_template(
+        "salseo.html",
+        datos=datos_curiosos,
+        cronicas=cronicas,
+        clausulazos=clausulazos,
+        tabla_justicia=tabla_justicia,
+        clausulazos_error=clausulazos_error,
+        error=error,
+        active_page="salseo",
+    )
+
+
+def _participacion_firestore(season: str) -> str:
+    """Firestore-backed version of the participacion route."""
+    error = None
+    stats: list = []
+    try:
+        participations = repository.get_participaciones(season)
+        stats = [
+            {
+                "autor": p.autor,
+                "comunicados": len(p.comunicados),
+                "datos": len(p.datos),
+                "cesiones": len(p.cesiones),
+                "cronicas": len(p.cronicas),
+                "total": p.total,
+            }
+            for p in participations
+        ]
+        stats.sort(key=lambda item: item["total"], reverse=True)
+    except Exception:
+        error = (
+            f"Ocurrió un error al calcular las estadísticas de la temporada {season}."
+        )
+        logger.exception(
+            "Error loading participacion from Firestore.", extra={"season": season}
+        )
+    return render_template(
+        "participacion.html",
+        stats=stats,
+        error=error,
+        active_page="participacion",
+    )
+
+
+def _mercado_firestore(season: str) -> str:
+    """Firestore-backed version of the mercado route."""
+    clausulazos: list = []
+    tabla_justicia: list = []
+    error = None
+    try:
+        clausulazos = repository.get_clausulazos(season)
+        tabla_justicia = [asdict(e) for e in repository.get_tabla_justicia(season)]
+    except Exception:
+        error = (
+            "Ocurrió un error al cargar los datos del mercado"
+            f" de la temporada {season}."
+        )
+        logger.exception(
+            "Error loading mercado from Firestore.", extra={"season": season}
+        )
+
+    clausulazos_summary = None
+    if clausulazos:
+        # repository.get_clausulazos returns most-recent-first.
+        clausulazos_summary = {
+            "total": len(clausulazos),
+            "total_eur": sum(c.precio for c in clausulazos),
+            "max_clausulazo": max(clausulazos, key=lambda c: c.precio),
+            "ultimo": clausulazos[0],
+        }
+
+    return render_template(
+        "mercado.html",
+        clausulazos=clausulazos,
+        clausulazos_summary=clausulazos_summary,
+        tabla_justicia=tabla_justicia,
+        error=error,
+        active_page="mercado",
+    )
+
+
 @bp.route("/<season>/")
 def comunicados(season: str) -> str:
     """Display paginated announcements for a given season."""
+    if config.DATA_BACKEND == "firestore":
+        return _comunicados_firestore(g.season)
     error = None
     paginated_messages: list = []
     comunicados_only: list = []
@@ -89,6 +252,8 @@ def comunicados(season: str) -> str:
 @bp.route("/<season>/salseo")
 def salseo(season: str) -> str:
     """Display various categories of content for a given season."""
+    if config.DATA_BACKEND == "firestore":
+        return _salseo_firestore(g.season)
     error = None
     datos_curiosos: list = []
     cronicas: list = []
@@ -151,6 +316,8 @@ def salseo(season: str) -> str:
 @bp.route("/<season>/participacion")
 def participacion(season: str) -> str:
     """Display participation statistics for a given season."""
+    if config.DATA_BACKEND == "firestore":
+        return _participacion_firestore(g.season)
     error = None
     stats: list = []
     try:
@@ -196,6 +363,8 @@ def participacion(season: str) -> str:
 @bp.route("/<season>/mercado")
 def mercado(season: str) -> str:
     """Display transfers and justice table for a given season."""
+    if config.DATA_BACKEND == "firestore":
+        return _mercado_firestore(g.season)
     clausulazos: list = []
     tabla_justicia: list = []
     error = None

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ requests
 google-api-python-client
 google-auth-oauthlib
 google-auth
+google-cloud-firestore
 python-dateutil
 python-json-logger
 
@@ -21,12 +22,22 @@ unidecode
 beautifulsoup4
 python-dotenv
 
-# From: packages/biwenger_tools/teams_analyzer/requirements.txt
-# teams_analyzer/requirements.txt
+# From: packages/biwenger_tools/api/requirements.txt
+# api/requirements.txt
+# flask, gunicorn, python-dotenv come in via core/; matplotlib is api-only
+# (logic/image_formatter.py renders PNG tables for Telegram).
+Flask
+gunicorn
 python-dotenv
-requests
-unidecode
 matplotlib
+
+# From: packages/biwenger_tools/bot/requirements.txt
+# bot/requirements.txt
+# All deps (flask, gunicorn, python-dotenv, google-auth, requests) are already
+# present in requirements_lock.txt via core/ and web/. No new additions needed.
+Flask
+gunicorn
+python-dotenv
 
 # From: packages/biwenger_tools/web/requirements.txt
 # web/requirements.txt
@@ -39,3 +50,10 @@ gunicorn
 
 # Para el manejo de fechas y zonas horarias
 python-dateutil
+
+# From: packages/chucknorris_bot/bot/requirements.txt
+# All deps (flask, gunicorn, python-dotenv, requests) are already
+# present in requirements_lock.txt. No new additions needed.
+Flask
+gunicorn
+python-dotenv

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -32,12 +32,15 @@ flake8==7.3.0
     # via -r requirements.in
 flask==3.1.3
     # via -r requirements.in
-fonttools==4.62.1
+fonttools==4.63.0
     # via matplotlib
 freezegun==1.5.5
     # via -r requirements.in
-google-api-core==2.30.3
-    # via google-api-python-client
+google-api-core[grpc]==2.30.3
+    # via
+    #   google-api-python-client
+    #   google-cloud-core
+    #   google-cloud-firestore
 google-api-python-client==2.195.0
     # via -r requirements.in
 google-auth==2.50.0
@@ -47,11 +50,26 @@ google-auth==2.50.0
     #   google-api-python-client
     #   google-auth-httplib2
     #   google-auth-oauthlib
+    #   google-cloud-core
+    #   google-cloud-firestore
 google-auth-httplib2==0.3.1
     # via google-api-python-client
 google-auth-oauthlib==1.3.1
     # via -r requirements.in
+google-cloud-core==2.6.0
+    # via google-cloud-firestore
+google-cloud-firestore==2.27.0
+    # via -r requirements.in
 googleapis-common-protos==1.74.0
+    # via
+    #   google-api-core
+    #   grpcio-status
+grpcio==1.80.0
+    # via
+    #   google-api-core
+    #   google-cloud-firestore
+    #   grpcio-status
+grpcio-status==1.62.3
     # via google-api-core
 gunicorn==26.0.0
     # via -r requirements.in
@@ -80,7 +98,7 @@ mccabe==0.7.0
     # via flake8
 mypy-extensions==1.1.0
     # via black
-numpy==2.4.4
+numpy==2.4.6
     # via
     #   contourpy
     #   matplotlib
@@ -101,11 +119,15 @@ platformdirs==4.9.6
 pluggy==1.6.0
     # via pytest
 proto-plus==1.27.2
-    # via google-api-core
+    # via
+    #   google-api-core
+    #   google-cloud-firestore
 protobuf==7.34.1
     # via
     #   google-api-core
+    #   google-cloud-firestore
     #   googleapis-common-protos
+    #   grpcio-status
     #   proto-plus
 pyasn1==0.6.3
     # via pyasn1-modules
@@ -151,7 +173,9 @@ six==1.17.0
 soupsieve==2.8.3
     # via beautifulsoup4
 typing-extensions==4.15.0
-    # via beautifulsoup4
+    # via
+    #   beautifulsoup4
+    #   grpcio
 unidecode==1.4.0
     # via -r requirements.in
 uritemplate==4.2.0

--- a/scripts/backfill_firestore.py
+++ b/scripts/backfill_firestore.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""One-shot backfill: legacy CSVs → Firestore.
+
+Reads the league CSVs (the same files the scraper uploads to Google Drive)
+and bulk-writes them to the Firestore collections the web app will read.
+
+Idempotent: every target collection is wiped and rewritten on each run, so
+re-running is safe and produces the same result. Doc ids are natural keys
+(id_hash / autor / equipo / temporada) except clausulazos, which have no
+natural key and use a deterministic content hash.
+
+Collections written:
+
+    comunicados/{season}/messages/{id_hash}
+    participacion/{season}/authors/{autor}
+    clausulazos/{season}/transfers/{content_hash}
+    tabla_justicia/{season}/teams/{equipo}
+    palmares/{temporada}
+
+Usage (from the repo root):
+
+    gcloud auth application-default login          # once, sets up ADC
+    python3 scripts/backfill_firestore.py --csv-dir ~/Downloads/Biwenger
+
+    # dry run — parse and report counts, write nothing:
+    python3 scripts/backfill_firestore.py --dry-run
+"""
+
+import argparse
+import csv
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+# Make `core.*` importable when run as a plain script from the repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+DEFAULT_PROJECT = "biwenger-tools"
+DEFAULT_CSV_DIR = "~/Downloads/Biwenger"
+
+
+def _read_csv(path: Path) -> list[dict]:
+    with path.open(encoding="utf-8") as fh:
+        return list(csv.DictReader(fh))
+
+
+def _clausulazo_id(row: dict) -> str:
+    """Deterministic doc id for a clausulazo — content hash, so re-runs map
+    a given transfer to the same document."""
+    raw = "|".join(
+        str(row.get(k, ""))
+        for k in ("fecha", "jugador", "equipo_vendedor", "equipo_comprador", "precio")
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:20]
+
+
+def _discover(csv_dir: Path, base: str) -> dict[str, Path]:
+    """Map season → csv path for files named `{base}_{season}.csv`."""
+    found = {}
+    for path in sorted(csv_dir.glob(f"{base}_*.csv")):
+        season = path.stem[len(base) + 1 :]
+        found[season] = path
+    return found
+
+
+def backfill(csv_dir: Path, dry_run: bool) -> int:
+    """Run the backfill. Returns a process exit code (0 on full parity)."""
+    from core.domain.models import (
+        Clausulazo,
+        JusticeEntry,
+        LeagueMessage,
+        Palmares,
+        Participation,
+    )
+    from core.sdk import firestore
+
+    mismatches = 0
+
+    def _write(collection: str, pairs: list[tuple[str, dict]], expected: int) -> None:
+        """Wipe + rewrite a collection, then verify the doc count."""
+        nonlocal mismatches
+        if dry_run:
+            print(f"  [dry-run] {collection}: would write {len(pairs)} docs")
+            return
+        deleted = firestore.delete_collection(collection)
+        written = firestore.batch_write(collection, pairs)
+        actual = firestore.count(collection)
+        ok = actual == expected == written
+        flag = "OK" if ok else "MISMATCH"
+        print(
+            f"  {collection}: cleared {deleted}, wrote {written}, "
+            f"count {actual}, expected {expected}  [{flag}]"
+        )
+        if not ok:
+            mismatches += 1
+
+    # --- comunicados -------------------------------------------------------
+    for season, path in _discover(csv_dir, "comunicados").items():
+        rows = _read_csv(path)
+        msgs = [LeagueMessage.from_csv_row(r) for r in rows]
+        pairs = [(m.id_hash, m.to_firestore()) for m in msgs if m.id_hash]
+        _write(f"comunicados/{season}/messages", pairs, len(pairs))
+
+    # --- participacion -----------------------------------------------------
+    for season, path in _discover(csv_dir, "participacion").items():
+        rows = _read_csv(path)
+        parts = [Participation.from_csv_row(r) for r in rows]
+        pairs = [(p.autor, p.to_firestore()) for p in parts if p.autor]
+        _write(f"participacion/{season}/authors", pairs, len(pairs))
+
+    # --- clausulazos -------------------------------------------------------
+    for season, path in _discover(csv_dir, "clausulazos").items():
+        rows = _read_csv(path)
+        pairs = [
+            (_clausulazo_id(r), Clausulazo.from_csv_row(r).to_firestore())
+            for r in rows
+        ]
+        _write(f"clausulazos/{season}/transfers", pairs, len(pairs))
+
+    # --- tabla_justicia ----------------------------------------------------
+    for season, path in _discover(csv_dir, "tabla_justicia").items():
+        rows = _read_csv(path)
+        entries = [JusticeEntry.from_csv_row(r) for r in rows]
+        pairs = [(e.equipo, e.to_firestore()) for e in entries if e.equipo]
+        _write(f"tabla_justicia/{season}/teams", pairs, len(pairs))
+
+    # --- palmares (single flat CSV, multi-row per season) ------------------
+    palmares_path = csv_dir / "palmares.csv"
+    if palmares_path.exists():
+        rows = _read_csv(palmares_path)
+        seasons = Palmares.from_csv_rows(rows)
+        pairs = [(p.temporada, p.to_firestore()) for p in seasons]
+        _write("palmares", pairs, len(pairs))
+    else:
+        print(f"  palmares.csv not found in {csv_dir} — skipped")
+
+    return 1 if mismatches else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--csv-dir",
+        default=DEFAULT_CSV_DIR,
+        help=f"Directory holding the league CSVs (default: {DEFAULT_CSV_DIR})",
+    )
+    parser.add_argument(
+        "--project",
+        default=DEFAULT_PROJECT,
+        help=f"GCP project hosting Firestore (default: {DEFAULT_PROJECT})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse the CSVs and report counts without writing to Firestore",
+    )
+    args = parser.parse_args()
+
+    csv_dir = Path(args.csv_dir).expanduser()
+    if not csv_dir.is_dir():
+        print(f"ERROR: csv dir not found: {csv_dir}", file=sys.stderr)
+        return 2
+
+    os.environ.setdefault("FIRESTORE_PROJECT", args.project)
+
+    print(f"Backfill source : {csv_dir}")
+    print(f"Firestore project: {args.project}")
+    print(f"Mode             : {'DRY RUN' if args.dry_run else 'WRITE'}")
+    print("-" * 60)
+
+    code = backfill(csv_dir, args.dry_run)
+
+    print("-" * 60)
+    print("Backfill complete." if code == 0 else "Backfill finished WITH MISMATCHES.")
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

End-to-end Firestore migration for the web's data plane. Bundles every
step needed to flip CSVs → Firestore in prod, validate live, and then
delete the CSV path in a follow-up cleanup PR.

The branch carries 9 commits — listed in the order they should be read:

1. `chore: add google-cloud-firestore (and restore matplotlib in api)`
2. `feat: Firestore SDK + Palmares model + from/to_firestore helpers`
3. `feat: backfill script to seed Firestore from existing CSVs`
4. `feat: DATA_BACKEND flag enables Firestore reads in the web`
5. `docs: pickup notes for the in-progress Firestore migration`
6. `feat: scraper dual-write CSV + Firestore`
7. `chore: bump python-base digest with google-cloud-firestore + grpcio`
8. `feat(web): flip DATA_BACKEND=firestore in Cloud Run image`
9. `chore(api): include .env in local target`

## What changes

**Reads (web).** `DATA_BACKEND` env var picks between the CSV/Drive path
and the new Firestore path (`packages/biwenger_tools/web/repository.py`).
Default is `csv` in `web/config.py`; deploy.yml ships the image with
`DATA_BACKEND=firestore` baked into `extra_env`. Local runs and tests
stay on CSV unless the env var is set explicitly.

**Writes (scraper).** Every scraper run mirrors its four CSV uploads
into Firestore using the same wipe-then-write contract as the backfill
script, so deletions on Biwenger propagate (e.g. a board message
removed upstream disappears from Firestore on the next run):

```
comunicados/{season}/messages/{id_hash}
participacion/{season}/authors/{autor}
clausulazos/{season}/transfers/{content_hash}
tabla_justicia/{season}/teams/{equipo}
```

CSV writes are intentionally kept during the dual-write window — the
cleanup PR rips them out after a few days of validation.

**Infra.** `python-base` rebuilt and pushed multi-arch with
`google-cloud-firestore 2.27.0`, `google-cloud-core 2.6.0`,
`grpcio 1.80.0`, `grpcio-status 1.62.3`, plus the pip-compile bumps
(`fonttools 4.62→4.63`, `numpy 2.4.4→2.4.6`). `MODULE.bazel` digest
updated. Repo storage delta: ~+15 MB compressed, well inside the 500 MB
Artifact Registry free tier.

## Decisions taken

- **Wipe-then-write** in the scraper to match the CSV-overwrite semantics
  (Firestore stays a faithful mirror of what the scraper saw upstream).
- **`fecha` as native Firestore timestamp** with per-model display-format
  on read — preserves the strings the templates expect.
- **Clausulazo doc id = content hash** (deterministic, idempotent) instead
  of auto-id; the backfill and the scraper produce identical ids.
- **`palmares`** collapses multi-row-per-season into one doc per season;
  `multa` becomes an array.

## Test plan

- [x] `bash scripts/lint.sh` clean.
- [x] `bazel test //...` green (all 6 packages).
- [x] OCI images build against the new digest for `linux_amd64`.
- [x] Firestore backfilled and counts verified against CSV row counts
      (`scripts/backfill_firestore.py`).
- [x] Local web with `DATA_BACKEND=firestore` renders every page
      (`/24-25/`, `/25-26/{salseo,mercado,participacion}`, `/palmares`).
- [ ] After merge + deploy: post a new board message in Biwenger, force
      the scraper job from the admin panel, confirm the new doc lands in
      Firestore and the web shows it.

## Follow-up (separate PR)

- Delete the CSV branches from `routes/main.py` and `routes/season.py`
  + the inline CSV loaders.
- Drop `biwenger-tools-sa-regional` secret + the Drive service-account
  key mount in deploy.yml.
- Empty the Drive folder.
- Retire `core.sdk.gcp.{find_file_on_drive, upload_csv_to_drive,
  download_csv_as_dict}` once no consumer remains (Sheets reads for
  `ligas_especiales`/`trofeos` still need `get_sheets_data`).