### PR TITLE
fix(web): drop bogus GOOGLE_APPLICATION_CREDENTIALS so Firestore uses ADC

### DIFF
--- a/packages/biwenger_tools/web/BUILD.bazel
+++ b/packages/biwenger_tools/web/BUILD.bazel
@@ -16,7 +16,16 @@ python_service(
         "LIGAS_ESPECIALES_SHEET_ID_25_26": "1ZaFZtKLFc0K4Ku099x3iV20OBkLZz9BEvojZpyOP0es",
         "TROFEOS_SHEET_ID_25_26": "1-ahWDHUby8KRXUZPdJqI302gnNEQTBcr1MQgqJOlk5Y",
         "GDRIVE_FOLDER_ID": "1DEY5pzf0iyZi3uxAFsjnE0tgVf8YiYI7",
-        "GOOGLE_APPLICATION_CREDENTIALS": "/app/packages/biwenger_tools/web/biwenger-tools-sa.json",
+        # GOOGLE_APPLICATION_CREDENTIALS intentionally NOT set:
+        #   - Drive SDK gets its SA key path explicitly via `SERVICE_ACCOUNT_PATH`
+        #     in web/config.py → `/gdrive_sa/biwenger-tools-sa.json`
+        #     (mounted from Secret Manager in deploy.yml).
+        #   - Firestore SDK uses ADC (the Cloud Run compute SA), which has
+        #     Firestore access at project level.
+        # Setting GOOGLE_APPLICATION_CREDENTIALS to a path that only exists
+        # in the local image (where `secrets` are baked into the OCI tar)
+        # made the Firestore client try to load a non-existent file and
+        # crash every Firestore read.
         # Flips the web off CSVs/Drive and onto Firestore. `web/config.py`
         # still defaults to "csv" so `bazel run //...:web_local` and the
         # tests stay on the unchanged path unless this env var is set.


### PR DESCRIPTION
## Summary
Removes \`GOOGLE_APPLICATION_CREDENTIALS\` from the web's \`extra_env\` so the Firestore SDK falls back to ADC (the Cloud Run compute SA).

## Why
The image had \`GOOGLE_APPLICATION_CREDENTIALS=/app/packages/biwenger_tools/web/biwenger-tools-sa.json\`. That path only exists in the LOCAL OCI image, where \`secrets\` get baked into the tar via \`_code_with_secrets_layer\`. The GCP image uses \`_code_layer\` (no secrets) and the Drive SA key is mounted from Secret Manager at \`/gdrive_sa/biwenger-tools-sa.json\` instead.

The Drive SDK never noticed because \`web/config.py\` passes \`SERVICE_ACCOUNT_PATH = /gdrive_sa/...\` explicitly to \`get_google_service\`. The Firestore SDK, which respects \`GOOGLE_APPLICATION_CREDENTIALS\`, tried to load a non-existent file and crashed every read after PR #76 flipped \`DATA_BACKEND=firestore\`.

Symptom on the live web (post #76):

\`\`\`
Ocurrió un error al cargar los comunicados de la temporada 25-26.
\`\`\`

Cloud Run compute SA has Firestore access at project level by default, so ADC is enough.

## Test plan
- [x] \`bazel test //packages/biwenger_tools/web:web_tests\` green.
- [ ] After merge + deploy: refresh the web, comunicados/salseo/mercado/participacion render.