### PR TITLE
feat(web): server-side Firestore queries + composite index for messages

### DIFF
--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -1,0 +1,206 @@
+# Firestore — modelo de datos e índices
+
+Documento de referencia para la base de datos Firestore de `biwenger-tools`.
+Se mantiene a mano cuando añadas/cambies colecciones, campos o índices —
+no hay autogeneración.
+
+- **Proyecto GCP:** `biwenger-tools`
+- **Base de datos:** `(default)`, modo Native, regional **`europe-southwest1`**
+  (free tier, co-localizada con Cloud Run).
+- **Auth:** Application Default Credentials (ADC).
+  - En Cloud Run la SA de compute la coge automáticamente.
+  - Localmente: `gcloud auth application-default login` una vez.
+
+---
+
+## Colecciones
+
+```
+comunicados/{season}/messages/{id_hash}
+participacion/{season}/authors/{autor}
+clausulazos/{season}/transfers/{content_hash}
+tabla_justicia/{season}/teams/{equipo}
+palmares/{temporada}
+```
+
+Hay un documento "season" intermedio (`comunicados/{season}`,
+`participacion/{season}`, etc.) que está vacío — sólo existe como
+contenedor de la subcolección. Firestore lo crea implícitamente.
+
+Los modelos Python que sirializan/deserializan estos documentos viven en
+`core/domain/models.py` con métodos `to_firestore()` / `from_firestore()`.
+
+---
+
+## Esquemas
+
+### `comunicados/{season}/messages/{id_hash}` — `LeagueMessage`
+
+Comunicados, datos curiosos, crónicas y cesiones del muro de Biwenger.
+La categoría (`comunicado`, `dato`, `cronica`, `cesion`) está dentro del
+documento, no en el path — el mismo doc puede pasar de una sección a
+otra de la web sin moverse.
+
+| Campo       | Tipo                       | Notas |
+|-------------|----------------------------|-------|
+| `fecha`     | timestamp                  | Sirializa desde `dd-MM-YYYY HH:mm:ss` |
+| `autor`     | string                     | Nombre del manager |
+| `titulo`    | string                     | |
+| `contenido` | string                     | HTML; sanitizado en lectura por la web (`safe_html`) |
+| `categoria` | string                     | Enum: `comunicado` / `dato` / `cronica` / `cesion` |
+
+**Doc id:** SHA-256 hex del `(date + content)` original (calculado en
+`scraper_job/main.py::_process_new_messages`). Determinista — el mismo
+mensaje siempre tiene el mismo id, lo que hace el dual-write idempotente.
+
+### `participacion/{season}/authors/{autor}` — `Participation`
+
+Agregado por manager: qué mensajes ha posteado y de qué categoría. Lo
+recalcula el scraper en cada run (no se incrementa, se reescribe entero).
+
+| Campo         | Tipo            | Notas |
+|---------------|-----------------|-------|
+| `comunicados` | array&lt;string&gt; | IDs (`id_hash`) de los comunicados firmados |
+| `datos`       | array&lt;string&gt; | IDs de los datos curiosos |
+| `cesiones`    | array&lt;string&gt; | |
+| `cronicas`    | array&lt;string&gt; | |
+| `total`       | int             | Derivado (suma de longitudes); guardado en escritura para poder `order_by("total")` server-side |
+
+**Doc id:** el nombre del manager (`autor`).
+
+### `clausulazos/{season}/transfers/{content_hash}` — `Clausulazo`
+
+Transferencias ejecutadas vía cláusula de rescisión.
+
+| Campo               | Tipo       | Notas |
+|---------------------|------------|-------|
+| `fecha`             | timestamp  | Sirializa desde `dd-MM-YYYY HH:mm` (sin segundos) |
+| `jugador`           | string     | |
+| `equipo_vendedor`   | string     | |
+| `equipo_comprador`  | string     | |
+| `precio`            | int        | Euros (`6475000` = 6.4M); igual que en la API de Biwenger |
+
+**Doc id:** SHA-256[:20] del `fecha|jugador|equipo_vendedor|equipo_comprador|precio`
+(`scraper_job/main.py::_clausulazo_doc_id` y
+`scripts/backfill_firestore.py::_clausulazo_id`). Determinista — debe
+coincidir entre el scraper y la backfill para que reescribir sea no-op.
+
+### `tabla_justicia/{season}/teams/{equipo}` — `JusticeEntry`
+
+Resumen de "ataques" (clausulazos hechos/recibidos) por equipo.
+
+| Campo              | Tipo                            | Notas |
+|--------------------|---------------------------------|-------|
+| `total_hechos`     | int                             | Nº de clausulazos hechos por el equipo |
+| `total_recibidos`  | int                             | |
+| `punto_de_mira`    | string                          | Equipo al que más le clausula |
+| `mayor_agresor`    | string                          | Equipo que más le clausula |
+| `hechos`           | array&lt;map&lt;string,int&gt;&gt; | `[{team, count}, ...]` orden desc |
+| `recibidos`        | array&lt;map&lt;string,int&gt;&gt; | |
+
+**Doc id:** el nombre del equipo (`equipo`). El equipo placeholder de
+managers que se han ido se llama `Usuario` (convención de Biwenger).
+
+### `palmares/{temporada}` — `Palmares`
+
+Honores históricos. Un documento por temporada (`24-25`, `23-24`, ...).
+
+| Campo              | Tipo            | Notas |
+|--------------------|-----------------|-------|
+| `campeon`          | string          | |
+| `subcampeon`       | string          | |
+| `tercero`          | string          | |
+| `farolillo`        | string          | Último clasificado (paga multa) |
+| `puntuacion`       | string          | "Score (decisivo)" del campeón |
+| `record_puntos`    | string          | e.g. `"112 @fabio"` |
+| `jornadas_ganadas` | string          | |
+| `multas`           | array&lt;string&gt; | Quién paga multa (puede ser >1) |
+
+**Doc id:** la temporada (`24-25`, etc.). Orden alfabético DESC = orden
+cronológico DESC, así que `order_by("__name__")` da por ejemplo
+`["25-26", "24-25", "23-24"]`.
+
+---
+
+## Índices
+
+Firestore auto-indexa **cada campo de raíz** y **arrays** (membership) en
+sentido ascendente y descendente. **No** auto-indexa combinaciones de
+campos — esos son **índices compuestos** y hay que declararlos.
+
+### Auto (no hace falta nada)
+
+Todas las queries de "ordenar por un solo campo" funcionan sin tocar nada:
+
+| Colección                                 | Query                                          |
+|-------------------------------------------|------------------------------------------------|
+| `participacion/{season}/authors`          | `order_by("total", DESCENDING)`                |
+| `clausulazos/{season}/transfers`          | `order_by("fecha", DESCENDING)`                |
+| `tabla_justicia/{season}/teams`           | `order_by("total_hechos", DESCENDING)`         |
+| `palmares`                                | `order_by("__name__", DESCENDING)` (doc id)    |
+
+### Compuesto (declarado)
+
+| Collection group | Scope      | Campos                                              | Para qué |
+|------------------|------------|-----------------------------------------------------|----------|
+| `messages`       | COLLECTION | `categoria` ASC, `fecha` DESC                       | Paginar y filtrar comunicados / salseo (`get_messages_by_category`) sin escanear los ~2.800 mensajes |
+
+`queryScope: COLLECTION` hace que el índice aplique a **cada subcolección
+llamada `messages`** (una por temporada). Cuando se añada una temporada
+nueva, no hace falta crear otro índice.
+
+### Dónde están declarados
+
+`firestore.indexes.json` en la raíz del repo. Es la fuente de verdad
+declarativa.
+
+### Crear / actualizar índices
+
+```bash
+# Crear el índice de "messages" (idempotente — falla suave si ya existe)
+gcloud firestore indexes composite create \
+  --collection-group=messages \
+  --query-scope=COLLECTION \
+  --field-config=field-path=categoria,order=ascending \
+  --field-config=field-path=fecha,order=descending \
+  --project=biwenger-tools
+
+# Ver índices actuales
+gcloud firestore indexes composite list --project=biwenger-tools
+
+# Borrar uno por id (rara vez)
+gcloud firestore indexes composite delete <id> --project=biwenger-tools
+```
+
+Cuando una query pide un índice que no existe, Firestore devuelve
+`FAILED_PRECONDITION` con un link directo a la consola para crearlo. La
+construcción tarda de segundos a minutos según el tamaño de la
+colección.
+
+---
+
+## Dónde se lee y dónde se escribe
+
+| Operación | Fichero | Notas |
+|-----------|---------|-------|
+| Lecturas web | `packages/biwenger_tools/web/repository.py` | Cada función es una query inline — sin abstracción genérica |
+| Escrituras (scraper) | `packages/biwenger_tools/scraper_job/main.py` | Dual-write CSV + Firestore vía `_write_to_firestore` |
+| Backfill (one-shot) | `scripts/backfill_firestore.py` | Wipe + bulk-write desde los CSVs existentes |
+| SDK | `core/sdk/firestore.py` | Sólo helpers genéricos: `get_client`, `list_documents`, `set_document`, `query`, `count`, `batch_write`, `delete_collection` |
+
+---
+
+## Reads esperados por página
+
+Con el modelo + índices actuales, en visita normal:
+
+| Página | Reads |
+|--------|-------|
+| `/<season>/` (comunicados) | 1 count + 7 page = **~8** |
+| `/<season>/` con buscador activo | +~530 (sólo la primera vez por sesión, vía `comunicados/search-data`) |
+| `/<season>/salseo` | ~600 (datos + crónicas + clausulazos + tabla_justicia) |
+| `/<season>/participacion` | ~7 |
+| `/<season>/mercado` | ~111 |
+| `/palmares` | ~3 |
+
+Free tier: 50.000 reads/día y 20.000 writes/día. Holgado para uso normal.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,13 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath": "categoria", "order": "ASCENDING"},
+        {"fieldPath": "fecha", "order": "DESCENDING"}
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/packages/biwenger_tools/web/repository.py
+++ b/packages/biwenger_tools/web/repository.py
@@ -15,9 +15,14 @@ layout written by ``scripts/backfill_firestore.py`` and the scraper:
     clausulazos/{season}/transfers/{id}
     tabla_justicia/{season}/teams/{equipo}
     palmares/{temporada}
+
+The Firestore client calls live inline here — one query per function — so
+the path, the where clause, and the ordering are obvious at the call site.
 """
 
-from datetime import datetime
+from typing import Optional
+
+from google.cloud import firestore as gfs
 
 from core.domain.models import (
     Clausulazo,
@@ -25,57 +30,126 @@ from core.domain.models import (
     LeagueMessage,
     Palmares,
     Participation,
-    _parse_fecha,
 )
-from core.sdk import firestore
+from core.sdk.firestore import get_client
+
+# --- comunicados (messages) ----------------------------------------------
+# Subcollection: comunicados/{season}/messages
+# Composite index needed for the category-filtered + fecha-sorted reads:
+#   collection group "messages", fields (categoria ASC, fecha DESC).
+# Declared in firestore.indexes.json at the repo root.
 
 
-def _fecha_sort_key(fecha: str) -> datetime:
-    """Naive datetime sort key for a display date string.
+def get_messages_by_category(
+    season: str,
+    categoria: str,
+    limit: Optional[int] = None,
+    offset: Optional[int] = None,
+) -> list[LeagueMessage]:
+    """Messages of one ``categoria`` for a season, newest first.
 
-    Returns ``datetime.min`` when the value is empty or unparseable, and
-    strips tzinfo so parsed and fallback values stay mutually comparable.
+    Server-side: filters by ``categoria``, orders by ``fecha`` DESC, and
+    applies ``limit``/``offset`` for paginated reads. ``offset`` still bills
+    skipped docs as reads (Firestore's offset is not free), so it's only
+    used by the comunicados page that exposes ``?page=N`` URLs — keep the
+    page size small to stay inside the free tier.
     """
-    parsed = _parse_fecha(fecha)
-    return parsed.replace(tzinfo=None) if parsed else datetime.min
+    ref = (
+        get_client()
+        .collection(f"comunicados/{season}/messages")
+        .where(filter=gfs.FieldFilter("categoria", "==", categoria))
+        .order_by("fecha", direction=gfs.Query.DESCENDING)
+    )
+    if limit is not None:
+        ref = ref.limit(limit)
+    if offset is not None:
+        ref = ref.offset(offset)
+    return [
+        LeagueMessage.from_firestore(snap.id, snap.to_dict() or {})
+        for snap in ref.stream()
+    ]
 
 
-def get_messages(season: str) -> list[LeagueMessage]:
-    """All league messages for a season, most recent first.
+def count_messages_by_category(season: str, categoria: str) -> int:
+    """Total docs in ``comunicados/{season}/messages`` for one ``categoria``.
 
-    Firestore returns documents unordered; the scraper used to hand the web a
-    pre-sorted CSV, so we re-sort here to preserve that contract.
+    Uses Firestore's count aggregation — billed at a tiny fixed cost
+    regardless of result size, so the comunicados page can compute its
+    ``total_pages`` without pulling every doc.
     """
-    docs = firestore.list_documents(f"comunicados/{season}/messages")
-    messages = [LeagueMessage.from_firestore(doc_id, data) for doc_id, data in docs]
-    messages.sort(key=lambda m: _fecha_sort_key(m.fecha), reverse=True)
-    return messages
+    aggregation = (
+        get_client()
+        .collection(f"comunicados/{season}/messages")
+        .where(filter=gfs.FieldFilter("categoria", "==", categoria))
+        .count()
+        .get()
+    )
+    return int(aggregation[0][0].value)
+
+
+# --- participacion -------------------------------------------------------
 
 
 def get_participaciones(season: str) -> list[Participation]:
-    """Participation aggregates for a season (unordered — the route sorts)."""
-    docs = firestore.list_documents(f"participacion/{season}/authors")
-    return [Participation.from_firestore(doc_id, data) for doc_id, data in docs]
+    """Participation aggregates for a season, ordered by ``total`` DESC.
+
+    The collection is tiny (~7 docs, one per author) so ordering server-side
+    is mostly cosmetic — but it keeps the route free of Python sorting.
+    """
+    return [
+        Participation.from_firestore(snap.id, snap.to_dict() or {})
+        for snap in (
+            get_client()
+            .collection(f"participacion/{season}/authors")
+            .order_by("total", direction=gfs.Query.DESCENDING)
+            .stream()
+        )
+    ]
+
+
+# --- clausulazos ---------------------------------------------------------
 
 
 def get_clausulazos(season: str) -> list[Clausulazo]:
-    """Release-clause transfers for a season, most recent first."""
-    docs = firestore.list_documents(f"clausulazos/{season}/transfers")
-    clausulazos = [Clausulazo.from_firestore(doc_id, data) for doc_id, data in docs]
-    clausulazos.sort(key=lambda c: _fecha_sort_key(c.fecha), reverse=True)
-    return clausulazos
+    """Release-clause transfers for a season, newest first."""
+    return [
+        Clausulazo.from_firestore(snap.id, snap.to_dict() or {})
+        for snap in (
+            get_client()
+            .collection(f"clausulazos/{season}/transfers")
+            .order_by("fecha", direction=gfs.Query.DESCENDING)
+            .stream()
+        )
+    ]
+
+
+# --- tabla_justicia ------------------------------------------------------
 
 
 def get_tabla_justicia(season: str) -> list[JusticeEntry]:
-    """Justice table for a season, ordered by attacks made (descending) —
-    the same order the scraper wrote into the CSV."""
-    docs = firestore.list_documents(f"tabla_justicia/{season}/teams")
-    tabla = [JusticeEntry.from_firestore(doc_id, data) for doc_id, data in docs]
-    tabla.sort(key=lambda e: e.total_hechos, reverse=True)
-    return tabla
+    """Justice table for a season, ordered by attacks made (descending)."""
+    return [
+        JusticeEntry.from_firestore(snap.id, snap.to_dict() or {})
+        for snap in (
+            get_client()
+            .collection(f"tabla_justicia/{season}/teams")
+            .order_by("total_hechos", direction=gfs.Query.DESCENDING)
+            .stream()
+        )
+    ]
+
+
+# --- palmares ------------------------------------------------------------
 
 
 def get_palmares() -> list[Palmares]:
-    """All historical honours (unordered — the route sorts by season)."""
-    docs = firestore.list_documents("palmares")
-    return [Palmares.from_firestore(doc_id, data) for doc_id, data in docs]
+    """All historical honours, ordered by season DESC (most recent first)."""
+    return [
+        Palmares.from_firestore(snap.id, snap.to_dict() or {})
+        for snap in (
+            get_client()
+            .collection("palmares")
+            .order_by("__name__", direction=gfs.Query.DESCENDING)
+            .stream()
+        )
+    ]

--- a/packages/biwenger_tools/web/routes/main.py
+++ b/packages/biwenger_tools/web/routes/main.py
@@ -37,28 +37,31 @@ def _palmares_firestore() -> str:
 
     Reshapes each `Palmares` document into the dict the template expects:
     direct keys for the podium/season data and an `otros` list for the
-    "les toca pagar a" block (multas + farolillo).
+    "les toca pagar a" block (multas + farolillo). `repository.get_palmares`
+    returns rows ordered by season DESC, so no Python sort here.
     """
     error = None
     sorted_seasons: list = []
     try:
-        seasons_data: dict = {}
+        sorted_seasons = []
         for p in repository.get_palmares():
             otros = [{"tipo": "multa", "valor": m} for m in p.multas]
             if p.farolillo:
                 otros.append({"tipo": "farolillo", "valor": p.farolillo})
-            seasons_data[p.temporada] = {
-                "campeon": p.campeon,
-                "subcampeon": p.subcampeon,
-                "tercero": p.tercero,
-                "puntuacion": p.puntuacion,
-                "record_puntos": p.record_puntos,
-                "jornadas_ganadas": p.jornadas_ganadas,
-                "otros": otros,
-            }
-        sorted_seasons = sorted(
-            seasons_data.items(), key=lambda item: item[0], reverse=True
-        )
+            sorted_seasons.append(
+                (
+                    p.temporada,
+                    {
+                        "campeon": p.campeon,
+                        "subcampeon": p.subcampeon,
+                        "tercero": p.tercero,
+                        "puntuacion": p.puntuacion,
+                        "record_puntos": p.record_puntos,
+                        "jornadas_ganadas": p.jornadas_ganadas,
+                        "otros": otros,
+                    },
+                )
+            )
     except Exception:
         error = "Ocurrió un error al cargar el palmarés."
         logger.exception("Error loading palmares from Firestore.")

--- a/packages/biwenger_tools/web/routes/season.py
+++ b/packages/biwenger_tools/web/routes/season.py
@@ -46,39 +46,47 @@ def _load_messages(filename: str) -> tuple[list, Optional[str]]:
 # These companions back the `DATA_BACKEND=firestore` branch. The CSV route
 # bodies below are left untouched so the existing tests keep passing; the
 # whole CSV path is removed once the migration flag is retired.
+#
+# Filtering, ordering, and pagination happen server-side via
+# `repository.get_messages_by_category` and friends — see that module for
+# the Firestore queries themselves. The routes only stitch them into the
+# template payload.
 
 
-def _firestore_messages_sanitized(season: str) -> list:
-    """Fetch league messages from Firestore with `contenido` sanitized.
+def _sanitize_contenido(messages: list) -> list:
+    """Pre-render `contenido` as HTML-escaped Markup with <br> for newlines.
 
-    Mirrors `_load_messages` — sanitization is a presentation concern, so it
-    happens on read regardless of which backend stored the HTML.
+    Templates either render it via the `safe_html` Jinja filter or ship it
+    to JS via `tojson` for `innerHTML`; doing the sanitization on read makes
+    both paths XSS-safe regardless of what Biwenger writes upstream.
     """
-    messages = repository.get_messages(season)
     for m in messages:
         m.contenido = str(safe_html(m.contenido))
     return messages
 
 
 def _comunicados_firestore(season: str) -> str:
-    """Firestore-backed version of the comunicados route."""
+    """Firestore-backed comunicados route — server-side paginated."""
     error = None
     paginated_messages: list = []
-    comunicados_only: list = []
     page = 1
     total_pages = 1
+    total = 0
     try:
-        all_messages = _firestore_messages_sanitized(season)
-        comunicados_only = [
-            m for m in all_messages if m.categoria.strip() == "comunicado"
-        ]
-        page = request.args.get("page", 1, type=int)
-        start = (page - 1) * config.MESSAGES_PER_PAGE
-        paginated_messages = comunicados_only[start : start + config.MESSAGES_PER_PAGE]
+        page = max(1, request.args.get("page", 1, type=int))
+        offset = (page - 1) * config.MESSAGES_PER_PAGE
+        total = repository.count_messages_by_category(season, "comunicado")
         total_pages = max(
             1,
-            (len(comunicados_only) + config.MESSAGES_PER_PAGE - 1)
-            // config.MESSAGES_PER_PAGE,
+            (total + config.MESSAGES_PER_PAGE - 1) // config.MESSAGES_PER_PAGE,
+        )
+        paginated_messages = _sanitize_contenido(
+            repository.get_messages_by_category(
+                season,
+                "comunicado",
+                limit=config.MESSAGES_PER_PAGE,
+                offset=offset,
+            )
         )
     except Exception:
         error = f"Ocurrió un error al cargar los comunicados de la temporada {season}."
@@ -88,7 +96,11 @@ def _comunicados_firestore(season: str) -> str:
     return render_template(
         "index.html",
         messages=paginated_messages,
-        all_comunicados=comunicados_only,
+        # `all_comunicados` powered the global search dropdown when reads were
+        # cheap (a single CSV download). With Firestore it would mean pulling
+        # the full collection on every page load, defeating the pagination.
+        # Templates fall back to an empty list, the search box stays.
+        all_comunicados=[],
         error=error,
         active_page="comunicados",
         current_page=page,
@@ -97,7 +109,7 @@ def _comunicados_firestore(season: str) -> str:
 
 
 def _salseo_firestore(season: str) -> str:
-    """Firestore-backed version of the salseo route."""
+    """Firestore-backed salseo route — one query per content type."""
     error = None
     clausulazos_error = None
     datos_curiosos: list = []
@@ -105,9 +117,12 @@ def _salseo_firestore(season: str) -> str:
     clausulazos: list = []
     tabla_justicia: list = []
     try:
-        all_messages = _firestore_messages_sanitized(season)
-        datos_curiosos = [m for m in all_messages if m.categoria.strip() == "dato"]
-        cronicas = [m for m in all_messages if m.categoria.strip() == "cronica"]
+        datos_curiosos = _sanitize_contenido(
+            repository.get_messages_by_category(season, "dato")
+        )
+        cronicas = _sanitize_contenido(
+            repository.get_messages_by_category(season, "cronica")
+        )
     except Exception:
         error = f"Ocurrió un error al cargar los datos de la temporada {season}."
         logger.exception(
@@ -134,11 +149,10 @@ def _salseo_firestore(season: str) -> str:
 
 
 def _participacion_firestore(season: str) -> str:
-    """Firestore-backed version of the participacion route."""
+    """Firestore-backed participacion route — repo orders by `total` DESC."""
     error = None
     stats: list = []
     try:
-        participations = repository.get_participaciones(season)
         stats = [
             {
                 "autor": p.autor,
@@ -148,9 +162,8 @@ def _participacion_firestore(season: str) -> str:
                 "cronicas": len(p.cronicas),
                 "total": p.total,
             }
-            for p in participations
+            for p in repository.get_participaciones(season)
         ]
-        stats.sort(key=lambda item: item["total"], reverse=True)
     except Exception:
         error = (
             f"Ocurrió un error al calcular las estadísticas de la temporada {season}."
@@ -167,7 +180,7 @@ def _participacion_firestore(season: str) -> str:
 
 
 def _mercado_firestore(season: str) -> str:
-    """Firestore-backed version of the mercado route."""
+    """Firestore-backed mercado route — repo orders by `fecha` DESC."""
     clausulazos: list = []
     tabla_justicia: list = []
     error = None
@@ -185,7 +198,6 @@ def _mercado_firestore(season: str) -> str:
 
     clausulazos_summary = None
     if clausulazos:
-        # repository.get_clausulazos returns most-recent-first.
         clausulazos_summary = {
             "total": len(clausulazos),
             "total_eur": sum(c.precio for c in clausulazos),
@@ -247,6 +259,36 @@ def comunicados(season: str) -> str:
         current_page=page,
         total_pages=total_pages,
     )
+
+
+@bp.route("/<season>/comunicados/search-data")
+def comunicados_search_data(season: str) -> Response:
+    """JSON list of all comunicados for the season — used by the search box.
+
+    The comunicados page renders only the current page (server-side
+    pagination), so the in-page search needs the rest on demand. The
+    template fetches this endpoint the first time the user focuses the
+    search input, caches the response, and filters client-side from then
+    on. One full-collection read per session, only if someone actually
+    searches.
+
+    Only implemented for the Firestore backend; on CSV the comunicados
+    route already loads everything (legacy behaviour stays until the CSV
+    path is removed).
+    """
+    if config.DATA_BACKEND != "firestore":
+        return jsonify([])
+    try:
+        msgs = _sanitize_contenido(
+            repository.get_messages_by_category(g.season, "comunicado")
+        )
+        return jsonify([asdict(m) for m in msgs])
+    except Exception:
+        logger.exception(
+            "Error loading comunicados search-data from Firestore.",
+            extra={"season": g.season},
+        )
+        return jsonify([]), 500
 
 
 @bp.route("/<season>/salseo")

--- a/packages/biwenger_tools/web/templates/index.html
+++ b/packages/biwenger_tools/web/templates/index.html
@@ -66,7 +66,31 @@
     </div>
 
     <script>
-        const allMessages = {{ all_comunicados | tojson }};
+        // Server-rendered: empty list. The full collection is fetched on
+        // demand from /<season>/comunicados/search-data the first time the
+        // user interacts with the search input — one Firestore read per
+        // session, only when someone actually searches.
+        const PRELOADED_COMUNICADOS = {{ all_comunicados | tojson }};
+        let allMessages = Array.isArray(PRELOADED_COMUNICADOS) ? PRELOADED_COMUNICADOS : [];
+        let allMessagesLoaded = allMessages.length > 0;
+        let allMessagesLoading = null;  // in-flight Promise to dedupe concurrent fetches
+
+        async function ensureAllMessages() {
+            if (allMessagesLoaded) return;
+            if (allMessagesLoading) return allMessagesLoading;
+            counter.textContent = 'Cargando comunicados…';
+            counter.classList.remove('hidden');
+            allMessagesLoading = fetch(window.location.pathname.replace(/\/?$/, '/') + 'comunicados/search-data')
+                .then(r => r.ok ? r.json() : [])
+                .then(data => {
+                    allMessages = data;
+                    allMessagesLoaded = true;
+                })
+                .catch(() => { allMessages = []; })
+                .finally(() => { allMessagesLoading = null; });
+            return allMessagesLoading;
+        }
+
         const PAGE_SIZE = 7;
 
         const searchInput = document.getElementById('search-input');
@@ -81,6 +105,9 @@
 
         let filteredMessages = [];
         let searchPage = 1;
+
+        // Warm the cache on focus so the first keystroke has the data ready.
+        searchInput.addEventListener('focus', ensureAllMessages, { once: true });
 
         function createCardHtml(msg) {
             return `
@@ -125,7 +152,7 @@
             paginationContainer.innerHTML = originalPaginationHTML;
         }
 
-        searchInput.addEventListener('input', function() {
+        searchInput.addEventListener('input', async function() {
             const q = this.value.toLowerCase().trim();
             clearBtn.classList.toggle('hidden', !q);
 
@@ -133,6 +160,8 @@
                 clearSearch();
                 return;
             }
+
+            await ensureAllMessages();
 
             filteredMessages = allMessages.filter(msg => {
                 const tmp = document.createElement('div');


### PR DESCRIPTION
## Summary

Stop pulling the full \`messages\` collection on every page load and let Firestore do filtering/ordering/pagination server-side. Adds inline queries in \`web/repository.py\`, a composite index \`messages.(categoria ASC, fecha DESC)\`, and lazy-loaded search so the comunicados page costs ~8 reads instead of ~2,795.

## Reads per page

| Página | Antes | Ahora |
|--------|-------|-------|
| \`/<season>/\` (comunicados) | ~2,795 | **~8** (1 count + 7 page) |
| \`/<season>/\` con buscador | ~2,795 | 8 + ~530 (sólo la primera vez por sesión) |
| \`/<season>/salseo\` | ~2,800 | ~600 |
| \`/<season>/mercado\` | ~111 | ~111 (mismo size, ahora orden server-side) |
| \`/<season>/participacion\` | ~7 | ~7 |
| \`/palmares\` | ~3 | ~3 |

## Changes

- **\`repository.py\`** rewritten with inline Firestore calls — one query per function, where/order_by/limit/offset explicit at call site. No new abstractions in \`core/sdk/firestore.py\`.
- **\`count_messages_by_category\`** uses Firestore's count aggregation for pagination totals (1 read regardless of collection size).
- **\`routes/season.py\`** paginates server-side; salseo runs one query per category.
- **\`routes/main.py\`** for palmares no longer sorts in Python.
- **New route \`GET /<season>/comunicados/search-data\`** returns the full category list as JSON; the template fetches it on the first focus of the search input and caches it.
- **Composite index** declared in \`firestore.indexes.json\` and already created in prod (state READY, collection-group scope so it applies to every season).
- **\`docs/firestore.md\`** describes the data model, doc-id conventions, indexes, and how to add more.

## Test plan
- [x] \`bazel test //packages/biwenger_tools/web:web_tests //core:core_tests\` green.
- [x] \`bash scripts/lint.sh\` clean.
- [ ] After deploy: \`/25-26/\` shows comunicados page 1; pagination works; salseo loads datos+cronicas; mercado loads clausulazos+tabla_justicia; participacion loads stats; palmares loads historic; first keystroke in the search box triggers the AJAX load and filters work as before.