### PR TITLE
fix(web): sort palmares in Python — `__name__ DESC` is not auto-indexed

### DIFF
--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -136,7 +136,12 @@ Every "order by a single field" query works out of the box:
 | `participacion/{season}/authors`          | `order_by("total", DESCENDING)`                |
 | `clausulazos/{season}/transfers`          | `order_by("fecha", DESCENDING)`                |
 | `tabla_justicia/{season}/teams`           | `order_by("total_hechos", DESCENDING)`         |
-| `palmares`                                | `order_by("__name__", DESCENDING)` (doc id)    |
+
+**Caveat:** Firestore does **not** auto-index `__name__` in DESCENDING
+order. If you need to order a collection by its document id descending,
+either create a single-field DESC index for `__name__` on that
+collection, or — when the collection is tiny — sort in Python after a
+plain `.stream()` (that's what `get_palmares()` does).
 
 ### Composite (declared)
 

--- a/packages/biwenger_tools/web/repository.py
+++ b/packages/biwenger_tools/web/repository.py
@@ -143,13 +143,16 @@ def get_tabla_justicia(season: str) -> list[JusticeEntry]:
 
 
 def get_palmares() -> list[Palmares]:
-    """All historical honours, ordered by season DESC (most recent first)."""
-    return [
+    """All historical honours, sorted by season DESC (most recent first).
+
+    Ordering happens in Python: the collection only has one doc per
+    season (~3 total), and `order_by("__name__", DESCENDING)` would need
+    a Firestore index — Firestore auto-indexes `__name__` ASC but not
+    DESC. Not worth a composite index for three documents.
+    """
+    items = [
         Palmares.from_firestore(snap.id, snap.to_dict() or {})
-        for snap in (
-            get_client()
-            .collection("palmares")
-            .order_by("__name__", direction=gfs.Query.DESCENDING)
-            .stream()
-        )
+        for snap in get_client().collection("palmares").stream()
     ]
+    items.sort(key=lambda p: p.temporada, reverse=True)
+    return items


### PR DESCRIPTION
## Symptom
Visiting \`/palmares\` (any season) shows "Ocurrió un error al cargar el palmarés." Cloud Run logs:

\`\`\`
grpc._channel._MultiThreadedRendezvous: status = StatusCode.FAILED_PRECONDITION
details = "The query requires an index..."
\`\`\`

## Cause
\`get_palmares()\` did \`order_by("__name__", DESCENDING)\` on the \`palmares\` collection, expecting Firestore to auto-index document ids in both directions. It only auto-indexes ascending — DESC requires an explicit index.

## Fix
The \`palmares\` collection only holds one doc per season (~3 total). Streaming unordered and sorting by \`temporada\` in Python is cheaper than the composite index would be.

Also corrects \`docs/firestore.md\`, which wrongly listed \`__name__ DESC\` under the "auto" indexes table.

## Test plan
- [x] \`bazel test //packages/biwenger_tools/web:web_tests\` green.
- [x] \`bash scripts/lint.sh\` clean.
- [ ] After deploy: \`/palmares\` shows seasons in DESC order (25-26 first).