### PR TITLE
perf(web): strip HTML from comunicados search payload

### DIFF
--- a/packages/biwenger_tools/web/routes/season.py
+++ b/packages/biwenger_tools/web/routes/season.py
@@ -11,7 +11,7 @@ from core.domain.models import Clausulazo, JusticeEntry, LeagueMessage, Particip
 from core.sdk.gcp import download_csv_as_dict, find_file_on_drive, get_sheets_data
 from core.utils import get_logger
 from packages.biwenger_tools.web import config, repository, services
-from packages.biwenger_tools.web.sanitize import safe_html
+from packages.biwenger_tools.web.sanitize import safe_html, to_text
 
 logger = get_logger(__name__)
 bp = Blueprint("season", __name__)
@@ -279,10 +279,23 @@ def comunicados_search_data(season: str) -> Response:
     if config.DATA_BACKEND != "firestore":
         return jsonify([])
     try:
-        msgs = _sanitize_contenido(
-            repository.get_messages_by_category(g.season, "comunicado")
+        msgs = repository.get_messages_by_category(g.season, "comunicado")
+        # Plain text instead of HTML: ~50% less on the wire and search
+        # filters on text content anyway. The search card renders with
+        # `whitespace-pre-wrap` to keep the `\n` line breaks visible.
+        return jsonify(
+            [
+                {
+                    "id_hash": m.id_hash,
+                    "titulo": m.titulo,
+                    "autor": m.autor,
+                    "fecha": m.fecha,
+                    "categoria": m.categoria,
+                    "contenido": to_text(m.contenido),
+                }
+                for m in msgs
+            ]
         )
-        return jsonify([asdict(m) for m in msgs])
     except Exception:
         logger.exception(
             "Error loading comunicados search-data from Firestore.",

--- a/packages/biwenger_tools/web/sanitize.py
+++ b/packages/biwenger_tools/web/sanitize.py
@@ -14,6 +14,7 @@ on the JS side after a `{{ ... | tojson }}`.
 """
 
 import bleach
+from bs4 import BeautifulSoup
 from markupsafe import Markup
 
 # Tags we accept from Biwenger announcements. Kept conservative:
@@ -67,3 +68,18 @@ def html_to_plain_text(html: str | None) -> str:
     template path and the `innerHTML` JS path safe.
     """
     return str(safe_html(html))
+
+
+def to_text(html: str | None) -> str:
+    """Return ``html`` stripped of every tag, preserving line breaks.
+
+    Used by the search-data endpoint to ship a slim, format-free payload
+    to the client. ``contenido`` from Biwenger can carry styled HTML
+    (~50% of the search payload is tags + attributes); collapsing it to
+    plain text with `\\n` line breaks roughly halves the bytes on the
+    wire. Safe for `textContent` (the search card renders with
+    `whitespace-pre-wrap` so the line breaks survive).
+    """
+    if not html:
+        return ""
+    return BeautifulSoup(html, "html.parser").get_text(separator="\n", strip=True)

--- a/packages/biwenger_tools/web/templates/index.html
+++ b/packages/biwenger_tools/web/templates/index.html
@@ -109,17 +109,27 @@
         // Warm the cache on focus so the first keystroke has the data ready.
         searchInput.addEventListener('focus', ensureAllMessages, { once: true });
 
+        // `msg.contenido` arrives as plain text (server-side strip in
+        // /comunicados/search-data) — `whitespace-pre-wrap` preserves the
+        // line breaks. Title/autor/contenido all come from board posts so
+        // escape every interpolation to keep the search cards XSS-safe.
+        function escapeHtml(s) {
+            const d = document.createElement('div');
+            d.textContent = s == null ? '' : s;
+            return d.innerHTML;
+        }
+
         function createCardHtml(msg) {
             return `
             <article class="message-card card p-6 rounded-xl shadow-md hover:shadow-lg transition-shadow">
                 <div class="flex justify-between items-start mb-4">
                     <div>
-                        <h2 class="text-2xl font-bold text-gray-900">${msg.titulo}</h2>
-                        <p class="text-sm font-medium text-green-700 mt-1">por ${msg.autor}</p>
+                        <h2 class="text-2xl font-bold text-gray-900">${escapeHtml(msg.titulo)}</h2>
+                        <p class="text-sm font-medium text-green-700 mt-1">por ${escapeHtml(msg.autor)}</p>
                     </div>
-                    <span class="text-sm text-gray-500 text-right flex-shrink-0 ml-4">${msg.fecha}</span>
+                    <span class="text-sm text-gray-500 text-right flex-shrink-0 ml-4">${escapeHtml(msg.fecha)}</span>
                 </div>
-                <div class="prose max-w-none leading-relaxed">${msg.contenido}</div>
+                <div class="prose max-w-none leading-relaxed whitespace-pre-wrap">${escapeHtml(msg.contenido)}</div>
             </article>`;
         }
 
@@ -164,9 +174,8 @@
             await ensureAllMessages();
 
             filteredMessages = allMessages.filter(msg => {
-                const tmp = document.createElement('div');
-                tmp.innerHTML = msg.contenido;
-                return (msg.titulo + msg.autor + (tmp.textContent || '')).toLowerCase().includes(q);
+                // contenido is already plain text (search-data endpoint).
+                return (msg.titulo + msg.autor + (msg.contenido || '')).toLowerCase().includes(q);
             });
 
             noResultsDiv.classList.toggle('hidden', filteredMessages.length > 0);


### PR DESCRIPTION
## Summary
\`/<season>/comunicados/search-data\` now returns plain-text \`contenido\` (with \`\\n\` line breaks) instead of sanitized HTML. Payload roughly halves, the lazy load on the search box stops stalling on mobile.

## Changes
- New \`sanitize.to_text()\` — bs4 \`get_text(separator="\\n")\`.
- Route applies it in the search-data payload.
- Template search card uses \`whitespace-pre-wrap\` + a small \`escapeHtml\` helper before innerHTML interpolation (XSS-safe with the new plain string).
- Client filter compares against the plain text directly — no more off-DOM \`tmp.innerHTML\` dance.

## Test plan
- [x] \`bazel test //packages/biwenger_tools/web:web_tests\` green.
- [x] \`bash scripts/lint.sh\` clean.
- [ ] After deploy: search box loads noticeably faster on mobile; filter finds the same hits as before; line breaks in results render properly.