### PR TITLE
chore(web): drop CSV/Drive reads — Firestore is the only data backend

### DIFF
--- a/packages/biwenger_tools/web/BUILD.bazel
+++ b/packages/biwenger_tools/web/BUILD.bazel
@@ -26,9 +26,5 @@ python_service(
         # in the local image (where `secrets` are baked into the OCI tar)
         # made the Firestore client try to load a non-existent file and
         # crash every Firestore read.
-        # Flips the web off CSVs/Drive and onto Firestore. `web/config.py`
-        # still defaults to "csv" so `bazel run //...:web_local` and the
-        # tests stay on the unchanged path unless this env var is set.
-        "DATA_BACKEND": "firestore",
     },
 )

--- a/packages/biwenger_tools/web/config.py
+++ b/packages/biwenger_tools/web/config.py
@@ -61,13 +61,6 @@ ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD")
 GIT_COMMIT = os.getenv("GIT_COMMIT", "local")
 DEPLOY_TIME = os.getenv("DEPLOY_TIME", "")
 
-# --- DATA BACKEND (feature flag: CSV/Drive → Firestore migration) ---
-# "csv"       → legacy reads from Google Drive CSVs (the proven path).
-# "firestore" → reads from Firestore via routes → repository.py.
-# Defaults to "csv" so master stays safe until Firestore is validated; flip
-# by setting DATA_BACKEND=firestore in deploy.yml (or .env for local dev).
-DATA_BACKEND = os.getenv("DATA_BACKEND", "csv").strip().lower()
-
 # --- CONFIGURACIÓN NO CRÍTICA (valores fijos) ---
 MESSAGES_PER_PAGE = 7
 

--- a/packages/biwenger_tools/web/routes/main.py
+++ b/packages/biwenger_tools/web/routes/main.py
@@ -1,11 +1,10 @@
 """Main routes: home, favicon, palmares, reglamento."""
 
 import ssl
-from collections import defaultdict
 
 from flask import Blueprint, Response, g, jsonify, redirect, render_template, url_for
 
-from core.sdk.gcp import download_csv_as_dict, find_file_on_drive, get_sheets_data
+from core.sdk.gcp import get_sheets_data
 from core.utils import get_logger
 from packages.biwenger_tools.web import config, repository, services
 
@@ -32,18 +31,18 @@ def home() -> Response:
     return redirect(url_for("season.comunicados", season=g.season))
 
 
-def _palmares_firestore() -> str:
-    """Firestore-backed version of the palmares route.
+@bp.route("/palmares")
+def palmares() -> str:
+    """Display historical records and awards.
 
     Reshapes each `Palmares` document into the dict the template expects:
     direct keys for the podium/season data and an `otros` list for the
     "les toca pagar a" block (multas + farolillo). `repository.get_palmares`
-    returns rows ordered by season DESC, so no Python sort here.
+    already returns rows sorted by season DESC, no Python sort here.
     """
     error = None
     sorted_seasons: list = []
     try:
-        sorted_seasons = []
         for p in repository.get_palmares():
             otros = [{"tipo": "multa", "valor": m} for m in p.multas]
             if p.farolillo:
@@ -65,56 +64,6 @@ def _palmares_firestore() -> str:
     except Exception:
         error = "Ocurrió un error al cargar el palmarés."
         logger.exception("Error loading palmares from Firestore.")
-
-    return render_template(
-        "palmares.html",
-        seasons=sorted_seasons,
-        error=error,
-        active_page="palmares",
-    )
-
-
-@bp.route("/palmares")
-def palmares() -> str:
-    """Display historical records and awards."""
-    if config.DATA_BACKEND == "firestore":
-        return _palmares_firestore()
-    seasons: dict = defaultdict(lambda: defaultdict(list))
-    error = None
-    sorted_seasons: list = []
-    try:
-        if not services.drive_service:
-            raise Exception("El servicio de Google Drive no está disponible.")
-
-        file_metadata = find_file_on_drive(
-            services.drive_service, config.PALMARES_FILENAME, config.GDRIVE_FOLDER_ID
-        )
-        if not file_metadata:
-            raise FileNotFoundError(
-                f"El archivo '{config.PALMARES_FILENAME}' "
-                "no se encontró en Google Drive."
-            )
-
-        palmares_data = download_csv_as_dict(
-            services.drive_service, file_metadata["id"]
-        )
-        for row in palmares_data:
-            season_data = row.get("temporada", "").strip()
-            category = row.get("categoria", "").strip()
-            value = row.get("valor", "").strip()
-            if not season_data or not category:
-                continue
-            if category in ["multa", "sancion", "farolillo"]:
-                seasons[season_data]["otros"].append({"tipo": category, "valor": value})
-            else:
-                seasons[season_data][category] = value
-        sorted_seasons = sorted(seasons.items(), key=lambda item: item[0], reverse=True)
-    except ssl.SSLError:
-        error = "Error de SSL al conectar con Google Drive."
-        logger.exception("SSL error loading palmares.")
-    except Exception:
-        error = "Ocurrió un error al cargar el palmarés."
-        logger.exception("Error loading palmares.")
 
     return render_template(
         "palmares.html",

--- a/packages/biwenger_tools/web/routes/season.py
+++ b/packages/biwenger_tools/web/routes/season.py
@@ -1,56 +1,25 @@
-"""Season-scoped routes: comunicados, salseo, participacion, lloros_awards, and API."""
+"""Season-scoped routes: comunicados, salseo, participacion, mercado,
+lloros_awards, and their API endpoints.
 
-import ssl
+Data flow:
+- Content (comunicados/datos/cronicas/clausulazos/participacion/tabla)
+  comes from Firestore via `repository.*`. Filtering, ordering, and
+  pagination all happen server-side — see the inline queries there.
+- Lloros Awards (ligas especiales + trofeos) still come from Google
+  Sheets — hand-edited by the user, not part of the Firestore data set.
+"""
+
 from dataclasses import asdict
-from datetime import datetime
-from typing import Optional
 
 from flask import Blueprint, Response, g, jsonify, render_template, request
 
-from core.domain.models import Clausulazo, JusticeEntry, LeagueMessage, Participation
-from core.sdk.gcp import download_csv_as_dict, find_file_on_drive, get_sheets_data
+from core.sdk.gcp import get_sheets_data
 from core.utils import get_logger
 from packages.biwenger_tools.web import config, repository, services
 from packages.biwenger_tools.web.sanitize import safe_html, to_text
 
 logger = get_logger(__name__)
 bp = Blueprint("season", __name__)
-
-
-def _load_messages(filename: str) -> tuple[list, Optional[str]]:
-    """Load all LeagueMessage entries from a Drive CSV. Returns (messages, error).
-
-    `contenido` is stripped of its HTML markup eagerly here: every caller either
-    renders it through the `safe_html` Jinja filter or ships it to the browser
-    via `tojson` to be assigned with `innerHTML`. Sanitizing once at load time
-    makes both paths XSS-safe regardless of what Biwenger writes upstream.
-    """
-    if not services.drive_service:
-        return [], "El servicio de Google Drive no está disponible."
-    file_meta = find_file_on_drive(
-        services.drive_service, filename, config.GDRIVE_FOLDER_ID
-    )
-    if not file_meta:
-        return [], f"El archivo '{filename}' no se encontró en Google Drive."
-    rows = download_csv_as_dict(services.drive_service, file_meta["id"])
-    messages = [LeagueMessage.from_csv_row(r) for r in rows]
-    for m in messages:
-        # Pre-render as HTML-escaped Markup with <br> for newlines so the
-        # value is safe for both server-side rendering and the JS innerHTML
-        # paths that pull it via `{{ ... | tojson }}`.
-        m.contenido = str(safe_html(m.contenido))
-    return messages, None
-
-
-# --- Firestore backend ----------------------------------------------------
-# These companions back the `DATA_BACKEND=firestore` branch. The CSV route
-# bodies below are left untouched so the existing tests keep passing; the
-# whole CSV path is removed once the migration flag is retired.
-#
-# Filtering, ordering, and pagination happen server-side via
-# `repository.get_messages_by_category` and friends — see that module for
-# the Firestore queries themselves. The routes only stitch them into the
-# template payload.
 
 
 def _sanitize_contenido(messages: list) -> list:
@@ -65,13 +34,20 @@ def _sanitize_contenido(messages: list) -> list:
     return messages
 
 
-def _comunicados_firestore(season: str) -> str:
-    """Firestore-backed comunicados route — server-side paginated."""
+# --- Content routes (Firestore) ------------------------------------------
+
+
+@bp.route("/<season>/")
+def comunicados(season: str) -> str:
+    """Display paginated announcements for a given season — newest first.
+
+    Reads cost ~1 (count aggregation) + N (page size) per request, no
+    matter how many comunicados live in the season.
+    """
     error = None
     paginated_messages: list = []
     page = 1
     total_pages = 1
-    total = 0
     try:
         page = max(1, request.args.get("page", 1, type=int))
         offset = (page - 1) * config.MESSAGES_PER_PAGE
@@ -96,10 +72,9 @@ def _comunicados_firestore(season: str) -> str:
     return render_template(
         "index.html",
         messages=paginated_messages,
-        # `all_comunicados` powered the global search dropdown when reads were
-        # cheap (a single CSV download). With Firestore it would mean pulling
-        # the full collection on every page load, defeating the pagination.
-        # Templates fall back to an empty list, the search box stays.
+        # The in-page search box loads the full list on demand from
+        # `/<season>/comunicados/search-data` — keeps the page cheap and
+        # only pays the read cost if the user actually searches.
         all_comunicados=[],
         error=error,
         active_page="comunicados",
@@ -108,8 +83,48 @@ def _comunicados_firestore(season: str) -> str:
     )
 
 
-def _salseo_firestore(season: str) -> str:
-    """Firestore-backed salseo route — one query per content type."""
+@bp.route("/<season>/comunicados/search-data")
+def comunicados_search_data(season: str) -> Response:
+    """JSON list of all comunicados for the season — used by the search box.
+
+    The comunicados page renders only the current page (server-side
+    pagination), so the in-page search needs the rest on demand. The
+    template fetches this endpoint the first time the user focuses the
+    search input, caches the response, and filters client-side from then
+    on. One full-category read per session, only if someone actually
+    searches. `contenido` ships as plain text (~50% smaller payload than
+    the sanitized HTML; the search card renders with `whitespace-pre-wrap`
+    to keep the line breaks visible).
+    """
+    try:
+        msgs = repository.get_messages_by_category(g.season, "comunicado")
+        return jsonify(
+            [
+                {
+                    "id_hash": m.id_hash,
+                    "titulo": m.titulo,
+                    "autor": m.autor,
+                    "fecha": m.fecha,
+                    "categoria": m.categoria,
+                    "contenido": to_text(m.contenido),
+                }
+                for m in msgs
+            ]
+        )
+    except Exception:
+        logger.exception(
+            "Error loading comunicados search-data from Firestore.",
+            extra={"season": g.season},
+        )
+        return jsonify([]), 500
+
+
+@bp.route("/<season>/salseo")
+def salseo(season: str) -> str:
+    """Display datos curiosos + crónicas + clausulazos + tabla de justicia.
+
+    One Firestore query per content type — no full-collection scan.
+    """
     error = None
     clausulazos_error = None
     datos_curiosos: list = []
@@ -148,8 +163,13 @@ def _salseo_firestore(season: str) -> str:
     )
 
 
-def _participacion_firestore(season: str) -> str:
-    """Firestore-backed participacion route — repo orders by `total` DESC."""
+@bp.route("/<season>/participacion")
+def participacion(season: str) -> str:
+    """Display participation statistics for a given season.
+
+    Repo returns authors already ordered by `total` DESC (Firestore
+    `order_by` on the stored derived field).
+    """
     error = None
     stats: list = []
     try:
@@ -179,8 +199,13 @@ def _participacion_firestore(season: str) -> str:
     )
 
 
-def _mercado_firestore(season: str) -> str:
-    """Firestore-backed mercado route — repo orders by `fecha` DESC."""
+@bp.route("/<season>/mercado")
+def mercado(season: str) -> str:
+    """Display transfers and justice table for a given season.
+
+    Repo returns clausulazos ordered by `fecha` DESC and tabla_justicia
+    by `total_hechos` DESC.
+    """
     clausulazos: list = []
     tabla_justicia: list = []
     error = None
@@ -215,271 +240,7 @@ def _mercado_firestore(season: str) -> str:
     )
 
 
-@bp.route("/<season>/")
-def comunicados(season: str) -> str:
-    """Display paginated announcements for a given season."""
-    if config.DATA_BACKEND == "firestore":
-        return _comunicados_firestore(g.season)
-    error = None
-    paginated_messages: list = []
-    comunicados_only: list = []
-    page = 1
-    total_pages = 1
-    try:
-        filename = f"{config.COMUNICADOS_FILENAME_BASE}_{g.season}.csv"
-        all_messages, err = _load_messages(filename)
-        if err:
-            raise Exception(err)
-        comunicados_only = [
-            m for m in all_messages if m.categoria.strip() == "comunicado"
-        ]
-        page = request.args.get("page", 1, type=int)
-        start = (page - 1) * config.MESSAGES_PER_PAGE
-        paginated_messages = comunicados_only[start : start + config.MESSAGES_PER_PAGE]
-        total_pages = max(
-            1,
-            (len(comunicados_only) + config.MESSAGES_PER_PAGE - 1)
-            // config.MESSAGES_PER_PAGE,
-        )
-    except ssl.SSLError:
-        error = "Error de SSL al conectar con Google Drive."
-        logger.exception("SSL error loading comunicados.", extra={"season": g.season})
-    except Exception:
-        error = (
-            f"Ocurrió un error al cargar los comunicados de la temporada {g.season}."
-        )
-        logger.exception("Error loading comunicados.", extra={"season": g.season})
-
-    return render_template(
-        "index.html",
-        messages=paginated_messages,
-        all_comunicados=comunicados_only,
-        error=error,
-        active_page="comunicados",
-        current_page=page,
-        total_pages=total_pages,
-    )
-
-
-@bp.route("/<season>/comunicados/search-data")
-def comunicados_search_data(season: str) -> Response:
-    """JSON list of all comunicados for the season — used by the search box.
-
-    The comunicados page renders only the current page (server-side
-    pagination), so the in-page search needs the rest on demand. The
-    template fetches this endpoint the first time the user focuses the
-    search input, caches the response, and filters client-side from then
-    on. One full-collection read per session, only if someone actually
-    searches.
-
-    Only implemented for the Firestore backend; on CSV the comunicados
-    route already loads everything (legacy behaviour stays until the CSV
-    path is removed).
-    """
-    if config.DATA_BACKEND != "firestore":
-        return jsonify([])
-    try:
-        msgs = repository.get_messages_by_category(g.season, "comunicado")
-        # Plain text instead of HTML: ~50% less on the wire and search
-        # filters on text content anyway. The search card renders with
-        # `whitespace-pre-wrap` to keep the `\n` line breaks visible.
-        return jsonify(
-            [
-                {
-                    "id_hash": m.id_hash,
-                    "titulo": m.titulo,
-                    "autor": m.autor,
-                    "fecha": m.fecha,
-                    "categoria": m.categoria,
-                    "contenido": to_text(m.contenido),
-                }
-                for m in msgs
-            ]
-        )
-    except Exception:
-        logger.exception(
-            "Error loading comunicados search-data from Firestore.",
-            extra={"season": g.season},
-        )
-        return jsonify([]), 500
-
-
-@bp.route("/<season>/salseo")
-def salseo(season: str) -> str:
-    """Display various categories of content for a given season."""
-    if config.DATA_BACKEND == "firestore":
-        return _salseo_firestore(g.season)
-    error = None
-    datos_curiosos: list = []
-    cronicas: list = []
-    clausulazos: list = []
-    tabla_justicia: list = []
-    clausulazos_error = None
-
-    try:
-        filename = f"{config.COMUNICADOS_FILENAME_BASE}_{g.season}.csv"
-        all_messages, err = _load_messages(filename)
-        if err:
-            raise Exception(err)
-        datos_curiosos = [m for m in all_messages if m.categoria.strip() == "dato"]
-        cronicas = [m for m in all_messages if m.categoria.strip() == "cronica"]
-    except ssl.SSLError:
-        error = "Error de SSL al conectar con Google Drive."
-        logger.exception("SSL error loading salseo.", extra={"season": g.season})
-    except Exception:
-        error = f"Ocurrió un error al cargar los datos de la temporada {g.season}."
-        logger.exception("Error loading salseo.", extra={"season": g.season})
-
-    try:
-        if services.drive_service:
-            clausulazos_meta = find_file_on_drive(
-                services.drive_service,
-                f"{config.CLAUSULAZOS_FILENAME_BASE}_{g.season}.csv",
-                config.GDRIVE_FOLDER_ID,
-            )
-            if clausulazos_meta:
-                rows = download_csv_as_dict(
-                    services.drive_service, clausulazos_meta["id"]
-                )
-                clausulazos = [Clausulazo.from_csv_row(r) for r in rows]
-
-            tabla_meta = find_file_on_drive(
-                services.drive_service,
-                f"{config.TABLA_JUSTICIA_FILENAME_BASE}_{g.season}.csv",
-                config.GDRIVE_FOLDER_ID,
-            )
-            if tabla_meta:
-                rows = download_csv_as_dict(services.drive_service, tabla_meta["id"])
-                # JS in salseo.html consumes this via {{ tojson }}, so flatten to dicts.
-                tabla_justicia = [asdict(JusticeEntry.from_csv_row(r)) for r in rows]
-    except Exception:
-        clausulazos_error = "Error al cargar clausulazos."
-        logger.exception("Error loading clausulazos.", extra={"season": g.season})
-
-    return render_template(
-        "salseo.html",
-        datos=datos_curiosos,
-        cronicas=cronicas,
-        clausulazos=clausulazos,
-        tabla_justicia=tabla_justicia,
-        clausulazos_error=clausulazos_error,
-        error=error,
-        active_page="salseo",
-    )
-
-
-@bp.route("/<season>/participacion")
-def participacion(season: str) -> str:
-    """Display participation statistics for a given season."""
-    if config.DATA_BACKEND == "firestore":
-        return _participacion_firestore(g.season)
-    error = None
-    stats: list = []
-    try:
-        if not services.drive_service:
-            raise Exception("El servicio de Google Drive no está disponible.")
-        filename = f"{config.PARTICIPACION_FILENAME_BASE}_{g.season}.csv"
-        file_meta = find_file_on_drive(
-            services.drive_service, filename, config.GDRIVE_FOLDER_ID
-        )
-        if not file_meta:
-            raise Exception(f"El archivo '{filename}' no se encontró en Google Drive.")
-        rows = download_csv_as_dict(services.drive_service, file_meta["id"])
-        participations = [Participation.from_csv_row(r) for r in rows]
-        stats = [
-            {
-                "autor": p.autor,
-                "comunicados": len(p.comunicados),
-                "datos": len(p.datos),
-                "cesiones": len(p.cesiones),
-                "cronicas": len(p.cronicas),
-                "total": p.total,
-            }
-            for p in participations
-        ]
-        stats.sort(key=lambda item: item["total"], reverse=True)
-    except ssl.SSLError:
-        error = "Error de SSL al conectar con Google Drive."
-        logger.exception("SSL error loading participacion.", extra={"season": g.season})
-    except Exception:
-        error = (
-            f"Ocurrió un error al calcular las estadísticas de la temporada {g.season}."
-        )
-        logger.exception("Error loading participacion.", extra={"season": g.season})
-
-    return render_template(
-        "participacion.html",
-        stats=stats,
-        error=error,
-        active_page="participacion",
-    )
-
-
-@bp.route("/<season>/mercado")
-def mercado(season: str) -> str:
-    """Display transfers and justice table for a given season."""
-    if config.DATA_BACKEND == "firestore":
-        return _mercado_firestore(g.season)
-    clausulazos: list = []
-    tabla_justicia: list = []
-    error = None
-    try:
-        if not services.drive_service:
-            raise Exception("El servicio de Google Drive no está disponible.")
-
-        clausulazos_meta = find_file_on_drive(
-            services.drive_service,
-            f"{config.CLAUSULAZOS_FILENAME_BASE}_{g.season}.csv",
-            config.GDRIVE_FOLDER_ID,
-        )
-        if clausulazos_meta:
-            rows = download_csv_as_dict(services.drive_service, clausulazos_meta["id"])
-            clausulazos = [Clausulazo.from_csv_row(r) for r in rows]
-
-        tabla_meta = find_file_on_drive(
-            services.drive_service,
-            f"{config.TABLA_JUSTICIA_FILENAME_BASE}_{g.season}.csv",
-            config.GDRIVE_FOLDER_ID,
-        )
-        if tabla_meta:
-            rows = download_csv_as_dict(services.drive_service, tabla_meta["id"])
-            tabla_justicia = [asdict(JusticeEntry.from_csv_row(r)) for r in rows]
-    except Exception:
-        error = (
-            "Ocurrió un error al cargar los datos del mercado"
-            f" de la temporada {g.season}."
-        )
-        logger.exception("Error loading mercado.", extra={"season": g.season})
-
-    clausulazos_summary = None
-    if clausulazos:
-
-        def _parse_fecha(f: str) -> datetime:
-            for fmt in ("%d/%m/%Y", "%Y-%m-%d", "%d-%m-%Y"):
-                try:
-                    return datetime.strptime(f, fmt)
-                except ValueError:
-                    continue
-            return datetime.min
-
-        clausulazos_by_date = sorted(
-            clausulazos, key=lambda c: _parse_fecha(c.fecha), reverse=True
-        )
-        clausulazos_summary = {
-            "total": len(clausulazos),
-            "total_eur": sum(c.precio for c in clausulazos),
-            "max_clausulazo": max(clausulazos, key=lambda c: c.precio),
-            "ultimo": clausulazos_by_date[0],
-        }
-
-    return render_template(
-        "mercado.html",
-        clausulazos=clausulazos,
-        clausulazos_summary=clausulazos_summary,
-        tabla_justicia=tabla_justicia,
-        error=error,
-        active_page="mercado",
-    )
+# --- Lloros Awards (Google Sheets) ---------------------------------------
 
 
 @bp.route("/<season>/lloros-awards")

--- a/packages/biwenger_tools/web/tests/test_web_app.py
+++ b/packages/biwenger_tools/web/tests/test_web_app.py
@@ -3,15 +3,28 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
-from packages.biwenger_tools.web.app import app
 from packages.biwenger_tools.web import services
+from packages.biwenger_tools.web.app import app
+from core.domain.models import (
+    Clausulazo,
+    JusticeEntry,
+    LeagueMessage,
+    Palmares,
+    Participation,
+)
 
 # --- Fixtures ---
 
 
 @pytest.fixture(autouse=True)
 def mock_services():
-    """Inject mock Google services before each test."""
+    """Inject mock Google services before each test.
+
+    Drive + Sheets still get a MagicMock so the admin panel + Lloros
+    Awards routes don't crash when they touch `services.*` — the content
+    routes themselves never touch Google services any more (they read
+    Firestore via `repository.*`, which the per-test patches stub out).
+    """
     services.drive_service = MagicMock()
     services.sheets_service = MagicMock()
     yield
@@ -28,63 +41,17 @@ def client():
         yield client
 
 
-def _row(id_hash: str, titulo: str, categoria: str, autor: str = "Jorge") -> dict:
-    """Build a CSV-shaped row with all the fields LeagueMessage.from_csv_row reads."""
-    return {
-        "id_hash": id_hash,
-        "fecha": "01-01-2025 10:00:00",
-        "autor": autor,
-        "titulo": titulo,
-        "contenido": f"<p>cuerpo de {titulo}</p>",
-        "categoria": categoria,
-    }
-
-
-@pytest.fixture
-def mock_comunicados_data():
-    """Realistic CSV rows — every field LeagueMessage.from_csv_row touches."""
-    return [
-        _row("h1", "C1", "comunicado"),
-        _row("h2", "D1", "dato"),
-        _row("h3", "C2", "comunicado"),
-        _row("h4", "CES1", "cesion"),
-        _row("h5", "CR1", "cronica"),
-        _row("h6", "C3", "comunicado"),
-    ]
-
-
-@pytest.fixture
-def mock_participacion_data():
-    """Sample participation data — counts will be 2/1/0/0 vs 0/2/0/0."""
-    return [
-        {
-            "autor": "Autor1",
-            "comunicados": "c1;c2",
-            "datos": "d1",
-            "cesiones": "",
-            "cronicas": "",
-        },
-        {
-            "autor": "Autor2",
-            "comunicados": "",
-            "datos": "d1;d2",
-            "cesiones": "",
-            "cronicas": "",
-        },
-    ]
-
-
-@pytest.fixture
-def mock_palmares_data():
-    """Mixes "regular" categories (campeon) with the "otros" group (multa, sancion,
-    farolillo) so we can verify grouping logic, not just rendering."""
-    return [
-        {"temporada": "24-25", "categoria": "campeon", "valor": "Jorge"},
-        {"temporada": "23-24", "categoria": "multa", "valor": "20"},
-        {"temporada": "23-24", "categoria": "sancion", "valor": "tarjeta roja"},
-        {"temporada": "23-24", "categoria": "farolillo", "valor": "Pepe"},
-        {"temporada": "23-24", "categoria": "campeon", "valor": "Dani"},
-    ]
+def _msg(
+    id_hash: str, titulo: str, categoria: str, autor: str = "Jorge"
+) -> LeagueMessage:
+    return LeagueMessage(
+        id_hash=id_hash,
+        fecha="01-01-2025 10:00:00",
+        autor=autor,
+        titulo=titulo,
+        contenido=f"<p>cuerpo de {titulo}</p>",
+        categoria=categoria,
+    )
 
 
 # --- Session and routing tests ---
@@ -121,117 +88,141 @@ def test_before_request_ignores_invalid_url(client):
 # --- Content route tests ---
 
 
-@patch("packages.biwenger_tools.web.routes.season.download_csv_as_dict")
+@patch("packages.biwenger_tools.web.routes.season.repository.get_messages_by_category")
 @patch(
-    "packages.biwenger_tools.web.routes.season.find_file_on_drive",
-    return_value={"id": "fake_id"},
+    "packages.biwenger_tools.web.routes.season.repository.count_messages_by_category"
 )
-def test_comunicados_success(
-    mock_find_file, mock_download_csv, client, mock_comunicados_data
-):
-    """Verify that the comunicados page loads correctly with data."""
-    mock_download_csv.return_value = mock_comunicados_data
+def test_comunicados_success(mock_count, mock_get, client):
+    """Verify that the comunicados page loads correctly with Firestore data."""
+    mock_count.return_value = 2
+    mock_get.return_value = [
+        _msg("h1", "C1", "comunicado"),
+        _msg("h2", "C2", "comunicado"),
+    ]
     response = client.get("/24-25/")
     assert response.status_code == 200
     assert b"C1" in response.data
     assert b"C2" in response.data
-    assert b"D1" not in response.data
+    # The route asks the repo with the right (season, categoria, limit, offset)
+    mock_get.assert_called_once()
+    args, kwargs = mock_get.call_args
+    assert args[0] == "24-25"
+    assert args[1] == "comunicado"
+    assert kwargs["limit"] == 7
+    assert kwargs["offset"] == 0
 
 
 @patch(
-    "packages.biwenger_tools.web.routes.season.find_file_on_drive", return_value=None
-)
-def test_comunicados_file_not_found(mock_find_file, client):
-    """Verify that an error is shown when the file is not found."""
-    response = client.get("/24-25/")
-    assert response.status_code == 200
-    assert b"error" in response.data.lower()
-
-
-@patch(
-    "packages.biwenger_tools.web.routes.season.download_csv_as_dict",
+    "packages.biwenger_tools.web.routes.season.repository.count_messages_by_category",
     side_effect=Exception("Test error"),
 )
-@patch(
-    "packages.biwenger_tools.web.routes.season.find_file_on_drive",
-    return_value={"id": "fake_id"},
-)
-def test_comunicados_general_exception(mock_find_file, mock_download_csv, client):
-    """Verify that a general exception is handled gracefully."""
+def test_comunicados_general_exception(mock_count, client):
+    """A Firestore failure surfaces as a friendly error message."""
     response = client.get("/24-25/")
     assert response.status_code == 200
     assert b"Ocurri\xc3\xb3 un error al cargar los comunicados" in response.data
 
 
-@patch("packages.biwenger_tools.web.routes.season.download_csv_as_dict")
-@patch("packages.biwenger_tools.web.routes.season.find_file_on_drive")
-def test_salseo_success(
-    mock_find_file, mock_download_csv, client, mock_comunicados_data
-):
-    """Verify that the salseo page loads correctly with data."""
-    mock_find_file.side_effect = [{"id": "fake_id"}, None, None]
-    mock_download_csv.return_value = mock_comunicados_data
-    response = client.get("/24-25/salseo")
+@patch("packages.biwenger_tools.web.routes.season.repository.get_messages_by_category")
+def test_salseo_success(mock_get, client):
+    """Salseo renders datos + crónicas + clausulazos + tabla."""
+
+    def _by_categoria(season, categoria):
+        if categoria == "dato":
+            return [_msg("h2", "D1", "dato")]
+        if categoria == "cronica":
+            return [_msg("h5", "CR1", "cronica")]
+        return []
+
+    mock_get.side_effect = _by_categoria
+    with patch(
+        "packages.biwenger_tools.web.routes.season.repository.get_clausulazos",
+        return_value=[],
+    ), patch(
+        "packages.biwenger_tools.web.routes.season.repository.get_tabla_justicia",
+        return_value=[],
+    ):
+        response = client.get("/24-25/salseo")
     assert response.status_code == 200
     assert b"D1" in response.data
     assert b"CR1" in response.data
-    assert b"C1" not in response.data
+    # Comunicados must NOT leak into salseo
+    assert b"cuerpo de C1" not in response.data
 
 
-@patch("packages.biwenger_tools.web.routes.season.download_csv_as_dict")
-@patch(
-    "packages.biwenger_tools.web.routes.season.find_file_on_drive",
-    return_value={"id": "fake_id"},
-)
-def test_participacion_renders_calculated_counts(
-    mock_find_file, mock_download_csv, client, mock_participacion_data
-):
-    """The route must compute counts from the semicolon-joined CSV cells.
+@patch("packages.biwenger_tools.web.routes.season.repository.get_participaciones")
+def test_participacion_renders_calculated_counts(mock_get, client):
+    """The route turns Participation arrays into their lengths.
 
-    Autor1 has comunicados="c1;c2", datos="d1" → 2 comunicados, 1 dato.
-    Autor2 has datos="d1;d2" → 2 datos. The page must render those
-    numbers, not the raw "c1;c2" string.
+    Autor1 has 2 comunicados + 1 dato; Autor2 has 2 datos. The template
+    renders those numbers, not the raw arrays — verify the page reflects
+    the counts the repo handed back.
     """
-    mock_download_csv.return_value = mock_participacion_data
+    mock_get.return_value = [
+        Participation(
+            autor="Autor1",
+            comunicados=["c1", "c2"],
+            datos=["d1"],
+            cesiones=[],
+            cronicas=[],
+        ),
+        Participation(
+            autor="Autor2",
+            comunicados=[],
+            datos=["d1", "d2"],
+            cesiones=[],
+            cronicas=[],
+        ),
+    ]
     response = client.get("/24-25/participacion")
     assert response.status_code == 200
     body = response.data.decode("utf-8")
 
-    # The raw CSV strings must NOT leak into the HTML
+    # The raw lists must NOT leak as joined strings
     assert "c1;c2" not in body
-    assert "d1;d2" not in body
+    assert "['c1'" not in body
 
-    # Authors and computed counts must appear
     assert "Autor1" in body
     assert "Autor2" in body
-    # Autor1's comunicados cell should render as 2; Autor2's datos cell as 2
-    # Use regex-friendly substring that locks the cell to the row
-    assert ">2<" in body  # at least one cell shows the count 2
-    assert ">1<" in body  # Autor1's "datos" count
+    assert ">2<" in body
+    assert ">1<" in body
 
 
-@patch("packages.biwenger_tools.web.routes.main.download_csv_as_dict")
-@patch(
-    "packages.biwenger_tools.web.routes.main.find_file_on_drive",
-    return_value={"id": "fake_id"},
-)
-def test_palmares_groups_otros_categories(
-    mock_find_file, mock_download_csv, client, mock_palmares_data
-):
-    """multa/sancion/farolillo are bucketed into seasons[year]["otros"];
-    other categories (e.g. campeon) become direct keys. Verify the grouping
-    actually happens — not just that names appear in the HTML."""
-    mock_download_csv.return_value = mock_palmares_data
+@patch("packages.biwenger_tools.web.routes.main.repository.get_palmares")
+def test_palmares_groups_otros_categories(mock_get, client):
+    """multa/farolillo become entries in the `otros` block; podium keys stay direct."""
+    mock_get.return_value = [
+        Palmares(
+            temporada="24-25",
+            campeon="Jorge",
+            subcampeon="",
+            tercero="",
+            farolillo="",
+            puntuacion="",
+            record_puntos="",
+            jornadas_ganadas="",
+            multas=[],
+        ),
+        Palmares(
+            temporada="23-24",
+            campeon="Dani",
+            subcampeon="",
+            tercero="",
+            farolillo="Pepe",
+            puntuacion="",
+            record_puntos="",
+            jornadas_ganadas="",
+            multas=["20"],
+        ),
+    ]
     response = client.get("/palmares")
     assert response.status_code == 200
     body = response.data.decode("utf-8")
 
-    # Direct categories rendered
     assert "Jorge" in body  # 24-25 campeon
     assert "Dani" in body  # 23-24 campeon
-    # "otros" group payload (multa/sancion/farolillo all from 23-24)
+    # `otros` block (multa + farolillo) for 23-24
     assert "20" in body
-    assert "tarjeta roja" in body
     assert "Pepe" in body
 
 
@@ -275,6 +266,39 @@ def test_api_lloros_trofeos_returns_sheets_data(mock_get_sheets, client):
         response = client.get("/api/lloros-awards/trofeos")
     assert response.status_code == 200
     assert response.get_json() == payload
+
+
+# --- Search-data endpoint ---
+
+
+@patch("packages.biwenger_tools.web.routes.season.repository.get_messages_by_category")
+def test_comunicados_search_data_returns_plain_text(mock_get, client):
+    """The search-data endpoint strips HTML and only sends search-relevant fields."""
+    mock_get.return_value = [
+        LeagueMessage(
+            id_hash="h1",
+            fecha="01-01-2025 10:00:00",
+            autor="Jorge",
+            titulo="A title",
+            contenido="<p>Line one</p><p>Line two</p>",
+            categoria="comunicado",
+        ),
+    ]
+    response = client.get("/24-25/comunicados/search-data")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert len(payload) == 1
+    item = payload[0]
+    # HTML tags are stripped; line breaks preserved as \n
+    assert "<p>" not in item["contenido"]
+    assert "Line one" in item["contenido"]
+    assert "Line two" in item["contenido"]
+    assert "\n" in item["contenido"]
+    # All the fields the search box uses
+    assert item["titulo"] == "A title"
+    assert item["autor"] == "Jorge"
+    assert item["fecha"] == "01-01-2025 10:00:00"
+    assert item["categoria"] == "comunicado"
 
 
 # --- Admin panel tests ---
@@ -422,31 +446,31 @@ def test_run_scraper_rejected_without_csrf(mock_trigger, client):
 # --- Mercado route tests ---
 
 
-@patch("packages.biwenger_tools.web.routes.season.download_csv_as_dict")
-@patch("packages.biwenger_tools.web.routes.season.find_file_on_drive")
-def test_mercado_success(mock_find_file, mock_download_csv, client):
-    """Mercado page renders clausulazos and tabla de justicia when both files exist."""
-    clausulazos_row = {
-        "fecha": "01-01-2025",
-        "jugador": "Mbappé",
-        "equipo_vendedor": "PSG",
-        "equipo_comprador": "Real Madrid",
-        "precio": "180000000",
-    }
-    tabla_row = {
-        "equipo": "Real Madrid",
-        "total_hechos": "3",
-        "total_recibidos": "1",
-        "punto_de_mira": "PSG",
-        "mayor_agresor": "Barça",
-        "hechos": "[]",
-        "recibidos": "[]",
-    }
-    mock_find_file.side_effect = [{"id": "clausulazos_id"}, {"id": "tabla_id"}]
-    mock_download_csv.side_effect = [[clausulazos_row], [tabla_row]]
-
+@patch("packages.biwenger_tools.web.routes.season.repository.get_clausulazos")
+@patch("packages.biwenger_tools.web.routes.season.repository.get_tabla_justicia")
+def test_mercado_success(mock_tabla, mock_clausulazos, client):
+    """Mercado renders clausulazos + tabla de justicia."""
+    mock_clausulazos.return_value = [
+        Clausulazo(
+            fecha="01-01-2025 10:00",
+            jugador="Mbappé",
+            equipo_vendedor="PSG",
+            equipo_comprador="Real Madrid",
+            precio=180_000_000,
+        ),
+    ]
+    mock_tabla.return_value = [
+        JusticeEntry(
+            equipo="Real Madrid",
+            total_hechos=3,
+            total_recibidos=1,
+            punto_de_mira="PSG",
+            mayor_agresor="Barça",
+            hechos=[],
+            recibidos=[],
+        ),
+    ]
     response = client.get("/24-25/mercado")
-
     assert response.status_code == 200
     body = response.data.decode("utf-8")
     assert "Mbappé" in body
@@ -454,18 +478,15 @@ def test_mercado_success(mock_find_file, mock_download_csv, client):
 
 
 @patch(
-    "packages.biwenger_tools.web.routes.season.find_file_on_drive", return_value=None
+    "packages.biwenger_tools.web.routes.season.repository.get_clausulazos",
+    return_value=[],
 )
-def test_mercado_no_data(mock_find_file, client):
-    """Mercado page renders without error when no CSV files are found."""
+@patch(
+    "packages.biwenger_tools.web.routes.season.repository.get_tabla_justicia",
+    return_value=[],
+)
+def test_mercado_no_data(mock_tabla, mock_clausulazos, client):
+    """Mercado page renders without error when both collections are empty."""
     response = client.get("/24-25/mercado")
     assert response.status_code == 200
     assert b"error" not in response.data.lower()
-
-
-def test_mercado_drive_unavailable(client):
-    """Mercado page shows an error when Drive service is unavailable."""
-    services.drive_service = None
-    response = client.get("/24-25/mercado")
-    assert response.status_code == 200
-    assert "error" in response.data.decode("utf-8").lower()


### PR DESCRIPTION
## Summary
Now that the Firestore migration has run in prod for a few days and the data layer is stable, this PR removes the legacy CSV/Drive read branches from the web. \`DATA_BACKEND=firestore\` is no longer a flag — it's the only path.

## Removed
- \`routes/season.py\`: \`_load_messages\`, the CSV branches in comunicados / salseo / participacion / mercado, the \`ssl\` exception handling, imports of \`download_csv_as_dict\` / \`find_file_on_drive\` / the CSV-shape domain models.
- \`routes/main.py\`: same for palmares.
- \`web/config.py\`: \`DATA_BACKEND\` env var.
- \`web/BUILD.bazel\`: \`extra_env["DATA_BACKEND"]\`.
- Test fixtures that mocked Drive reads → rewritten to stub \`repository.*\`.

## Kept (for next week's cleanup when Drive is wiped)
- \`services.drive_service\` (used by admin file-status + scraper trigger).
- Scraper dual-write (CSV writes become unused but harmless until next PR removes them).
- Drive SA secret mount in \`deploy.yml\`.
- Google Sheets path (ligas_especiales / trofeos) — staying on Sheets.

## Net diff
-280 lines.

## Test plan
- [x] \`bazel test //...\` green across all 6 packages.
- [x] \`bash scripts/lint.sh\` clean.
- [ ] After deploy: every content page (comunicados / salseo / participacion / mercado / palmares) renders from Firestore; lloros-awards still loads Sheets; admin panel still shows file statuses.