### PR TITLE
feat(bot): /menu + inline-keyboard picker for /analizar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ The main projects are located under `packages/biwenger_tools`:
     - Fetches squad and market data from the Biwenger API.
     - Pulls predicted player ratings from the **Jornada Perfecta private API** (the SofaScore-based "Automanager" rating system) — one HTTP call instead of browser automation.
     - Cross-references both sources by normalised player name + slug.
-    - Endpoints: `GET /teams`, `GET /teams/mine`, `GET /market`, `POST /lineups/auto-pick`, `GET /budget/recommendations`, `POST /digests/daily`.
+    - Endpoints: `GET /teams[?manager=<id>]`, `GET /managers`, `GET /market`, `POST /lineups/auto-pick`, `GET /budget/recommendations`, `POST /scraper/trigger`, `POST /digests/daily`.
     - Renders PNG tables (matplotlib) and sends them as Telegram photos.
 - **Technology:** Python, Flask + gunicorn, Biwenger API, Jornada Perfecta private API, Telegram Bot API, matplotlib. Deployed on Cloud Run with `--no-allow-unauthenticated`.
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ graph TD
 | Package | Description | Deployment |
 |---------|-------------|------------|
 | `biwenger_tools/web` | Flask analytics dashboard | Cloud Run Service |
-| `biwenger_tools/scraper_job` | League board scraper → CSV → Drive | Cloud Run Job (weekly cron) |
-| `biwenger_tools/api` | Biwenger business logic over HTTP: `/teams`, `/lineups/auto-pick`, `/budget/recommendations`, `/digests/daily`, etc. Renders PNG, sends to Telegram. | Cloud Run Service (`--no-allow-unauthenticated`) |
-| `biwenger_tools/bot` | Webhook handler for `/analizar`, `/myteam`, `/mercado`, `/alinear`, `/recomendar`, `/help` — calls the api with an ID token | Cloud Run Service |
+| `biwenger_tools/scraper_job` | League board scraper → Firestore | Cloud Run Job (weekly cron) |
+| `biwenger_tools/api` | Biwenger business logic over HTTP: `/teams`, `/lineups/auto-pick`, `/budget/recommendations`, `/digests/daily`, `/managers`, etc. Renders PNG, sends to Telegram. | Cloud Run Service (`--no-allow-unauthenticated`) |
+| `biwenger_tools/bot` | Webhook handler for `/menu`, `/analizar`, `/mercado`, `/alinear`, `/recomendar`, `/scrapper`, `/help` plus inline-keyboard callbacks — calls the api with an ID token | Cloud Run Service |
 | `chucknorris_bot` | Webhook handler that fetches jokes from chucknorris.io | Cloud Run Service |
 
 ## Repository Structure

--- a/core/sdk/telegram.py
+++ b/core/sdk/telegram.py
@@ -1,5 +1,5 @@
 import hmac
-from typing import Any
+from typing import Any, Optional
 
 import requests
 
@@ -10,6 +10,8 @@ logger = get_logger(__name__)
 TELEGRAM_SEND_MESSAGE_URL = "https://api.telegram.org/bot{token}/sendMessage"
 TELEGRAM_SET_COMMANDS_URL = "https://api.telegram.org/bot{token}/setMyCommands"
 TELEGRAM_SET_MENU_BUTTON_URL = "https://api.telegram.org/bot{token}/setChatMenuButton"
+TELEGRAM_ANSWER_CALLBACK_URL = "https://api.telegram.org/bot{token}/answerCallbackQuery"
+TELEGRAM_EDIT_MESSAGE_URL = "https://api.telegram.org/bot{token}/editMessageText"
 
 # Hard limit on Bot API sendMessage; anything longer is truncated server-side.
 TELEGRAM_MAX_MESSAGE_LENGTH = 4096
@@ -21,12 +23,14 @@ def send_telegram_message(
     text: str,
     parse_mode: str = "HTML",
     disable_web_page_preview: bool = True,
+    reply_markup: Optional[dict] = None,
 ) -> None:
     """Sends a text message to a Telegram chat via the Bot API.
 
     Truncates messages over TELEGRAM_MAX_MESSAGE_LENGTH chars. For long content
     that needs splitting, do the splitting at the call site so each chunk
-    forms a coherent unit.
+    forms a coherent unit. `reply_markup` accepts a Telegram InlineKeyboard
+    dict (or any of the markup shapes the Bot API documents).
     """
     if len(text) > TELEGRAM_MAX_MESSAGE_LENGTH:
         logger.warning(
@@ -36,18 +40,69 @@ def send_telegram_message(
         text = text[: TELEGRAM_MAX_MESSAGE_LENGTH - 3] + "..."
 
     url = TELEGRAM_SEND_MESSAGE_URL.format(token=bot_token)
-    payload = {
+    payload: dict[str, Any] = {
         "chat_id": chat_id,
         "text": text,
         "parse_mode": parse_mode,
         "disable_web_page_preview": disable_web_page_preview,
     }
+    if reply_markup is not None:
+        payload["reply_markup"] = reply_markup
     try:
         response = requests.post(url, json=payload, timeout=15)
         response.raise_for_status()
         logger.info("Telegram message sent.", extra={"chars": len(text)})
     except requests.RequestException as e:
         logger.error("Failed to send Telegram message.", extra={"error": str(e)})
+
+
+def answer_callback_query(
+    bot_token: str, callback_query_id: str, text: str = ""
+) -> None:
+    """Acknowledge an inline-keyboard tap.
+
+    Telegram shows the loading spinner on the tapped button until this is
+    called (or 30s pass). `text` (≤200 chars) flashes as a toast — keep it
+    short or omit it; the real response should come via a regular message.
+    """
+    url = TELEGRAM_ANSWER_CALLBACK_URL.format(token=bot_token)
+    payload = {"callback_query_id": callback_query_id}
+    if text:
+        payload["text"] = text[:200]
+    try:
+        response = requests.post(url, json=payload, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        logger.error("Failed to answer callback_query.", extra={"error": str(e)})
+
+
+def edit_message_text(
+    bot_token: str,
+    chat_id: str,
+    message_id: int,
+    text: str,
+    parse_mode: str = "HTML",
+    reply_markup: Optional[dict] = None,
+) -> None:
+    """Replace an existing message's text (and optionally its keyboard).
+
+    Used after a callback_query tap to swap the picker for a "processing…"
+    status without leaving a stale menu hanging on the chat.
+    """
+    url = TELEGRAM_EDIT_MESSAGE_URL.format(token=bot_token)
+    payload: dict[str, Any] = {
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "text": text,
+        "parse_mode": parse_mode,
+    }
+    if reply_markup is not None:
+        payload["reply_markup"] = reply_markup
+    try:
+        response = requests.post(url, json=payload, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        logger.error("Failed to edit Telegram message.", extra={"error": str(e)})
 
 
 def send_telegram_photo(
@@ -112,13 +167,36 @@ def parse_command(text: str) -> str:
 def extract_webhook_update(request: Any) -> tuple[str, str]:
     """Extract (chat_id, text) from a Flask webhook POST request body.
 
-    Returns ('', '') for empty or malformed bodies.
+    Only handles plain text messages — callback_query updates go through
+    `extract_webhook_callback`. Returns ('', '') for empty/malformed bodies
+    or for updates that aren't text messages.
     """
     body = request.get_json(silent=True) or {}
     message = body.get("message", {})
     chat_id = str(message.get("chat", {}).get("id", ""))
     text = (message.get("text") or "").strip()
     return chat_id, text
+
+
+def extract_webhook_callback(request: Any) -> Optional[dict]:
+    """Pull the callback_query out of a Flask webhook POST.
+
+    Returns a dict with `id`, `chat_id`, `message_id` and `data` when the
+    update is an inline-keyboard tap, or None for any other update kind.
+    `data` is the `callback_data` string the button was created with —
+    typically `"prefix:value"`.
+    """
+    body = request.get_json(silent=True) or {}
+    cq = body.get("callback_query")
+    if not cq:
+        return None
+    message = cq.get("message") or {}
+    return {
+        "id": cq.get("id", ""),
+        "chat_id": str(message.get("chat", {}).get("id", "")),
+        "message_id": message.get("message_id"),
+        "data": cq.get("data", ""),
+    }
 
 
 def validate_webhook_secret(request: Any, expected: str) -> bool:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -190,11 +190,12 @@ ID token whose service account has `roles/run.invoker` on `biwenger-api`.
     |---|---|---|
     | `GET`  | `/health` | Liveness (do NOT use `/healthz` — GFE reserves it) |
     | `GET`  | `/version` | SHA + deploy time |
-    | `GET`  | `/teams` | All managers + market (was `/analizar`) |
-    | `GET`  | `/teams/mine` | My squad (was `/myteam`) |
+    | `GET`  | `/teams[?manager=<id>]` | One squad if `manager` is set; all managers + market otherwise |
+    | `GET`  | `/managers` | League managers list (powers the bot's `/analizar` picker) |
     | `GET`  | `/market` | Transfer market (was `/mercado`) |
     | `POST` | `/lineups/auto-pick` | Pick + apply lineup (was `/alinear`) |
     | `GET`  | `/budget/recommendations` | Top affordable clausulazo targets per position |
+    | `POST` | `/scraper/trigger` | Queue a scraper job execution (bot's `/scrapper`) |
     | `POST` | `/digests/daily` | Cron — my team + market (Scheduler only) |
 
   * **Smoke test:**

--- a/packages/biwenger_tools/api/README.md
+++ b/packages/biwenger_tools/api/README.md
@@ -16,8 +16,8 @@ OIDC ID token; the bot's and the Scheduler's service accounts both have
 |---|---|---|
 | `GET`  | `/health` | Liveness. **Do not use `/healthz`** — Google Frontend reserves it on `*.run.app`. |
 | `GET`  | `/version` | `{service, commit, deploy_time}` |
-| `GET`  | `/teams` | All managers + market (was `/analizar`) |
-| `GET`  | `/teams/mine` | My squad (was `/myteam`) |
+| `GET`  | `/teams[?manager=<id>]` | One squad if `manager` is set; all managers + market otherwise |
+| `GET`  | `/managers` | League managers list (powers the bot's `/analizar` picker) |
 | `GET`  | `/market` | Transfer market (was `/mercado`) |
 | `POST` | `/lineups/auto-pick` | Pick + apply lineup (was `/alinear`) |
 | `GET`  | `/budget/recommendations[?top=N]` | Top-N affordable clausulazo targets per position |

--- a/packages/biwenger_tools/api/app.py
+++ b/packages/biwenger_tools/api/app.py
@@ -62,14 +62,32 @@ def version():
 
 @app.route("/teams", methods=["GET"])
 def teams():
-    """All managers + market — was /analizar."""
-    return _run_action("teams", actions.run_all_teams)
+    """Squad images to Telegram.
+
+    Query params:
+      - `manager=<int>` — only that manager's squad (no market block).
+      - omitted (or `manager=all`) — every manager + market (the
+        original `/analizar` flow).
+    """
+    manager_arg = request.args.get("manager")
+    manager_id: int | None
+    if manager_arg in (None, "", "all"):
+        manager_id = None
+    else:
+        try:
+            manager_id = int(manager_arg)
+        except (TypeError, ValueError):
+            return (
+                jsonify({"status": "error", "error": "manager must be an integer"}),
+                400,
+            )
+    return _run_action("teams", lambda: actions.run_teams(manager_id))
 
 
-@app.route("/teams/mine", methods=["GET"])
-def teams_mine():
-    """My squad only — was /myteam."""
-    return _run_action("teams.mine", actions.run_my_team)
+@app.route("/managers", methods=["GET"])
+def managers():
+    """League managers — used by the bot's `/analizar` picker."""
+    return _run_action("managers", actions.list_managers)
 
 
 @app.route("/market", methods=["GET"])

--- a/packages/biwenger_tools/api/logic/actions.py
+++ b/packages/biwenger_tools/api/logic/actions.py
@@ -1,5 +1,5 @@
-"""Handlers for the bot-triggered endpoints (/teams, /teams/mine, /market,
-/lineups/auto-pick).
+"""Handlers for the bot-triggered endpoints (/teams, /market,
+/lineups/auto-pick, /managers).
 
 Each function owns one mode end to end: builds the JP index, opens the
 Biwenger session, computes the response, and sends the result to Telegram.
@@ -113,8 +113,15 @@ def _require_telegram() -> tuple[str, str] | None:
     return config.TELEGRAM_BOT_TOKEN, config.TELEGRAM_CHAT_ID
 
 
-def run_all_teams() -> dict:
-    """Send a separate image per manager + market — used by /teams (was /analizar)."""
+def run_teams(manager_id: int | None = None) -> dict:
+    """Send squad image(s) to Telegram.
+
+    - `manager_id is None` → ALL managers + market (the original
+      `/analizar` behaviour, used by the bot's "TODOS" menu choice).
+    - `manager_id` set → just that manager's squad; no market. The
+      Clausulable/Cláusula columns are included for rivals (not for
+      yourself — you already know your own clauses).
+    """
     biwenger, biwenger_players, jp_index = _prepare_context()
     telegram = _require_telegram()
     if telegram is None:
@@ -122,16 +129,46 @@ def run_all_teams() -> dict:
     token, chat_id = telegram
 
     managers = biwenger.get_league_users(config.LEAGUE_DATA_URL)
+
+    if manager_id is not None:
+        # Single-manager mode: one image, no market.
+        if manager_id not in managers:
+            send_telegram_message(
+                bot_token=token,
+                chat_id=chat_id,
+                text=(
+                    f"❌ Manager <code>{manager_id}</code> no encontrado en la liga."
+                ),
+            )
+            return {"sent": 0, "reason": "manager_not_found"}
+        manager_name = managers[manager_id]
+        is_me = manager_id == biwenger.user_id
+        squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, manager_id)
+        rows = build_squad_rows(
+            squad, biwenger_players, jp_index, include_clause=not is_me
+        )
+        title = "🛡️ Mi equipo" if is_me else f"👤 {manager_name}"
+        extra_cols = None if is_me else ["Clausulable", "Cláusula"]
+        _send_image(
+            token, chat_id, build_table_image(rows, title, extra_cols=extra_cols), title
+        )
+        logger.info(
+            "Single-manager analysis sent.",
+            extra={"manager": manager_name, "size": len(rows)},
+        )
+        return {"sent": 1, "manager": manager_name, "size": len(rows)}
+
+    # All-managers mode (original /analizar): every squad + market.
     my_team: list[dict] = []
     rivals: dict[str, list[dict]] = {}
 
-    for manager_id, manager_name in managers.items():
-        squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, manager_id)
+    for mgr_id, manager_name in managers.items():
+        squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, mgr_id)
         logger.info(
             "Squad fetched.",
             extra={"manager": manager_name, "size": len(squad)},
         )
-        if manager_id == biwenger.user_id:
+        if mgr_id == biwenger.user_id:
             my_team = build_squad_rows(squad, biwenger_players, jp_index)
         else:
             rivals[manager_name] = build_squad_rows(
@@ -165,19 +202,27 @@ def run_all_teams() -> dict:
     }
 
 
-def run_my_team() -> dict:
-    """Send only my squad — used by /teams/mine (was /myTeam)."""
-    biwenger, biwenger_players, jp_index = _prepare_context()
-    telegram = _require_telegram()
-    if telegram is None:
-        return {"sent": 0, "reason": "telegram_credentials_missing"}
-    token, chat_id = telegram
+def list_managers() -> dict:
+    """Return the manager list for the league.
 
-    my_squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, biwenger.user_id)
-    my_team = build_squad_rows(my_squad, biwenger_players, jp_index)
-    _send_image(token, chat_id, build_table_image(my_team, "Mi equipo"), "Mi equipo")
-    logger.info("My-team analysis sent.", extra={"size": len(my_team)})
-    return {"sent": 1, "size": len(my_team)}
+    Powers the bot's `/analizar` picker. Plain JSON, no Telegram side
+    effects — the bot uses the response to build an inline keyboard.
+    Mine is flagged so the bot can present it as "🛡️ Mi equipo".
+    """
+    biwenger = BiwengerClient(
+        config.BIWENGER_EMAIL,
+        config.BIWENGER_PASSWORD,
+        config.LOGIN_URL,
+        config.ACCOUNT_URL,
+        config.LEAGUE_ID,
+    )
+    managers = biwenger.get_league_users(config.LEAGUE_DATA_URL)
+    items = [
+        {"id": mgr_id, "name": name, "is_me": mgr_id == biwenger.user_id}
+        for mgr_id, name in managers.items()
+    ]
+    items.sort(key=lambda m: (not m["is_me"], m["name"].lower()))
+    return {"managers": items}
 
 
 def run_market() -> dict:

--- a/packages/biwenger_tools/api/tests/test_api.py
+++ b/packages/biwenger_tools/api/tests/test_api.py
@@ -121,32 +121,72 @@ def test_digests_daily_rejects_get(client):
     assert resp.status_code == 405  # method not allowed
 
 
-# --- /teams, /teams/mine, /market, /lineups/auto-pick ---
+# --- /teams, /managers, /market, /lineups/auto-pick ---
 
 
-def test_teams_calls_run_all_teams(client):
+def test_teams_without_manager_calls_run_teams_with_none(client):
+    """No `manager` query → run_teams(None) (all-managers + market)."""
     fake = {"sent": 5, "teams": 4, "market": 6}
     with patch(
-        "packages.biwenger_tools.api.app.actions.run_all_teams",
+        "packages.biwenger_tools.api.app.actions.run_teams",
         return_value=fake,
     ) as mock_run:
         resp = client.get("/teams")
-    mock_run.assert_called_once()
+    mock_run.assert_called_once_with(None)
     assert resp.status_code == 200
     body = resp.get_json()
     assert body["status"] == "ok"
     assert body["teams"] == 4
 
 
-def test_teams_mine_calls_run_my_team(client):
+def test_teams_with_manager_id_filters(client):
+    """`?manager=42` → run_teams(42) (single-squad image, no market)."""
     with patch(
-        "packages.biwenger_tools.api.app.actions.run_my_team",
-        return_value={"sent": 1, "size": 12},
+        "packages.biwenger_tools.api.app.actions.run_teams",
+        return_value={"sent": 1, "manager": "Jorge", "size": 12},
     ) as mock_run:
-        resp = client.get("/teams/mine")
-    mock_run.assert_called_once()
+        resp = client.get("/teams?manager=42")
+    mock_run.assert_called_once_with(42)
     assert resp.status_code == 200
     assert resp.get_json()["size"] == 12
+
+
+def test_teams_with_manager_all_is_alias_for_no_filter(client):
+    """`?manager=all` is treated the same as omitting the param."""
+    with patch(
+        "packages.biwenger_tools.api.app.actions.run_teams",
+        return_value={"sent": 5, "teams": 4, "market": 6},
+    ) as mock_run:
+        resp = client.get("/teams?manager=all")
+    mock_run.assert_called_once_with(None)
+    assert resp.status_code == 200
+
+
+def test_teams_with_invalid_manager_returns_400(client):
+    """A non-integer `manager` param is rejected upfront."""
+    resp = client.get("/teams?manager=abc")
+    assert resp.status_code == 400
+    assert "manager must be an integer" in resp.get_json()["error"]
+
+
+def test_managers_endpoint(client):
+    """The picker endpoint exposes the manager list to the bot."""
+    fake = {
+        "managers": [
+            {"id": 1, "name": "Jorge", "is_me": True},
+            {"id": 2, "name": "Pepe", "is_me": False},
+        ]
+    }
+    with patch(
+        "packages.biwenger_tools.api.app.actions.list_managers",
+        return_value=fake,
+    ) as mock_run:
+        resp = client.get("/managers")
+    mock_run.assert_called_once()
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "ok"
+    assert body["managers"][0]["is_me"] is True
 
 
 def test_market_calls_run_market(client):
@@ -181,7 +221,7 @@ def test_lineups_auto_pick_rejects_get(client):
 
 def test_action_endpoint_returns_500_on_exception(client):
     with patch(
-        "packages.biwenger_tools.api.app.actions.run_all_teams",
+        "packages.biwenger_tools.api.app.actions.run_teams",
         side_effect=RuntimeError("biwenger 503"),
     ):
         resp = client.get("/teams")

--- a/packages/biwenger_tools/bot/README.md
+++ b/packages/biwenger_tools/bot/README.md
@@ -21,14 +21,19 @@ silently dropped (returns `200` so Telegram does not retry).
    with a Google-signed ID token.
 
 ```
-/analizar    →  GET  /teams
-/myteam      →  GET  /teams/mine
+/menu        →  sends an inline-keyboard menu (no api call)
+/analizar    →  opens the manager picker (GET /managers, then /teams?manager=<id|all>)
 /mercado     →  GET  /market
 /alinear     →  POST /lineups/auto-pick
 /recomendar  →  GET  /budget/recommendations
+/scrapper    →  POST /scraper/trigger
 /version     →  bot SHA + GET /version on biwenger-api
 /help        →  static HTML message (no api call)
 ```
+
+Inline-keyboard taps come back as `callback_query` updates. They share
+the same webhook entry point and dispatch on a `prefix:value`
+`callback_data` shape (`menu:<action>`, `analizar:<id|all>`).
 
 The api processes each request synchronously (build JP index, talk to
 Biwenger, render PNG, send to Telegram). The bot is just the HTTP edge.

--- a/packages/biwenger_tools/bot/api_client.py
+++ b/packages/biwenger_tools/bot/api_client.py
@@ -27,7 +27,11 @@ def _fetch_id_token(audience: str) -> str:
 
 
 def call_api(
-    base_url: str, path: str, method: str = "POST", timeout: int = 600
+    base_url: str,
+    path: str,
+    method: str = "POST",
+    timeout: int = 600,
+    params: dict | None = None,
 ) -> None:
     """Call biwenger-api with an ID token. Raises on non-2xx.
 
@@ -45,6 +49,7 @@ def call_api(
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
         },
+        params=params,
         json={} if method != "GET" else None,
         timeout=timeout,
     )
@@ -53,6 +58,32 @@ def call_api(
         "biwenger-api call ok.",
         extra={"path": path, "method": method, "status": resp.status_code},
     )
+
+
+def list_managers(base_url: str, timeout: int = 30) -> list[dict] | None:
+    """Fetch the league managers — used by the bot's /analizar picker.
+
+    Returns a list of `{id, name, is_me}` or None on failure. Short
+    timeout: the api endpoint hits Biwenger's `league` endpoint once and
+    returns plain JSON, no images.
+    """
+    url = base_url.rstrip("/") + "/managers"
+    try:
+        token = _fetch_id_token(base_url)
+        resp = http_requests.get(
+            url,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        return resp.json().get("managers", [])
+    except (
+        google.auth.exceptions.GoogleAuthError,
+        http_requests.RequestException,
+        ValueError,
+    ) as exc:
+        logger.warning("Failed to fetch managers.", extra={"error": str(exc)})
+        return None
 
 
 def get_api_version(base_url: str, timeout: int = 10) -> dict | None:

--- a/packages/biwenger_tools/bot/app.py
+++ b/packages/biwenger_tools/bot/app.py
@@ -1,17 +1,34 @@
-"""Biwenger bot service — handles Telegram webhook and calls biwenger-api."""
+"""Biwenger bot service — handles Telegram webhook and calls biwenger-api.
+
+Two kinds of updates land on the webhook:
+
+1. **Text commands** (`/menu`, `/analizar`, etc.). `/analizar` opens the
+   manager picker; the rest dispatch directly to biwenger-api.
+2. **Inline-keyboard taps** (callback_query). `menu:<action>` rows
+   either dispatch the action (mercado, alinear, …) or — for analizar —
+   answer with the manager picker. `analizar:<id|all>` taps run the
+   teams endpoint with the selected filter.
+
+Heavy work always runs synchronously against biwenger-api; the bot only
+acknowledges the tap, edits the picker into a "processing…" message and
+lets the api post the results.
+"""
 
 import os
 
 from flask import Flask, request
 
 from core.sdk.telegram import (
+    answer_callback_query,
+    edit_message_text,
+    extract_webhook_callback,
     extract_webhook_update,
     parse_command,
     send_telegram_message,
     validate_webhook_secret,
 )
 from core.utils import get_logger
-from packages.biwenger_tools.bot import api_client, config
+from packages.biwenger_tools.bot import api_client, config, menu
 
 logger = get_logger(__name__)
 
@@ -19,8 +36,8 @@ app = Flask(__name__)
 
 _HELP_TEXT = (
     "<b>Biwenger Bot</b>\n\n"
-    "/analizar — Análisis completo (todos los equipos)\n"
-    "/myteam — Análisis solo de mi equipo\n"
+    "/menu — Menú visual con botones (recomendado)\n"
+    "/analizar — Análisis (te pregunta a quién)\n"
     "/mercado — Solo el mercado\n"
     "/alinear — Aplica la mejor alineación posible\n"
     "/recomendar — Qué fichar si me clausulan (top 3 por posición)\n"
@@ -29,14 +46,13 @@ _HELP_TEXT = (
     "/help — Muestra este mensaje"
 )
 
-# Map Telegram command → (api path, http method).
-_COMMAND_ROUTES = {
-    "/analizar": ("/teams", "GET"),
-    "/myteam": ("/teams/mine", "GET"),
-    "/mercado": ("/market", "GET"),
-    "/alinear": ("/lineups/auto-pick", "POST"),
-    "/recomendar": ("/budget/recommendations", "GET"),
-    "/scrapper": ("/scraper/trigger", "POST"),
+# Map main-menu action key → (api path, http method). `analizar` is special
+# because it opens the manager picker before hitting any endpoint.
+_ACTION_ROUTES = {
+    "mercado": ("/market", "GET"),
+    "alinear": ("/lineups/auto-pick", "POST"),
+    "recomendar": ("/budget/recommendations", "GET"),
+    "scrapper": ("/scraper/trigger", "POST"),
 }
 
 
@@ -63,6 +79,144 @@ def _build_version_text() -> str:
     )
 
 
+def _send_menu() -> None:
+    """Send the main inline-keyboard menu to the configured chat."""
+    send_telegram_message(
+        bot_token=config.TELEGRAM_BOT_TOKEN,
+        chat_id=config.TELEGRAM_CHAT_ID,
+        text="<b>¿Qué hacemos?</b>",
+        reply_markup=menu.main_menu_keyboard(),
+    )
+
+
+def _send_manager_picker() -> None:
+    """Ask biwenger-api for the manager list and post the picker keyboard.
+
+    Hitting `/managers` on every tap is fine — it's a single Biwenger
+    league call (well under a second). No caching keeps the flow stateless.
+    """
+    managers = (
+        api_client.list_managers(config.BIWENGER_API_URL)
+        if config.BIWENGER_API_URL
+        else None
+    )
+    if not managers:
+        send_telegram_message(
+            bot_token=config.TELEGRAM_BOT_TOKEN,
+            chat_id=config.TELEGRAM_CHAT_ID,
+            text="❌ No pude cargar la lista de managers. Vuelve a intentarlo.",
+        )
+        return
+    send_telegram_message(
+        bot_token=config.TELEGRAM_BOT_TOKEN,
+        chat_id=config.TELEGRAM_CHAT_ID,
+        text="<b>📊 Analizar — ¿a quién?</b>",
+        reply_markup=menu.managers_keyboard(managers),
+    )
+
+
+def _dispatch_action(action_key: str, label: str) -> None:
+    """Send "procesando…" and fire the matching api endpoint."""
+    path, method = _ACTION_ROUTES[action_key]
+    send_telegram_message(
+        bot_token=config.TELEGRAM_BOT_TOKEN,
+        chat_id=config.TELEGRAM_CHAT_ID,
+        text=f"⏳ <b>{label}</b> — procesando…",
+    )
+    try:
+        api_client.call_api(config.BIWENGER_API_URL, path, method=method)
+    except Exception as exc:
+        logger.error(
+            "Webhook: api call failed",
+            extra={"action": action_key, "error": str(exc)},
+        )
+        send_telegram_message(
+            bot_token=config.TELEGRAM_BOT_TOKEN,
+            chat_id=config.TELEGRAM_CHAT_ID,
+            text=f"❌ Error al ejecutar <b>{label}</b>: <code>{exc}</code>",
+        )
+
+
+def _run_analizar(manager_value: str, edit_into: tuple[str, int] | None) -> None:
+    """Call `/teams` with the selected manager filter.
+
+    `edit_into` is a `(chat_id, message_id)` of the picker that triggered
+    this — when present, the picker is replaced with a "procesando…" line
+    so the chat history stays clean. `manager_value` is the raw callback
+    payload: either a digit string (manager id) or `"all"`.
+    """
+    if manager_value == "all":
+        params = None
+        label = "Analizar — TODOS"
+    else:
+        params = {"manager": manager_value}
+        label = f"Analizar — manager {manager_value}"
+
+    status_text = f"⏳ <b>{label}</b> — procesando…"
+    if edit_into is not None:
+        chat_id, message_id = edit_into
+        edit_message_text(
+            bot_token=config.TELEGRAM_BOT_TOKEN,
+            chat_id=chat_id,
+            message_id=message_id,
+            text=status_text,
+        )
+    else:
+        send_telegram_message(
+            bot_token=config.TELEGRAM_BOT_TOKEN,
+            chat_id=config.TELEGRAM_CHAT_ID,
+            text=status_text,
+        )
+
+    try:
+        api_client.call_api(
+            config.BIWENGER_API_URL, "/teams", method="GET", params=params
+        )
+    except Exception as exc:
+        logger.error(
+            "Webhook: /teams call failed",
+            extra={"manager": manager_value, "error": str(exc)},
+        )
+        send_telegram_message(
+            bot_token=config.TELEGRAM_BOT_TOKEN,
+            chat_id=config.TELEGRAM_CHAT_ID,
+            text=f"❌ Error al ejecutar <b>{label}</b>: <code>{exc}</code>",
+        )
+
+
+def _handle_callback(cb: dict) -> None:
+    """Dispatch on the callback_data prefix.
+
+    `menu:analizar` opens the manager picker (a second keyboard).
+    `menu:<other>` fires the matching api endpoint.
+    `analizar:<id|all>` runs `/teams` with the filter.
+    """
+    answer_callback_query(config.TELEGRAM_BOT_TOKEN, cb["id"])
+    data = cb.get("data", "")
+    if ":" not in data:
+        logger.info("Webhook: unknown callback_data", extra={"data": data})
+        return
+    prefix, value = data.split(":", 1)
+
+    if prefix == "menu":
+        if value == "analizar":
+            _send_manager_picker()
+            return
+        if value in _ACTION_ROUTES:
+            label = next(lbl for key, lbl in menu.MAIN_MENU_ACTIONS if key == value)
+            _dispatch_action(value, label)
+            return
+        logger.info("Webhook: unknown menu action", extra={"value": value})
+        return
+
+    if prefix == "analizar":
+        edit_into = (cb["chat_id"], cb["message_id"]) if cb.get("message_id") else None
+        _run_analizar(value, edit_into)
+        return
+
+    logger.info("Webhook: unhandled callback prefix", extra={"prefix": prefix})
+
+
 @app.route("/telegram/webhook", methods=["POST"])
 def webhook():
     if not validate_webhook_secret(request, config.TELEGRAM_WEBHOOK_SECRET):
@@ -75,8 +229,19 @@ def webhook():
         )
         return "", 401
 
-    chat_id, text = extract_webhook_update(request)
+    # Inline-keyboard tap first — callback updates carry no `message.text`.
+    cb = extract_webhook_callback(request)
+    if cb is not None:
+        if cb["chat_id"] != config.TELEGRAM_CHAT_ID:
+            logger.info(
+                "Webhook: ignoring callback from unknown chat",
+                extra={"chat_id": cb["chat_id"]},
+            )
+            return "", 200
+        _handle_callback(cb)
+        return "", 200
 
+    chat_id, text = extract_webhook_update(request)
     if chat_id != config.TELEGRAM_CHAT_ID:
         logger.info(
             "Webhook: ignoring message from unknown chat",
@@ -86,35 +251,27 @@ def webhook():
 
     cmd = parse_command(text)
 
-    if cmd in _COMMAND_ROUTES:
-        path, method = _COMMAND_ROUTES[cmd]
-        logger.info("Webhook: %s received — calling api %s %s", cmd, method, path)
-        send_telegram_message(
-            bot_token=config.TELEGRAM_BOT_TOKEN,
-            chat_id=config.TELEGRAM_CHAT_ID,
-            text=f"⏳ <code>{cmd}</code> recibido, procesando…",
-        )
-        try:
-            api_client.call_api(config.BIWENGER_API_URL, path, method=method)
-        except Exception as exc:
-            logger.error(
-                "Webhook: api call failed",
-                extra={"cmd": cmd, "error": str(exc)},
-            )
-            send_telegram_message(
-                bot_token=config.TELEGRAM_BOT_TOKEN,
-                chat_id=config.TELEGRAM_CHAT_ID,
-                text=f"❌ Error al ejecutar <code>{cmd}</code>: <code>{exc}</code>",
-            )
+    if cmd in ("/menu", "/start"):
+        logger.info("Webhook: %s received", cmd)
+        _send_menu()
+    elif cmd == "/analizar":
+        logger.info("Webhook: /analizar received — sending picker")
+        _send_manager_picker()
+    elif cmd == "/mercado":
+        _dispatch_action("mercado", "🛒 Mercado")
+    elif cmd == "/alinear":
+        _dispatch_action("alinear", "📋 Alinear")
+    elif cmd == "/recomendar":
+        _dispatch_action("recomendar", "💡 Recomendar")
+    elif cmd == "/scrapper":
+        _dispatch_action("scrapper", "🧹 Scraper")
     elif cmd == "/help":
-        logger.info("Webhook: /help received")
         send_telegram_message(
             bot_token=config.TELEGRAM_BOT_TOKEN,
             chat_id=config.TELEGRAM_CHAT_ID,
             text=_HELP_TEXT,
         )
     elif cmd == "/version":
-        logger.info("Webhook: /version received")
         send_telegram_message(
             bot_token=config.TELEGRAM_BOT_TOKEN,
             chat_id=config.TELEGRAM_CHAT_ID,

--- a/packages/biwenger_tools/bot/menu.py
+++ b/packages/biwenger_tools/bot/menu.py
@@ -1,0 +1,51 @@
+"""Inline-keyboard builders for the bot's /menu UI.
+
+The webhook handler in ``app.py`` calls these to produce the dicts that
+Telegram's ``reply_markup`` expects. Keep them pure and stateless — the
+network round-trips happen there, not here.
+
+`callback_data` strings are namespaced with a `"prefix:value"` form so
+the handler can dispatch on the prefix:
+
+- ``menu:<action>``     → main menu tap (analizar / mercado / …).
+- ``analizar:<id|all>`` → manager picker tap.
+"""
+
+from typing import Iterable
+
+# Main-menu actions. Order matters — the rows in the keyboard mirror this.
+MAIN_MENU_ACTIONS = [
+    ("analizar", "📊 Analizar"),
+    ("mercado", "🛒 Mercado"),
+    ("alinear", "📋 Alinear"),
+    ("recomendar", "💡 Recomendar"),
+    ("scrapper", "🧹 Scraper"),
+]
+
+
+def main_menu_keyboard() -> dict:
+    """Two-column inline keyboard with every main-menu action."""
+    buttons = [
+        {"text": label, "callback_data": f"menu:{key}"}
+        for key, label in MAIN_MENU_ACTIONS
+    ]
+    rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
+    return {"inline_keyboard": rows}
+
+
+def managers_keyboard(managers: Iterable[dict]) -> dict:
+    """Vertical keyboard with one button per manager + a "TODOS" row.
+
+    Each manager dict needs `id`, `name`, `is_me`. "Mi equipo" sits at
+    the top (the api already orders the list that way), then the rivals,
+    then the "TODOS" row.
+    """
+    rows = []
+    for m in managers:
+        if m.get("is_me"):
+            label = f"🛡️ Mi equipo ({m['name']})"
+        else:
+            label = f"👤 {m['name']}"
+        rows.append([{"text": label, "callback_data": f"analizar:{m['id']}"}])
+    rows.append([{"text": "🌍 TODOS", "callback_data": "analizar:all"}])
+    return {"inline_keyboard": rows}

--- a/packages/biwenger_tools/bot/setup_commands.py
+++ b/packages/biwenger_tools/bot/setup_commands.py
@@ -12,8 +12,8 @@ from packages.biwenger_tools.bot import config
 from core.sdk.telegram import register_bot_commands, set_commands_menu_button
 
 COMMANDS = [
-    {"command": "analizar", "description": "Análisis completo de todos los equipos"},
-    {"command": "myteam", "description": "Análisis solo de mi equipo"},
+    {"command": "menu", "description": "Menú visual con botones (recomendado)"},
+    {"command": "analizar", "description": "Análisis (te pregunta a quién)"},
     {"command": "mercado", "description": "Solo el mercado"},
     {"command": "alinear", "description": "Aplica la mejor alineación posible"},
     {

--- a/packages/biwenger_tools/bot/tests/test_bot.py
+++ b/packages/biwenger_tools/bot/tests/test_bot.py
@@ -33,6 +33,18 @@ def _update(chat_id, text):
     return {"update_id": 1, "message": {"chat": {"id": chat_id}, "text": text}}
 
 
+def _callback_update(chat_id, data, message_id=42, query_id="cb-1"):
+    """Webhook body for an inline-keyboard tap."""
+    return {
+        "update_id": 2,
+        "callback_query": {
+            "id": query_id,
+            "data": data,
+            "message": {"chat": {"id": chat_id}, "message_id": message_id},
+        },
+    }
+
+
 def _post(client, body, secret=_VALID_SECRET):
     return client.post(
         "/telegram/webhook",
@@ -45,13 +57,13 @@ def _post(client, body, secret=_VALID_SECRET):
 
 
 def test_wrong_secret_returns_401(client):
-    resp = _post(client, _update(_VALID_CHAT, "/analizar"), secret="wrong")
+    resp = _post(client, _update(_VALID_CHAT, "/mercado"), secret="wrong")
     assert resp.status_code == 401
 
 
 def test_correct_secret_returns_200(client):
     with patch("packages.biwenger_tools.bot.app.api_client.call_api"):
-        resp = _post(client, _update(_VALID_CHAT, "/analizar"))
+        resp = _post(client, _update(_VALID_CHAT, "/mercado"))
     assert resp.status_code == 200
 
 
@@ -60,38 +72,42 @@ def test_correct_secret_returns_200(client):
 
 def test_wrong_chat_id_is_silently_ignored(client):
     with patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call:
-        resp = _post(client, _update("999999", "/analizar"))
+        resp = _post(client, _update("999999", "/mercado"))
     assert resp.status_code == 200
     mock_call.assert_not_called()
 
 
-# --- Command → api route mapping ---
+def test_wrong_chat_callback_is_silently_ignored(client):
+    with patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call:
+        resp = _post(client, _callback_update("999999", "menu:mercado"))
+    assert resp.status_code == 200
+    mock_call.assert_not_called()
+
+
+# --- Direct text commands → api route mapping ---
 
 
 @pytest.mark.parametrize(
     "command,path,method",
     [
-        ("/analizar", "/teams", "GET"),
-        ("/myTeam", "/teams/mine", "GET"),
-        ("/myteam", "/teams/mine", "GET"),
         ("/mercado", "/market", "GET"),
         ("/alinear", "/lineups/auto-pick", "POST"),
         ("/recomendar", "/budget/recommendations", "GET"),
         ("/scrapper", "/scraper/trigger", "POST"),
     ],
 )
-def test_command_calls_correct_api_endpoint(client, command, path, method):
+def test_text_command_calls_api(client, command, path, method):
     with patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call:
         resp = _post(client, _update(_VALID_CHAT, command))
     assert resp.status_code == 200
     mock_call.assert_called_once_with(_API_URL, path, method=method)
 
 
-def test_command_with_botname_suffix_calls_api(client):
+def test_command_with_botname_suffix_routes_correctly(client):
     with patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call:
-        resp = _post(client, _update(_VALID_CHAT, "/analizar@biwenger_tools_bot"))
+        resp = _post(client, _update(_VALID_CHAT, "/mercado@biwenger_tools_bot"))
     assert resp.status_code == 200
-    mock_call.assert_called_once_with(_API_URL, "/teams", method="GET")
+    mock_call.assert_called_once_with(_API_URL, "/market", method="GET")
 
 
 def test_api_call_failure_sends_error_message(client):
@@ -99,12 +115,141 @@ def test_api_call_failure_sends_error_message(client):
         "packages.biwenger_tools.bot.app.api_client.call_api",
         side_effect=RuntimeError("permission denied"),
     ), patch("packages.biwenger_tools.bot.app.send_telegram_message") as mock_send:
-        resp = _post(client, _update(_VALID_CHAT, "/analizar"))
+        resp = _post(client, _update(_VALID_CHAT, "/mercado"))
     assert resp.status_code == 200
     # first call = ACK, second call = error
     assert mock_send.call_count == 2
     error_text = mock_send.call_args_list[1].kwargs.get("text", "")
     assert "permission denied" in error_text
+
+
+# --- /analizar opens the manager picker ---
+
+
+def test_analizar_text_command_opens_manager_picker(client):
+    """`/analizar` does NOT call /teams directly — it opens the picker."""
+    fake_managers = [
+        {"id": 1, "name": "Jorge", "is_me": True},
+        {"id": 2, "name": "Pepe", "is_me": False},
+    ]
+    with patch(
+        "packages.biwenger_tools.bot.app.api_client.list_managers",
+        return_value=fake_managers,
+    ), patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call, patch(
+        "packages.biwenger_tools.bot.app.send_telegram_message"
+    ) as mock_send:
+        resp = _post(client, _update(_VALID_CHAT, "/analizar"))
+    assert resp.status_code == 200
+    mock_call.assert_not_called()
+    # The picker message carries an inline keyboard with one row per manager
+    # plus the TODOS row.
+    markup = mock_send.call_args.kwargs.get("reply_markup")
+    assert markup is not None
+    rows = markup["inline_keyboard"]
+    assert len(rows) == 3  # 2 managers + TODOS
+    assert rows[-1][0]["callback_data"] == "analizar:all"
+
+
+def test_analizar_text_command_handles_manager_fetch_failure(client):
+    """If `/managers` is unreachable, the bot tells the user instead of
+    sending an empty keyboard."""
+    with patch(
+        "packages.biwenger_tools.bot.app.api_client.list_managers",
+        return_value=None,
+    ), patch("packages.biwenger_tools.bot.app.send_telegram_message") as mock_send:
+        resp = _post(client, _update(_VALID_CHAT, "/analizar"))
+    assert resp.status_code == 200
+    text = mock_send.call_args.kwargs.get("text", "")
+    assert "No pude cargar la lista" in text
+
+
+# --- /menu sends the main keyboard ---
+
+
+def test_menu_sends_inline_keyboard(client):
+    with patch("packages.biwenger_tools.bot.app.send_telegram_message") as mock_send:
+        resp = _post(client, _update(_VALID_CHAT, "/menu"))
+    assert resp.status_code == 200
+    markup = mock_send.call_args.kwargs.get("reply_markup")
+    assert markup is not None
+    # 5 actions arranged in 2 columns → 3 rows
+    assert len(markup["inline_keyboard"]) == 3
+    flattened = [b["callback_data"] for row in markup["inline_keyboard"] for b in row]
+    assert "menu:analizar" in flattened
+    assert "menu:scrapper" in flattened
+
+
+def test_start_aliases_menu(client):
+    with patch("packages.biwenger_tools.bot.app.send_telegram_message") as mock_send:
+        resp = _post(client, _update(_VALID_CHAT, "/start"))
+    assert resp.status_code == 200
+    assert mock_send.call_args.kwargs.get("reply_markup") is not None
+
+
+# --- callback_query handling ---
+
+
+def test_menu_callback_dispatches_action(client):
+    """Tapping the "Mercado" button on the menu fires `/market`."""
+    with patch(
+        "packages.biwenger_tools.bot.app.answer_callback_query"
+    ) as mock_ack, patch(
+        "packages.biwenger_tools.bot.app.api_client.call_api"
+    ) as mock_call:
+        resp = _post(client, _callback_update(_VALID_CHAT, "menu:mercado"))
+    assert resp.status_code == 200
+    mock_ack.assert_called_once()
+    mock_call.assert_called_once_with(_API_URL, "/market", method="GET")
+
+
+def test_menu_analizar_callback_opens_picker(client):
+    """Tapping "Analizar" in the menu opens the manager picker."""
+    fake_managers = [{"id": 1, "name": "Jorge", "is_me": True}]
+    with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
+        "packages.biwenger_tools.bot.app.api_client.list_managers",
+        return_value=fake_managers,
+    ), patch("packages.biwenger_tools.bot.app.send_telegram_message") as mock_send:
+        resp = _post(client, _callback_update(_VALID_CHAT, "menu:analizar"))
+    assert resp.status_code == 200
+    markup = mock_send.call_args.kwargs.get("reply_markup")
+    assert markup is not None
+    flattened = [b["callback_data"] for row in markup["inline_keyboard"] for b in row]
+    assert "analizar:1" in flattened
+    assert "analizar:all" in flattened
+
+
+def test_analizar_id_callback_calls_teams_with_filter(client):
+    """A manager tap calls `/teams?manager=<id>` and edits the picker."""
+    with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
+        "packages.biwenger_tools.bot.app.edit_message_text"
+    ) as mock_edit, patch(
+        "packages.biwenger_tools.bot.app.api_client.call_api"
+    ) as mock_call:
+        resp = _post(client, _callback_update(_VALID_CHAT, "analizar:7"))
+    assert resp.status_code == 200
+    mock_edit.assert_called_once()
+    mock_call.assert_called_once_with(
+        _API_URL, "/teams", method="GET", params={"manager": "7"}
+    )
+
+
+def test_analizar_all_callback_calls_teams_without_filter(client):
+    """The TODOS tap fires `/teams` with no `manager` param (legacy flow)."""
+    with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
+        "packages.biwenger_tools.bot.app.edit_message_text"
+    ), patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call:
+        resp = _post(client, _callback_update(_VALID_CHAT, "analizar:all"))
+    assert resp.status_code == 200
+    mock_call.assert_called_once_with(_API_URL, "/teams", method="GET", params=None)
+
+
+def test_unknown_callback_prefix_is_ignored(client):
+    with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
+        "packages.biwenger_tools.bot.app.api_client.call_api"
+    ) as mock_call:
+        resp = _post(client, _callback_update(_VALID_CHAT, "bogus:value"))
+    assert resp.status_code == 200
+    mock_call.assert_not_called()
 
 
 # --- /help, /version, unknown ---


### PR DESCRIPTION
## Summary
Replaces the text-only bot UI with inline keyboards. Two highlights:

1. **`/menu`** (and `/start`) sends a 2-column keyboard with every action — visual entry point that beats memorising slash commands.
2. **`/analizar`** asks who to analyze. The keyboard lists each manager (with 🛡️ for "Mi equipo") plus a "🌍 TODOS" row that triggers the original full sweep. Solves the "ahora mismo me saca a todos" pain.

\`/myteam\` retired — "🛡️ Mi equipo" is just another entry in the picker.

## Surface
| Bot input | Behavior |
|---|---|
| \`/menu\` / \`/start\` | sends main keyboard (analizar / mercado / alinear / recomendar / scrapper) |
| \`/analizar\` | sends manager picker |
| tap **menu:X** | dispatches the action directly |
| tap **menu:analizar** | sends manager picker |
| tap **analizar:<id>** | calls \`GET /teams?manager=<id>\` |
| tap **analizar:all** | calls \`GET /teams\` (full sweep) |

## API changes
- \`GET /teams\` accepts \`?manager=<int>\` or \`?manager=all\`.
- New \`GET /managers\` returns \`{managers: [{id, name, is_me}]}\`.
- \`GET /teams/mine\` retired.
- \`run_all_teams\` + \`run_my_team\` collapse into \`run_teams(manager_id)\`.

## SDK additions (\`core/sdk/telegram.py\`)
- \`send_telegram_message\` learns \`reply_markup\`.
- \`answer_callback_query\`, \`edit_message_text\` for the callback flow.
- \`extract_webhook_callback\` reads \`callback_query\` updates.

## Test plan
- [x] \`bazel test //...\` green across all 6 packages.
- [x] \`bash scripts/lint.sh\` clean.
- [ ] After deploy: run \`python3 packages/biwenger_tools/bot/setup_commands.py\` to refresh the \`/\` menu (drops \`/myteam\`, adds \`/menu\`).
- [ ] \`/menu\` shows the 5-button keyboard; tapping each action does the right thing.
- [ ] \`/analizar\` shows the manager picker; tapping a name sends just that squad; tapping "🌍 TODOS" sends everything + market.
- [ ] \`/myteam\` no longer responds (or shows "comando desconocido" silently — which is the design).