### PR TITLE
feat(jp,bot): JP cache + /preview + bot auto-setup in CI

### DIFF
--- a/.claude/plans/next_phases.md
+++ b/.claude/plans/next_phases.md
@@ -40,85 +40,30 @@ PR 1 – PR 6 of `.claude/plans/biwenger_api_refactor.md` (now deleted, see rele
 
 ## Pending work
 
-### 1. Firestore migration — SHIPPED (2026-05-21)
+### 1. Drive folder cleanup — USER-OWNED (week of 2026-05-26)
 
-Done. Web reads from Firestore, scraper writes to Firestore, indexes
-declared in `firestore.indexes.json`, schemas + read-cost reference in
-`docs/firestore.md`. The CSV/Drive read path was retired in PR #82 and
-the dual-write retired in the "part 2" cleanup PR. Drive folder
-contents will be deleted by the user when the league ends.
+When the league ends: delete the Drive folder contents (the old CSVs the
+scraper used to upload), then drop the `biwenger-tools-sa-regional`
+secret — or repoint it to a Sheets-only SA, because the Sheets API
+(ligas_especiales, trofeos) still authenticates through that mount.
 
-The deferred-plan section that used to live here (with schemas, gotchas,
-and the one-time backfill) is preserved in the git history at
-commit 08c4a4e (`.claude/plans/firestore_pickup.md`) in case the
-context is ever needed again.
-
-Schemas, indexes, and read-cost reference live in `docs/firestore.md`.
-
-**User-owned cleanup (week of 2026-05-26):** delete the Drive folder
-contents, then drop the `biwenger-tools-sa-regional` secret (or repoint
-it to a Sheets-only SA — Sheets API is still wired up).
-
-### 2. New GCP project for photos (no spec yet)
-Mentioned as TODO. Waiting for spec.
+### 2. Photo-recognition project
+Tracked in `packages/my_photos/README.md`, not here.
 
 ### 3. Move Drive/Sheets IDs out of BUILD.bazel
-Currently hardcoded in `packages/biwenger_tools/web/BUILD.bazel`. Dies naturally with Firestore migration.
-
-### 4. Bot display name in Telegram set to "Biwenger Tools Bot"
-Done via BotFather on 2026-05-18.
+Sheets IDs are still hardcoded in `packages/biwenger_tools/web/BUILD.bazel`. Env-var the `LIGAS_ESPECIALES_*` / `TROFEOS_*` entries when convenient — low priority.
 
 ---
 
-## Mejoras propuestas (senior review 2026-05-19, ordenadas por impacto)
+## Shipped this sprint (2026-05-21 → 22)
 
-Surfaced during a code-review pass after the v6.0 refactor shipped. None
-of these block anything; pick when ready.
-
-1. **JP cache in the api.** Today `/alinear`, `/teams`, etc. pay ~5–10s of
-   JP fetch per call. A 5-minute in-process cache on
-   `core.sdk.jp.fetch_all_players` (the JP response is identical for all
-   five endpoints within a few minutes) drops average request time to
-   ~2s and reduces load on the private JP API. ~10 LoC with a TTL decorator.
-
-2. **Cloud Run alerts for `biwenger-api` and the scraper job.** Free tier
-   covers 5 alerts. Two minimum:
-   - `biwenger-api` 5xx > 0 in a 5-minute window
-   - Scraper job execution failed (now that the job re-raises on error,
-     this is finally meaningful)
-   The api already notifies Telegram on `/alinear` failure; Cloud Run alerts
-   add coverage for the cases where the bot never even reaches the api
-   (deploy regression, OIDC misconfiguration, etc.).
-
-3. **`/alinear` dry-run mode.** `POST /lineups/auto-pick?dry_run=1` skips
-   the Biwenger PUT and just sends "would have done X" to Telegram. ~10
-   LoC plus a bot flag or a separate `/alinear?` syntax. Useful when you
-   want to see what the picker would do without committing.
-
-4. **Auto-register bot commands on deploy.** `setup_commands.py` is
-   one-shot and manual today. Hook it into CI's `deploy-bot` job
-   (post-deploy step). Doable in 1 step:
-   `gcloud run jobs execute biwenger-bot-setup-commands` — or simpler,
-   add a `setup-commands` step to the deploy.yml that uses
-   `gcloud secrets versions access` + a few lines of curl.
-
-5. **Single-tenant escape.** League ID, chat ID and user identity are
-   hard-coded for one user. If a second pana wants to use it, ~1 sprint
-   to extract per-user config into a Firestore `users/{user_id}`
-   collection. Decision should drive whether to invest — if it's a
-   personal project, fine to keep single-tenant.
-
-6. **Tests mutate module-level `cfg.X`.** Works because pytest is serial.
-   Migrate the relevant tests to use a `monkeypatch` fixture-injection
-   pattern. Low priority — touched only when we modify those tests.
-
-7. **Drive/Sheets IDs in `web/BUILD.bazel`.** Dies naturally with the
-   Firestore migration; until then, env-vars would work fine.
-
-8. **Documentation auto-render of the architecture diagram.** The
-   Mermaid in `README.md` is hand-written and drifts. A small script
-   that introspects `deploy.yml` + READMEs could regenerate it. Low
-   priority.
+- **Firestore migration** — web reads/writes through `repository.py`; scraper writes only to Firestore; schemas + indexes + read-cost reference in `docs/firestore.md`.
+- **Server-side queries** in the web — paginated comunicados via Firestore `count` + `limit/offset`; salseo runs one query per content type instead of full-scan; lazy-load search box for free-text.
+- **Drive/CSV pipeline retired** — `core.sdk.gcp.{find_file_on_drive, download_csv_*, upload_csv_*, get_file_metadata}` deleted. Sheets API still uses the SA mount.
+- **Bot UI overhaul** — `/menu` keyboard + `/analizar` manager picker (`menu:<action>`, `analizar:<id|all>` callbacks). `/myteam` retired in favour of "🛡️ Mi equipo" in the picker.
+- **`/preview`** — `POST /lineups/auto-pick?dry_run=1` previews the lineup without the Biwenger PUT.
+- **JP cache** (`core/sdk/jp.py`) — in-process dict keyed by `(competition, score_type)`, invalidated via a `limit=1` `updated_at` probe. ~5-10s → ~200ms on cache hits.
+- **Bot auto-setup in CI** — post-deploy step re-registers commands + sets the webhook with `allowed_updates=["message","callback_query"]` so the menu callbacks never silently break again.
 
 ---
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -310,6 +310,28 @@ jobs:
           GIT_COMMIT=${GITHUB_SHA::7},\
           DEPLOY_TIME=$(TZ=Europe/Madrid date '+%d/%m/%Y %H:%M')"
 
+      - name: Refresh bot commands + webhook
+        # Idempotent post-deploy hook. Refreshes the `/`-menu so command
+        # additions/removals reach Telegram, and re-registers the webhook
+        # with `allowed_updates=[message, callback_query]` so inline keyboards
+        # keep working. The latter is what dropped on 2026-05-21 — without
+        # `callback_query` in `allowed_updates`, Telegram silently drops
+        # menu taps.
+        run: |
+          CFG=$(gcloud secrets versions access latest \
+            --secret=telegram-bot-config-regional --project=${{ env.PROJECT_ID }})
+          TELEGRAM_BOT_TOKEN=$(echo "$CFG" | jq -r .bot_token)
+          TELEGRAM_WEBHOOK_SECRET=$(echo "$CFG" | jq -r .webhook_secret)
+          BOT_URL=$(gcloud run services describe biwenger-bot \
+            --region ${{ env.REGION }} --project ${{ env.PROJECT_ID }} \
+            --format='value(status.url)')
+          pip install --quiet requests python-dotenv
+          PYTHONPATH=. \
+            TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN" \
+            TELEGRAM_WEBHOOK_SECRET="$TELEGRAM_WEBHOOK_SECRET" \
+            BIWENGER_BOT_URL="${BOT_URL}/telegram/webhook" \
+            python3 packages/biwenger_tools/bot/setup_commands.py
+
   # -------------------------------------------------------
   # 2d. Build and deploy biwenger-api Cloud Run Service
   # -------------------------------------------------------

--- a/core/sdk/jp.py
+++ b/core/sdk/jp.py
@@ -3,6 +3,14 @@
 La app móvil usa un token fijo hardcoded en el bundle JS. El endpoint
 fitness-daily devuelve la lista completa de jugadores de LaLiga con sus
 predicciones para la próxima jornada.
+
+JP marca cada `predict` con un `updated_at` (Unix timestamp). Usamos ese
+campo para invalidar la cache en proceso: un `limit=1` muy barato lee
+sólo el primer jugador y compara su `updated_at`; si coincide con lo
+cacheado, devolvemos el payload completo de memoria sin volver a pegar a
+JP. Asumimos que JP actualiza el `updated_at` de todos los jugadores
+para un `score_type` a la vez (consistente con lo que muestra la app —
+"última actualización ayer a las 23:59" para toda la liga).
 """
 
 from typing import Optional
@@ -18,6 +26,12 @@ JP_HEADERS = {
     "accept": "application/json, text/plain, */*",
     "user-agent": "AppBlog/Android",
 }
+
+# In-process cache. `(competition, score_type) → (updated_at, players)`. Lives
+# per Cloud Run instance — losing it on cold start is fine, and not sharing
+# across instances just means two instances may each pay one full fetch per
+# JP refresh (a couple of seconds for a single-user league).
+_CACHE: dict[tuple[int, int], tuple[Optional[int], list[dict]]] = {}
 
 
 def _build_params(
@@ -39,12 +53,64 @@ def _build_params(
     }
 
 
+def _extract_updated_at(player: dict, score_type: int) -> Optional[int]:
+    for entry in player.get("predict") or []:
+        if entry.get("type") == score_type:
+            return entry.get("updated_at")
+    return None
+
+
+def _peek_updated_at(
+    auth_token: str, competition: int, score_type: int
+) -> Optional[int]:
+    """Lightweight freshness probe: 1-player `limit=1` request.
+
+    Returns the `updated_at` of the first player's prediction for the
+    requested `score_type`, or `None` if the API can't be parsed.
+    """
+    params = _build_params(auth_token, competition, score_type)
+    params["limit"] = "1"
+    try:
+        response = requests.get(JP_URL, headers=JP_HEADERS, params=params, timeout=10)
+        response.raise_for_status()
+        players = response.json().get("players") or []
+    except (requests.RequestException, ValueError):
+        return None
+    if not players:
+        return None
+    return _extract_updated_at(players[0], score_type)
+
+
 def fetch_all_players(
     auth_token: str,
     competition: int = 1,
     score_type: int = 2,
 ) -> list[dict]:
-    """Devuelve la lista completa de jugadores JP para la competición indicada."""
+    """Returns the full JP player list for the given competition + score type.
+
+    On a warm cache, validates freshness via a `limit=1` probe (~200ms)
+    and returns the cached payload when JP hasn't refreshed. On a cold
+    cache, skips the probe — we'd fetch in full either way.
+    """
+    cache_key = (competition, score_type)
+    cached_entry = _CACHE.get(cache_key)
+
+    # Warm-cache path: probe for staleness with a cheap limit=1 call.
+    if cached_entry is not None:
+        cached_updated_at, cached_players = cached_entry
+        current_updated_at = _peek_updated_at(auth_token, competition, score_type)
+        if current_updated_at is not None and cached_updated_at == current_updated_at:
+            logger.info(
+                "JP players served from cache.",
+                extra={
+                    "competition": competition,
+                    "score_type": score_type,
+                    "count": len(cached_players),
+                    "updated_at": cached_updated_at,
+                },
+            )
+            return cached_players
+
     logger.info(
         "Fetching JP players...",
         extra={"competition": competition, "score_type": score_type},
@@ -53,7 +119,14 @@ def fetch_all_players(
     response = requests.get(JP_URL, headers=JP_HEADERS, params=params, timeout=30)
     response.raise_for_status()
     players = response.json().get("players", [])
-    logger.info("JP players fetched.", extra={"count": len(players)})
+
+    fresh_updated_at = _extract_updated_at(players[0], score_type) if players else None
+    _CACHE[cache_key] = (fresh_updated_at, players)
+
+    logger.info(
+        "JP players fetched.",
+        extra={"count": len(players), "updated_at": fresh_updated_at},
+    )
     return players
 
 

--- a/core/sdk/telegram.py
+++ b/core/sdk/telegram.py
@@ -154,6 +154,43 @@ def set_commands_menu_button(bot_token: str) -> None:
         logger.error("Failed to set menu button.", extra={"error": str(e)})
 
 
+def set_webhook(
+    bot_token: str,
+    url: str,
+    secret_token: str,
+    allowed_updates: Optional[list[str]] = None,
+) -> None:
+    """Register a webhook with Telegram.
+
+    `allowed_updates` defaults to `["message", "callback_query"]` — that
+    combination is the *only* one that lets the bot receive both text
+    commands and inline-keyboard taps. Calling `setWebhook` without this
+    parameter ends up at Telegram's default (which historically defaulted
+    to `["message"]` for our bot — that's exactly the trap that broke
+    every menu callback for hours until we found it).
+    """
+    if allowed_updates is None:
+        allowed_updates = ["message", "callback_query"]
+    api_url = f"https://api.telegram.org/bot{bot_token}/setWebhook"
+    try:
+        response = requests.post(
+            api_url,
+            json={
+                "url": url,
+                "secret_token": secret_token,
+                "allowed_updates": allowed_updates,
+            },
+            timeout=15,
+        )
+        response.raise_for_status()
+        logger.info(
+            "Webhook set.",
+            extra={"url": url, "allowed_updates": allowed_updates},
+        )
+    except requests.RequestException as e:
+        logger.error("Failed to set webhook.", extra={"error": str(e)})
+
+
 def parse_command(text: str) -> str:
     """Extract the bare command from a Telegram message text.
 

--- a/core/tests/test_jp.py
+++ b/core/tests/test_jp.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 import requests_mock
 
+from core.sdk import jp
 from core.sdk.jp import (
     JP_URL,
     check_api_health,
@@ -12,16 +13,66 @@ from core.sdk.jp import (
 TOKEN = "abc"
 
 
+@pytest.fixture(autouse=True)
+def reset_cache():
+    """Wipe the in-process JP cache between tests so they stay isolated."""
+    jp._CACHE.clear()
+    yield
+    jp._CACHE.clear()
+
+
+def _player(pid: int, name: str, updated_at: int = 1779000000) -> dict:
+    return {
+        "id": pid,
+        "name": name,
+        "predict": [{"type": 2, "rate": 100 + pid, "updated_at": updated_at}],
+    }
+
+
 def test_fetch_all_players_returns_list():
     with requests_mock.Mocker() as m:
-        m.get(JP_URL, json={"players": [{"id": 1, "name": "X"}]})
+        m.get(JP_URL, json={"players": [_player(1, "X")]})
         players = fetch_all_players(TOKEN)
-        assert players == [{"id": 1, "name": "X"}]
-        # Sanity-check the params we send
+        assert players == [_player(1, "X")]
+        # Sanity-check the params on the last (full) request
         sent = m.last_request.qs
         assert sent["auth"] == [TOKEN]
         assert sent["showpredict"] == ["true"]
         assert sent["limit"] == ["600"]
+
+
+def test_fetch_all_players_uses_cache_when_updated_at_unchanged():
+    """Second call hits a `limit=1` peek but reuses the cached payload."""
+    payload = {"players": [_player(1, "X", updated_at=1779000000)]}
+    with requests_mock.Mocker() as m:
+        m.get(JP_URL, json=payload)
+        first = fetch_all_players(TOKEN)
+        second = fetch_all_players(TOKEN)
+        assert first == second
+        # Requests in order: full (no peek on cold cache), peek, …
+        # Cold-cache path skips the peek (no cached_players); first call
+        # is one full request. The second call peeks and finds the cache
+        # still valid → no full re-fetch.
+        limits = [req.qs.get("limit", [""])[0] for req in m.request_history]
+        # 1 cold full + 1 warm peek = 2 calls total, limits "600" and "1".
+        assert limits == ["600", "1"]
+
+
+def test_fetch_all_players_invalidates_when_updated_at_changes():
+    """If the peek shows a newer `updated_at`, we re-fetch in full."""
+    stale_payload = {"players": [_player(1, "X", updated_at=1779000000)]}
+    fresh_payload = {"players": [_player(1, "X", updated_at=1779999999)]}
+    with requests_mock.Mocker() as m:
+        m.get(JP_URL, json=stale_payload)
+        first = fetch_all_players(TOKEN)
+        # JP refreshes: peek + full both return the newer timestamp.
+        m.get(JP_URL, json=fresh_payload)
+        second = fetch_all_players(TOKEN)
+        assert first == [_player(1, "X", updated_at=1779000000)]
+        assert second == [_player(1, "X", updated_at=1779999999)]
+        limits = [req.qs.get("limit", [""])[0] for req in m.request_history]
+        # cold full + peek (sees fresh) + full re-fetch = 3 calls.
+        assert limits == ["600", "1", "600"]
 
 
 def test_get_predict_rate_returns_value():

--- a/packages/biwenger_tools/api/app.py
+++ b/packages/biwenger_tools/api/app.py
@@ -98,8 +98,16 @@ def market():
 
 @app.route("/lineups/auto-pick", methods=["POST"])
 def lineups_auto_pick():
-    """Pick best lineup, apply on Biwenger, confirm via Telegram — was /alinear."""
-    return _run_action("lineups.auto-pick", actions.run_auto_pick_lineup)
+    """Pick best lineup, apply on Biwenger, confirm via Telegram — was /alinear.
+
+    Query param `dry_run=1` previews the lineup without doing the
+    Biwenger PUT — sends the same Telegram message but tagged "Preview".
+    """
+    dry_run_raw = (request.args.get("dry_run") or "").strip().lower()
+    dry_run = dry_run_raw in ("1", "true", "yes")
+    return _run_action(
+        "lineups.auto-pick", lambda: actions.run_auto_pick_lineup(dry_run=dry_run)
+    )
 
 
 @app.route("/budget/recommendations", methods=["GET"])

--- a/packages/biwenger_tools/api/logic/actions.py
+++ b/packages/biwenger_tools/api/logic/actions.py
@@ -240,10 +240,12 @@ def run_market() -> dict:
     return {"sent": 1, "size": len(market_rows)}
 
 
-def run_auto_pick_lineup() -> dict:
+def run_auto_pick_lineup(dry_run: bool = False) -> dict:
     """Pick the best lineup, apply it on Biwenger, confirm via Telegram.
 
-    Used by POST /lineups/auto-pick (was /alinear).
+    Used by POST /lineups/auto-pick (was /alinear). With `dry_run=True`
+    skips the Biwenger PUT and sends the would-be lineup to Telegram as
+    a preview — useful before a high-stakes matchday.
     """
     biwenger, biwenger_players, jp_index = _prepare_context()
     telegram = _require_telegram()
@@ -257,7 +259,7 @@ def run_auto_pick_lineup() -> dict:
     by_status = _squad_breakdown(my_team)
     logger.info(
         "Squad ready for auto-pick.",
-        extra={"total": len(my_team), **by_status},
+        extra={"total": len(my_team), **by_status, "dry_run": dry_run},
     )
 
     result = pick_lineup(my_team)
@@ -276,6 +278,23 @@ def run_auto_pick_lineup() -> dict:
             text="No se pudo calcular la alineacion (jugadores insuficientes).",
         )
         return {"sent": 1, "applied": False, "reason": "no_lineup"}
+
+    if dry_run:
+        preview = format_lineup_message(result).replace(
+            "✅ Alineación aplicada", "👀 <b>Preview</b> — no aplicada"
+        )
+        send_telegram_message(bot_token=token, chat_id=chat_id, text=preview)
+        logger.info(
+            "Dry-run lineup preview sent.",
+            extra={"formation": result["formation"], "total_sf": result["total_sf"]},
+        )
+        return {
+            "sent": 1,
+            "applied": False,
+            "dry_run": True,
+            "formation": result["formation"],
+            "total_sf": result["total_sf"],
+        }
 
     starters_ids = [
         r["bw_id"] for r, _ in sorted(result["starters"], key=lambda rp: rp[1])

--- a/packages/biwenger_tools/api/tests/test_api.py
+++ b/packages/biwenger_tools/api/tests/test_api.py
@@ -207,11 +207,32 @@ def test_lineups_auto_pick_calls_run_auto_pick(client):
         return_value=fake,
     ) as mock_run:
         resp = client.post("/lineups/auto-pick")
-    mock_run.assert_called_once()
+    mock_run.assert_called_once_with(dry_run=False)
     assert resp.status_code == 200
     body = resp.get_json()
     assert body["applied"] is True
     assert body["formation"] == "4-3-3"
+
+
+def test_lineups_auto_pick_with_dry_run_flag(client):
+    """`?dry_run=1` flips `run_auto_pick_lineup(dry_run=True)`."""
+    fake = {
+        "sent": 1,
+        "applied": False,
+        "dry_run": True,
+        "formation": "4-3-3",
+        "total_sf": 4200,
+    }
+    with patch(
+        "packages.biwenger_tools.api.app.actions.run_auto_pick_lineup",
+        return_value=fake,
+    ) as mock_run:
+        resp = client.post("/lineups/auto-pick?dry_run=1")
+    mock_run.assert_called_once_with(dry_run=True)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["applied"] is False
+    assert body["dry_run"] is True
 
 
 def test_lineups_auto_pick_rejects_get(client):

--- a/packages/biwenger_tools/bot/app.py
+++ b/packages/biwenger_tools/bot/app.py
@@ -40,19 +40,23 @@ _HELP_TEXT = (
     "/analizar — Análisis (te pregunta a quién)\n"
     "/mercado — Solo el mercado\n"
     "/alinear — Aplica la mejor alineación posible\n"
+    "/preview — Previsualiza la alineación sin aplicarla\n"
     "/recomendar — Qué fichar si me clausulan (top 3 por posición)\n"
     "/scrapper — Lanza el scraper a demanda (te avisa al acabar)\n"
     "/version — Versión desplegada del bot y de la API\n"
     "/help — Muestra este mensaje"
 )
 
-# Map main-menu action key → (api path, http method). `analizar` is special
-# because it opens the manager picker before hitting any endpoint.
-_ACTION_ROUTES = {
-    "mercado": ("/market", "GET"),
-    "alinear": ("/lineups/auto-pick", "POST"),
-    "recomendar": ("/budget/recommendations", "GET"),
-    "scrapper": ("/scraper/trigger", "POST"),
+# Map main-menu action key → (api path, http method, query params).
+# `analizar` is special because it opens the manager picker before
+# hitting any endpoint. `alinear_dry` mirrors `alinear` but with
+# `?dry_run=1` so the api previews the lineup without doing the PUT.
+_ACTION_ROUTES: dict[str, tuple[str, str, dict | None]] = {
+    "mercado": ("/market", "GET", None),
+    "alinear": ("/lineups/auto-pick", "POST", None),
+    "alinear_dry": ("/lineups/auto-pick", "POST", {"dry_run": "1"}),
+    "recomendar": ("/budget/recommendations", "GET", None),
+    "scrapper": ("/scraper/trigger", "POST", None),
 }
 
 
@@ -117,14 +121,14 @@ def _send_manager_picker() -> None:
 
 def _dispatch_action(action_key: str, label: str) -> None:
     """Send "procesando…" and fire the matching api endpoint."""
-    path, method = _ACTION_ROUTES[action_key]
+    path, method, params = _ACTION_ROUTES[action_key]
     send_telegram_message(
         bot_token=config.TELEGRAM_BOT_TOKEN,
         chat_id=config.TELEGRAM_CHAT_ID,
         text=f"⏳ <b>{label}</b> — procesando…",
     )
     try:
-        api_client.call_api(config.BIWENGER_API_URL, path, method=method)
+        api_client.call_api(config.BIWENGER_API_URL, path, method=method, params=params)
     except Exception as exc:
         logger.error(
             "Webhook: api call failed",
@@ -261,6 +265,8 @@ def webhook():
         _dispatch_action("mercado", "🛒 Mercado")
     elif cmd == "/alinear":
         _dispatch_action("alinear", "📋 Alinear")
+    elif cmd == "/preview":
+        _dispatch_action("alinear_dry", "👀 Preview alineación")
     elif cmd == "/recomendar":
         _dispatch_action("recomendar", "💡 Recomendar")
     elif cmd == "/scrapper":

--- a/packages/biwenger_tools/bot/setup_commands.py
+++ b/packages/biwenger_tools/bot/setup_commands.py
@@ -1,21 +1,38 @@
-"""One-shot script: registers bot commands and sets the menu button.
+"""One-shot post-deploy hook: registers bot commands, sets the menu
+button, and (re-)registers the webhook with the right `allowed_updates`.
 
-Run once after deploy (or whenever commands change):
+CI runs this after every bot deploy (see `deploy-bot` in
+`.github/workflows/deploy.yml`). Locally you can run it the same way:
+
   python3 packages/biwenger_tools/bot/setup_commands.py
 
-Requires TELEGRAM_BOT_TOKEN in the environment (or .env file).
+Required env: `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`. Optional
+`BIWENGER_BOT_URL` (full webhook URL, e.g.
+`https://biwenger-bot-.../telegram/webhook`); when set the script also
+calls `setWebhook` with `allowed_updates=["message", "callback_query"]`.
+Skipping the webhook registration locally is fine — Telegram remembers
+the last URL configured.
 """
 
+import os
 import sys
 
 from packages.biwenger_tools.bot import config
-from core.sdk.telegram import register_bot_commands, set_commands_menu_button
+from core.sdk.telegram import (
+    register_bot_commands,
+    set_commands_menu_button,
+    set_webhook,
+)
 
 COMMANDS = [
     {"command": "menu", "description": "Menú visual con botones (recomendado)"},
     {"command": "analizar", "description": "Análisis (te pregunta a quién)"},
     {"command": "mercado", "description": "Solo el mercado"},
     {"command": "alinear", "description": "Aplica la mejor alineación posible"},
+    {
+        "command": "preview",
+        "description": "Previsualiza la alineación sin aplicarla",
+    },
     {
         "command": "recomendar",
         "description": "Qué fichar si me clausulan (top 3 por posición)",
@@ -40,6 +57,20 @@ def main():
 
     print("Setting menu button…")
     set_commands_menu_button(token)
+
+    bot_url = os.getenv("BIWENGER_BOT_URL", "").strip()
+    if bot_url:
+        secret = config.TELEGRAM_WEBHOOK_SECRET
+        if not secret:
+            print(
+                "ERROR: TELEGRAM_WEBHOOK_SECRET required to set webhook.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(f"Setting webhook → {bot_url}")
+        set_webhook(token, bot_url, secret)
+    else:
+        print("Skipping webhook (BIWENGER_BOT_URL not set).")
 
     print("Done.")
 

--- a/packages/biwenger_tools/bot/tests/test_bot.py
+++ b/packages/biwenger_tools/bot/tests/test_bot.py
@@ -88,26 +88,37 @@ def test_wrong_chat_callback_is_silently_ignored(client):
 
 
 @pytest.mark.parametrize(
-    "command,path,method",
+    "command,path,method,params",
     [
-        ("/mercado", "/market", "GET"),
-        ("/alinear", "/lineups/auto-pick", "POST"),
-        ("/recomendar", "/budget/recommendations", "GET"),
-        ("/scrapper", "/scraper/trigger", "POST"),
+        ("/mercado", "/market", "GET", None),
+        ("/alinear", "/lineups/auto-pick", "POST", None),
+        ("/preview", "/lineups/auto-pick", "POST", {"dry_run": "1"}),
+        ("/recomendar", "/budget/recommendations", "GET", None),
+        ("/scrapper", "/scraper/trigger", "POST", None),
     ],
 )
-def test_text_command_calls_api(client, command, path, method):
+def test_text_command_calls_api(client, command, path, method, params):
     with patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call:
         resp = _post(client, _update(_VALID_CHAT, command))
     assert resp.status_code == 200
-    mock_call.assert_called_once_with(_API_URL, path, method=method)
+    mock_call.assert_called_once_with(_API_URL, path, method=method, params=params)
 
 
 def test_command_with_botname_suffix_routes_correctly(client):
     with patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call:
         resp = _post(client, _update(_VALID_CHAT, "/mercado@biwenger_tools_bot"))
     assert resp.status_code == 200
-    mock_call.assert_called_once_with(_API_URL, "/market", method="GET")
+    mock_call.assert_called_once_with(_API_URL, "/market", method="GET", params=None)
+
+
+def test_preview_text_command_calls_api_with_dry_run(client):
+    """`/preview` calls /lineups/auto-pick with `?dry_run=1`."""
+    with patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call:
+        resp = _post(client, _update(_VALID_CHAT, "/preview"))
+    assert resp.status_code == 200
+    mock_call.assert_called_once_with(
+        _API_URL, "/lineups/auto-pick", method="POST", params={"dry_run": "1"}
+    )
 
 
 def test_api_call_failure_sends_error_message(client):
@@ -199,7 +210,7 @@ def test_menu_callback_dispatches_action(client):
         resp = _post(client, _callback_update(_VALID_CHAT, "menu:mercado"))
     assert resp.status_code == 200
     mock_ack.assert_called_once()
-    mock_call.assert_called_once_with(_API_URL, "/market", method="GET")
+    mock_call.assert_called_once_with(_API_URL, "/market", method="GET", params=None)
 
 
 def test_menu_analizar_callback_opens_picker(client):


### PR DESCRIPTION
4 commits packaged together — all small, related, and ready to ship.

### 1. JP cache (`51a4a55`)
`fetch_all_players` now caches per `(competition, score_type)`. Before serving, a `limit=1` probe (~200ms) checks JP's `predict[type=N].updated_at`; if it matches the cached value the full payload comes straight from memory. JP refreshed → re-fetch. ~5-10s → ~200ms on cache hits. In-process only, no new resource.

### 2. `/preview` dry-run (`b26c932`)
`POST /lineups/auto-pick?dry_run=1` runs the picker and posts the lineup tagged "👀 Preview — no aplicada" without doing the Biwenger PUT. Bot exposes it as `/preview`. Not on the inline menu by design — keeps the menu focused on the 5 main actions.

### 3. Bot auto-setup in CI (`10087f4`)
After every `biwenger-bot` deploy, the workflow reads the secret + resolves the Cloud Run URL and runs `setup_commands.py`. The script learnt a new step: when `BIWENGER_BOT_URL` is set it also calls `setWebhook` with `allowed_updates=["message", "callback_query"]`. Prevents the silent-callback-drop incident from 2026-05-21 from recurring (and re-registers commands on every deploy as a bonus).

### 4. Docs (`220520c`)
`next_phases.md` collapsed to the three actual pending items (Drive cleanup user-owned, photo-recognition lives in its own README, Sheets IDs in BUILD.bazel) + a sprint summary.

## Test plan
- [x] `bazel test //...` green across all 6 packages.
- [x] `bash scripts/lint.sh` clean.
- [ ] After deploy: `/preview` returns a preview without PUTting on Biwenger.
- [ ] Two `/teams` or `/analizar` calls in quick succession → second one visibly faster (cache hit).
- [ ] CI's "Refresh bot commands + webhook" step succeeds and the `/preview` command shows up in the Telegram `/`-menu.
- [ ] `getWebhookInfo` reports `allowed_updates: ["message","callback_query"]`.