### PR TITLE
fix(jp) + feat(scraper): cache fingerprint hardening + clausulazos in notify

### DIFF
--- a/core/sdk/jp.py
+++ b/core/sdk/jp.py
@@ -4,13 +4,17 @@ La app móvil usa un token fijo hardcoded en el bundle JS. El endpoint
 fitness-daily devuelve la lista completa de jugadores de LaLiga con sus
 predicciones para la próxima jornada.
 
-JP marca cada `predict` con un `updated_at` (Unix timestamp). Usamos ese
-campo para invalidar la cache en proceso: un `limit=1` muy barato lee
-sólo el primer jugador y compara su `updated_at`; si coincide con lo
-cacheado, devolvemos el payload completo de memoria sin volver a pegar a
-JP. Asumimos que JP actualiza el `updated_at` de todos los jugadores
-para un `score_type` a la vez (consistente con lo que muestra la app —
-"última actualización ayer a las 23:59" para toda la liga).
+JP marca cada `predict` con un `updated_at` (Unix timestamp). Usamos
+esos timestamps como fingerprint de freshness: un `limit=5` muy barato
+lee los 5 primeros jugadores y calcula `max(updated_at)`. Si ese máximo
+coincide con el cacheado, devolvemos el payload completo de memoria sin
+volver a pegar a JP completo.
+
+Empíricamente (2026-05-23) JP escribe los ~549 jugadores en una ventana
+de ~4.5 min, así que cada jugador tiene su propio `updated_at` dentro
+del batch. Probar solo 1 jugador era brittle (el "primero" cambia con
+el orden por `priceIncrement DESC`); con 5 cubrimos la probabilidad de
+que al menos uno haya cambiado tras un refresh.
 """
 
 from typing import Optional
@@ -60,25 +64,39 @@ def _extract_updated_at(player: dict, score_type: int) -> Optional[int]:
     return None
 
 
-def _peek_updated_at(
+_PROBE_SAMPLE_SIZE = 5
+
+
+def _max_updated_at(players: list[dict], score_type: int) -> Optional[int]:
+    """Highest `updated_at` across the given players for `score_type`.
+
+    Returns None if no player in the sample has a usable timestamp.
+    """
+    timestamps = [_extract_updated_at(p, score_type) for p in players]
+    valid = [t for t in timestamps if t is not None]
+    return max(valid) if valid else None
+
+
+def _peek_fingerprint(
     auth_token: str, competition: int, score_type: int
 ) -> Optional[int]:
-    """Lightweight freshness probe: 1-player `limit=1` request.
+    """Lightweight freshness probe: `limit=N` request, returns max timestamp.
 
-    Returns the `updated_at` of the first player's prediction for the
-    requested `score_type`, or `None` if the API can't be parsed.
+    JP writes the league in a batch over a few minutes, so each player's
+    `updated_at` is its own value within the batch window. Sampling N
+    players and taking the max is a stable fingerprint of the snapshot
+    — strictly stronger than reading just the first player (whose
+    position by `priceIncrement DESC` shifts between requests).
     """
     params = _build_params(auth_token, competition, score_type)
-    params["limit"] = "1"
+    params["limit"] = str(_PROBE_SAMPLE_SIZE)
     try:
         response = requests.get(JP_URL, headers=JP_HEADERS, params=params, timeout=10)
         response.raise_for_status()
         players = response.json().get("players") or []
     except (requests.RequestException, ValueError):
         return None
-    if not players:
-        return None
-    return _extract_updated_at(players[0], score_type)
+    return _max_updated_at(players, score_type)
 
 
 def fetch_all_players(
@@ -88,25 +106,32 @@ def fetch_all_players(
 ) -> list[dict]:
     """Returns the full JP player list for the given competition + score type.
 
-    On a warm cache, validates freshness via a `limit=1` probe (~200ms)
+    On a warm cache, validates freshness via a `limit=5` probe (~200ms)
     and returns the cached payload when JP hasn't refreshed. On a cold
     cache, skips the probe — we'd fetch in full either way.
+
+    Cache fingerprint is `max(updated_at)` across the probe sample; the
+    cached payload stores `max(updated_at)` across all ~549 players so
+    a strictly increasing snapshot triggers a refetch.
     """
     cache_key = (competition, score_type)
     cached_entry = _CACHE.get(cache_key)
 
-    # Warm-cache path: probe for staleness with a cheap limit=1 call.
+    # Warm-cache path: probe for staleness with a cheap multi-player call.
     if cached_entry is not None:
-        cached_updated_at, cached_players = cached_entry
-        current_updated_at = _peek_updated_at(auth_token, competition, score_type)
-        if current_updated_at is not None and cached_updated_at == current_updated_at:
+        cached_fingerprint, cached_players = cached_entry
+        current_fingerprint = _peek_fingerprint(auth_token, competition, score_type)
+        if (
+            current_fingerprint is not None
+            and cached_fingerprint == current_fingerprint
+        ):
             logger.info(
                 "JP players served from cache.",
                 extra={
                     "competition": competition,
                     "score_type": score_type,
                     "count": len(cached_players),
-                    "updated_at": cached_updated_at,
+                    "fingerprint": cached_fingerprint,
                 },
             )
             return cached_players
@@ -120,12 +145,14 @@ def fetch_all_players(
     response.raise_for_status()
     players = response.json().get("players", [])
 
-    fresh_updated_at = _extract_updated_at(players[0], score_type) if players else None
-    _CACHE[cache_key] = (fresh_updated_at, players)
+    # Use the same `top N by priceIncrement DESC` sample the probe sees,
+    # so the next probe's max is comparable to what we cache here.
+    fresh_fingerprint = _max_updated_at(players[:_PROBE_SAMPLE_SIZE], score_type)
+    _CACHE[cache_key] = (fresh_fingerprint, players)
 
     logger.info(
         "JP players fetched.",
-        extra={"count": len(players), "updated_at": fresh_updated_at},
+        extra={"count": len(players), "fingerprint": fresh_fingerprint},
     )
     return players
 

--- a/core/tests/test_jp.py
+++ b/core/tests/test_jp.py
@@ -29,6 +29,13 @@ def _player(pid: int, name: str, updated_at: int = 1779000000) -> dict:
     }
 
 
+def _batch(start_ts: int) -> list[dict]:
+    """A 5-player sample with `updated_at` values spread over ~120 seconds —
+    matches JP's real shape where each player gets its own timestamp
+    inside the batch window."""
+    return [_player(i, f"P{i}", updated_at=start_ts + (i * 30)) for i in range(1, 6)]
+
+
 def test_fetch_all_players_returns_list():
     with requests_mock.Mocker() as m:
         m.get(JP_URL, json={"players": [_player(1, "X")]})
@@ -41,38 +48,59 @@ def test_fetch_all_players_returns_list():
         assert sent["limit"] == ["600"]
 
 
-def test_fetch_all_players_uses_cache_when_updated_at_unchanged():
-    """Second call hits a `limit=1` peek but reuses the cached payload."""
-    payload = {"players": [_player(1, "X", updated_at=1779000000)]}
+def test_fetch_all_players_uses_cache_when_fingerprint_unchanged():
+    """Second call hits a `limit=5` peek but reuses the cached payload.
+
+    The probe and the cached fingerprint both compute `max(updated_at)`
+    across the same top-N sample, so unchanged data → identical maxes
+    → cache hit.
+    """
+    batch = _batch(start_ts=1779000000)
     with requests_mock.Mocker() as m:
-        m.get(JP_URL, json=payload)
+        m.get(JP_URL, json={"players": batch})
         first = fetch_all_players(TOKEN)
         second = fetch_all_players(TOKEN)
         assert first == second
-        # Requests in order: full (no peek on cold cache), peek, …
-        # Cold-cache path skips the peek (no cached_players); first call
-        # is one full request. The second call peeks and finds the cache
-        # still valid → no full re-fetch.
         limits = [req.qs.get("limit", [""])[0] for req in m.request_history]
-        # 1 cold full + 1 warm peek = 2 calls total, limits "600" and "1".
-        assert limits == ["600", "1"]
+        # 1 cold full + 1 warm probe = 2 calls. The probe sends limit=5
+        # (sample size); the cold full sends the default 600.
+        assert limits == ["600", "5"]
 
 
-def test_fetch_all_players_invalidates_when_updated_at_changes():
-    """If the peek shows a newer `updated_at`, we re-fetch in full."""
-    stale_payload = {"players": [_player(1, "X", updated_at=1779000000)]}
-    fresh_payload = {"players": [_player(1, "X", updated_at=1779999999)]}
+def test_fetch_all_players_invalidates_when_any_top_player_refreshes():
+    """A new max within the probe sample triggers re-fetch."""
+    stale = _batch(start_ts=1779000000)
+    # Same five players, but one of them got a newer timestamp → max moves up.
+    fresh = _batch(start_ts=1779000000)
+    fresh[2]["predict"][0]["updated_at"] = 1779999999  # third player refreshed
+
     with requests_mock.Mocker() as m:
-        m.get(JP_URL, json=stale_payload)
-        first = fetch_all_players(TOKEN)
-        # JP refreshes: peek + full both return the newer timestamp.
-        m.get(JP_URL, json=fresh_payload)
+        m.get(JP_URL, json={"players": stale})
+        fetch_all_players(TOKEN)
+        m.get(JP_URL, json={"players": fresh})
         second = fetch_all_players(TOKEN)
-        assert first == [_player(1, "X", updated_at=1779000000)]
-        assert second == [_player(1, "X", updated_at=1779999999)]
+        # Cache invalidated because probe's max (1779999999) differs from
+        # the cached max (1779000000 + 4*30 = 1779000120).
+        assert second == fresh
         limits = [req.qs.get("limit", [""])[0] for req in m.request_history]
-        # cold full + peek (sees fresh) + full re-fetch = 3 calls.
-        assert limits == ["600", "1", "600"]
+        # cold full + probe (sees newer max) + full re-fetch = 3 calls.
+        assert limits == ["600", "5", "600"]
+
+
+def test_fetch_all_players_probe_resilient_to_player_without_timestamp():
+    """Cache stays valid when the probe sample includes a player without
+    `predict[type=2]` — the max ignores `None`s and uses the rest."""
+    batch_with_gap = _batch(start_ts=1779000000)
+    batch_with_gap[0]["predict"] = []  # first player has no prediction
+
+    with requests_mock.Mocker() as m:
+        m.get(JP_URL, json={"players": batch_with_gap})
+        first = fetch_all_players(TOKEN)
+        second = fetch_all_players(TOKEN)
+        assert first == second
+        # Still serves from cache on the second call.
+        limits = [req.qs.get("limit", [""])[0] for req in m.request_history]
+        assert limits == ["600", "5"]
 
 
 def test_get_predict_rate_returns_value():

--- a/packages/biwenger_tools/scraper_job/main.py
+++ b/packages/biwenger_tools/scraper_job/main.py
@@ -122,8 +122,12 @@ def _write_collection(collection: str, pairs: list[tuple[str, dict]]) -> None:
     )
 
 
-def _write_clausulazos_and_tabla(biwenger: BiwengerClient, cfg) -> None:
-    """Pull the clausulazos feed, derive the justice table, write both."""
+def _write_clausulazos_and_tabla(biwenger: BiwengerClient, cfg) -> int:
+    """Pull the clausulazos feed, derive the justice table, write both.
+
+    Returns the total number of clausulazos written so `main()` can
+    surface the count in the Telegram notify.
+    """
     logger.info("Processing clausulazos...")
     players_map = biwenger.get_all_players_data_map(cfg.ALL_PLAYERS_DATA_URL)
     raw = biwenger.get_all_clausulazos(cfg.CLAUSULAZOS_URL)
@@ -141,6 +145,7 @@ def _write_clausulazos_and_tabla(biwenger: BiwengerClient, cfg) -> None:
         [(e.equipo, e.to_firestore()) for e in tabla_justicia if e.equipo],
     )
     logger.info("Clausulazos and tabla_justicia written to Firestore.")
+    return len(clausulazos)
 
 
 def _notify(text: str) -> None:
@@ -164,6 +169,7 @@ def main() -> None:
     """
     started_at = datetime.now(timezone.utc)
     new_count = 0
+    clausulazos_count = 0
 
     try:
         season = config.TEMPORADA_ACTUAL
@@ -197,7 +203,7 @@ def main() -> None:
         else:
             logger.info("No new messages found.")
 
-        _write_clausulazos_and_tabla(biwenger, config)
+        clausulazos_count = _write_clausulazos_and_tabla(biwenger, config)
 
     except Exception as exc:
         logger.exception("Unexpected error in scraper.")
@@ -211,9 +217,16 @@ def main() -> None:
 
     elapsed = (datetime.now(timezone.utc) - started_at).total_seconds()
     if new_count > 0:
-        body = f"🧹 <b>Scraper OK</b> · {new_count} mensajes nuevos · {elapsed:.0f}s"
+        msg_s = "s" if new_count != 1 else ""
+        messages_part = f"{new_count} mensaje{msg_s} nuevo{msg_s}"
     else:
-        body = f"🧹 <b>Scraper OK</b> · sin mensajes nuevos · {elapsed:.0f}s"
+        messages_part = "sin mensajes nuevos"
+    cl_s = "s" if clausulazos_count != 1 else ""
+    clausulazos_part = f"{clausulazos_count} clausulazo{cl_s}"
+    body = (
+        f"🧹 <b>Scraper OK</b> · {messages_part} · "
+        f"{clausulazos_part} · {elapsed:.0f}s"
+    )
     _notify(body)
 
 

--- a/packages/biwenger_tools/scraper_job/tests/test_main.py
+++ b/packages/biwenger_tools/scraper_job/tests/test_main.py
@@ -143,10 +143,13 @@ def _enable_notify() -> None:
 
 
 def test_main_sends_telegram_on_success(mock_external_deps):
-    """On success, the scraper notifies the configured chat."""
+    """On success, the scraper notifies the configured chat with both
+    counts (messages + clausulazos)."""
     _enable_notify()
     mock_external_deps["biwenger"].get_league_users.return_value = {}
     mock_external_deps["biwenger"].get_all_board_messages.return_value = []
+    # parse_clausulazos returns nothing by default in the fixture, so the
+    # count will be 0 — assert the wording reflects that.
 
     with patch(
         "packages.biwenger_tools.scraper_job.main.send_telegram_message"
@@ -157,6 +160,8 @@ def test_main_sends_telegram_on_success(mock_external_deps):
     text = mock_send.call_args.kwargs.get("text", "")
     assert "Scraper OK" in text
     assert "sin mensajes nuevos" in text
+    # Clausulazos count is always reported, even when 0.
+    assert "0 clausulazos" in text
 
 
 def test_main_sends_telegram_and_reraises_on_error(mock_external_deps):


### PR DESCRIPTION
Two small, related improvements.

### 1. JP cache fingerprint (`9f1c47c`)
The `limit=1` probe was reading only the first player by `priceIncrement DESC`. With JP's per-player `updated_at` (each of the ~549 in a 4.5-min batch), one player wasn't enough to detect a refresh reliably. Now we probe with `limit=5` and compare `max(updated_at)`. Same shape on the cached side: store the max across the top-5 of the full response.

### 2. Scraper clausulazos count (`2a47e70`)
\`_write_clausulazos_and_tabla\` returns the count; \`main()\` weaves it into the Telegram notify line:

\`\`\`
🧹 Scraper OK · sin mensajes nuevos · 104 clausulazos · 15s
\`\`\`

## Test plan
- [x] \`bazel test //...\` green across all 6 packages.
- [x] \`bash scripts/lint.sh\` clean.
- [ ] After deploy: two \`/teams\` (or \`/alinear\`) close together → second one served from cache; check api logs for "JP players served from cache · fingerprint=…".
- [ ] Next weekly scraper run posts a message with the new "N clausulazos" tail.