### PR TITLE
feat(api): POST /market/auto-bid — daily tiered auto-bidding

### DIFF
--- a/docs/gcp.md
+++ b/docs/gcp.md
@@ -13,6 +13,7 @@ Project: `biwenger-tools` · Region: `europe-southwest1` (Madrid)
 | Cloud Run (Jobs) | `biwenger-scraper-data` | Scrapes league messages → CSV → Google Drive |
 | Cloud Scheduler | `biwenger-scraper-data-scheduler-trigger` (`europe-west1`) | Triggers scraper job (cron weekly Sun 22:00) |
 | Cloud Scheduler | `biwenger-daily-digest-trigger` (`europe-west1`) | Triggers `biwenger-api/digests/daily` (daily 09:00 Madrid) |
+| Cloud Scheduler | `biwenger-auto-bid-trigger` (`europe-west1`) | Triggers `biwenger-api/market/auto-bid` (daily 09:00 Madrid) |
 | Secret Manager | 4 secrets (see below) | Credentials and bot tokens |
 | Artifact Registry | `biwenger-docker` | Docker images for all Cloud Run services/jobs |
 | Cloud Logging | — | Automatic, structured logs via `get_logger()` |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -197,6 +197,26 @@ ID token whose service account has `roles/run.invoker` on `biwenger-api`.
     | `GET`  | `/budget/recommendations` | Top affordable clausulazo targets per position |
     | `POST` | `/scraper/trigger` | Queue a scraper job execution (bot's `/scrapper`) |
     | `POST` | `/digests/daily` | Cron — my team + market (Scheduler only) |
+    | `POST` | `/market/auto-bid` | Cron — tiered auto-bid on the daily market (Scheduler only) |
+
+  * **Create the auto-bid Cloud Scheduler job (one-shot):**
+
+    ```bash
+      API_URL=$(gcloud run services describe biwenger-api --region europe-southwest1 --format='value(status.url)')
+      gcloud scheduler jobs create http biwenger-auto-bid-trigger \
+        --schedule="0 9 * * *" \
+        --time-zone="Europe/Madrid" \
+        --location=europe-west1 \
+        --uri="$API_URL/market/auto-bid" \
+        --http-method=POST \
+        --oidc-service-account-email=biwenger-scheduler@biwenger-tools.iam.gserviceaccount.com \
+        --oidc-token-audience="$API_URL" \
+        --attempt-deadline=120s
+    ```
+
+    Same service account + audience pattern as `biwenger-daily-digest-trigger`.
+    Idempotency is handled by the endpoint itself (Firestore `auto_bid_log/{date}`),
+    so a retry on transient 5xx is safe.
 
   * **Smoke test:**
 

--- a/packages/biwenger_tools/api/app.py
+++ b/packages/biwenger_tools/api/app.py
@@ -14,6 +14,7 @@ from core.utils import get_logger
 from packages.biwenger_tools.api import config
 from packages.biwenger_tools.api.logic import (
     actions,
+    auto_bid,
     digests,
     recommendations,
     scraper,
@@ -154,6 +155,16 @@ def scraper_trigger():
 def digests_daily():
     """Cron-triggered: send "my team + market" PNGs to Telegram."""
     return _run_action("digests.daily", digests.run_daily)
+
+
+@app.route("/market/auto-bid", methods=["POST"])
+def market_auto_bid():
+    """Cron-triggered (09:00 Madrid): tiered auto-bid on the daily market.
+
+    Idempotent across same-day retries — bids are logged to Firestore
+    under `auto_bid_log/{date}/bids` and skipped on replay.
+    """
+    return _run_action("market.auto-bid", auto_bid.run_auto_bid)
 
 
 if __name__ == "__main__":

--- a/packages/biwenger_tools/api/logic/auto_bid.py
+++ b/packages/biwenger_tools/api/logic/auto_bid.py
@@ -1,0 +1,354 @@
+"""Daily aggressive auto-bidding on the Biwenger daily market.
+
+`POST /market/auto-bid` (Cloud Scheduler 09:00 Madrid) drives this. We
+look at the rotating computer-owned free agents Biwenger exposes every
+morning, attach SofaScore (Automanager) ratings from JP, and place a
+bid on each player according to the tier below — best score first,
+stopping when cash runs out.
+
+Tiers (over Biwenger's cf-base `price`, NOT `owner.price`):
+
+    SF > 800             → bid = remaining_cash    (all-in, never maxBid)
+    600 < SF ≤ 800       → bid = price + 5_000_000  (aggressive)
+    400 < SF ≤ 600       → bid = price + 2_000_000
+    SF ≤ 400             → skip
+
+Hard rule across every tier: skip the player when the would-be bid
+exceeds `remaining_cash` — we never go negative. The all-in tier bids
+the full cash regardless of price (a 26M player against 30M cash is
+still a 30M bid, by the user's call).
+
+Idempotency: Cloud Scheduler retries 5xx responses. We log placed bids
+to `auto_bid_log/{YYYY-MM-DD}` (one doc per player) and skip anything
+in that log before bidding, so a retry of a half-completed run does
+not double-bid the players that already went through.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+import requests
+
+from core.constants import MADRID_TZ
+from core.sdk import firestore
+from core.sdk.biwenger import BiwengerClient
+from core.sdk.jp import (
+    check_api_health,
+    fetch_all_players,
+    get_predict_rate,
+)
+from core.sdk.telegram import send_telegram_message
+from core.utils import get_logger
+from packages.biwenger_tools.api import config
+from packages.biwenger_tools.api.logic.player_matching import (
+    build_jp_index,
+    find_player_match,
+)
+from packages.biwenger_tools.api.player_formatting import SCORE_SF
+
+logger = get_logger(__name__)
+
+# Tier thresholds and surcharges. Kept as a module-level table so the
+# unit tests can pin every band without reaching into private helpers.
+TIER_ALL_IN_MIN = 800
+TIER_PLUS_5M_MIN = 600
+TIER_PLUS_2M_MIN = 400
+TIER_PLUS_5M_SURCHARGE = 5_000_000
+TIER_PLUS_2M_SURCHARGE = 2_000_000
+
+# Firestore path for today's per-player bid log. Cloud Scheduler retries
+# on 5xx — looking up the log before bidding makes a retried run a no-op
+# on the players that already went through.
+AUTO_BID_LOG_PATH = "auto_bid_log"
+
+
+def _today_madrid() -> str:
+    """`YYYY-MM-DD` in Europe/Madrid — the doc id for today's log."""
+    return datetime.now(MADRID_TZ).strftime("%Y-%m-%d")
+
+
+def _log_collection_path(day: str) -> str:
+    """`auto_bid_log/{day}/bids` — odd-segment subcollection for Firestore."""
+    return f"{AUTO_BID_LOG_PATH}/{day}/bids"
+
+
+def _euros(n: int | None) -> str:
+    """Spanish-style thousands separator: 12.345.678 €."""
+    if n is None:
+        return "—"
+    s = f"{int(n):,}".replace(",", ".")
+    return f"{s} €"
+
+
+def tier_bid(sf: int, price: int, remaining_cash: int) -> tuple[Optional[int], str]:
+    """Return `(target_bid, label)` for a player, or `(None, reason)` to skip.
+
+    `target_bid` may exceed `remaining_cash` — the caller is in charge of
+    the affordability check (so the skip reason can be richer than a
+    bare None).
+    """
+    if sf > TIER_ALL_IN_MIN:
+        # All-in on the cash we have right now. Price is irrelevant — the
+        # user accepts paying 30M for a 26M player rather than leaving cash
+        # on the table. `remaining_cash` of 0 falls through to the
+        # affordability check below and gets reported as "sin cash".
+        return remaining_cash, f"T1 all-in (SF {sf})"
+    if sf > TIER_PLUS_5M_MIN:
+        return price + TIER_PLUS_5M_SURCHARGE, f"T2 precio+5M (SF {sf})"
+    if sf > TIER_PLUS_2M_MIN:
+        return price + TIER_PLUS_2M_SURCHARGE, f"T3 precio+2M (SF {sf})"
+    return None, f"SF {sf} ≤ {TIER_PLUS_2M_MIN}"
+
+
+def _build_candidates(
+    market_players: list,
+    biwenger_players: dict,
+    jp_index: dict,
+) -> list[dict]:
+    """Daily-market players (computer-owned) enriched with SF + price.
+
+    `sale.get("user") is None` is the marker for daily-market entries;
+    user listings carry the seller's id and are out of scope. Anything
+    we cannot price (no Biwenger lookup) or cannot score (no JP match)
+    is dropped here so the tier loop only sees actionable rows.
+    """
+    candidates: list[dict] = []
+    for sale in market_players:
+        if sale.get("user") is not None:
+            continue
+        player_ref = sale.get("player") or {}
+        player_id = player_ref.get("id")
+        bw_player = biwenger_players.get(player_id)
+        if not bw_player:
+            continue
+        name = bw_player.get("name") or player_ref.get("name") or "?"
+        price = int(bw_player.get("price") or 0)
+        jp_player = find_player_match(name, jp_index)
+        sf = get_predict_rate(jp_player or {}, SCORE_SF) or 0
+        candidates.append(
+            {"player_id": player_id, "name": name, "price": price, "sf": sf}
+        )
+    candidates.sort(key=lambda c: c["sf"], reverse=True)
+    return candidates
+
+
+def _already_bid_ids(day: str) -> set[int]:
+    """Player ids already in today's Firestore log (Cloud Scheduler retries)."""
+    try:
+        return {
+            int(doc_id)
+            for doc_id, _ in firestore.list_documents(_log_collection_path(day))
+        }
+    except Exception:  # pragma: no cover — defensive: Firestore unreachable
+        # If the log read fails we prefer to bid (the worst case is a rare
+        # double-bid on a retry) over silently skipping every candidate
+        # because the lookup blew up. The error surfaces in the response.
+        logger.exception("Failed to read auto-bid log — proceeding without dedup.")
+        return set()
+
+
+def _log_bid(day: str, candidate: dict, bid_amount: int, offer: dict) -> None:
+    """Record a successful bid so a retried run won't repeat it."""
+    firestore.set_document(
+        _log_collection_path(day),
+        str(candidate["player_id"]),
+        {
+            "player_id": candidate["player_id"],
+            "name": candidate["name"],
+            "sf": candidate["sf"],
+            "price": candidate["price"],
+            "bid": bid_amount,
+            "offer_id": offer.get("id"),
+            "status": offer.get("status"),
+            "created_at": datetime.now(MADRID_TZ).isoformat(),
+        },
+    )
+
+
+def _format_telegram_text(
+    day: str,
+    placed: list[dict],
+    skipped: list[dict],
+    total_bid: int,
+    remaining_cash: int,
+) -> str:
+    """Render the per-run summary message the Telegram chat receives."""
+    header_date = datetime.now(MADRID_TZ).strftime("%d/%m %H:%M")
+    lines = [f"💸 <b>Pujas automáticas en el mercado — {header_date}</b>", ""]
+
+    for entry in placed:
+        lines.append(
+            f"✅ Pujado <b>{_euros(entry['bid'])}</b> por "
+            f"<b>{entry['name']}</b> ({entry['tier_label']})"
+        )
+
+    if skipped:
+        for entry in skipped:
+            lines.append(f"⏭️ Saltado <b>{entry['name']}</b> ({entry['reason']})")
+
+    if not placed and not skipped:
+        lines.append("Sin candidatos en el mercado diario.")
+
+    lines.append("")
+    lines.append(
+        f"Total pujado: <b>{_euros(total_bid)}</b> · "
+        f"Cash restante: <b>{_euros(remaining_cash)}</b>"
+    )
+    if not placed:
+        lines.append(f"<i>Log: auto_bid_log/{day}</i>")
+    return "\n".join(lines)
+
+
+def _maybe_notify(text: str) -> int:
+    """Send the summary to Telegram if creds are configured. Returns sent count."""
+    if not (config.TELEGRAM_BOT_TOKEN and config.TELEGRAM_CHAT_ID):
+        logger.warning("Telegram credentials missing — skipping send.")
+        return 0
+    send_telegram_message(
+        bot_token=config.TELEGRAM_BOT_TOKEN,
+        chat_id=config.TELEGRAM_CHAT_ID,
+        text=text,
+    )
+    return 1
+
+
+def run_auto_bid() -> dict:
+    """Walk the daily market, place tiered bids, log + notify.
+
+    Returns a summary dict consumed by the route handler. Side effects:
+    Biwenger session + N `POST /api/v2/offers`, Firestore writes per
+    successful bid, one Telegram message.
+    """
+    check_api_health(
+        config.JP_AUTH_TOKEN,
+        competition=config.JP_COMPETITION,
+        score_type=config.JP_SCORE_TYPE,
+    )
+    jp_players = fetch_all_players(
+        config.JP_AUTH_TOKEN,
+        competition=config.JP_COMPETITION,
+        score_type=config.JP_SCORE_TYPE,
+    )
+    jp_index = build_jp_index(jp_players)
+
+    biwenger = BiwengerClient(
+        config.BIWENGER_EMAIL,
+        config.BIWENGER_PASSWORD,
+        config.LOGIN_URL,
+        config.ACCOUNT_URL,
+        config.LEAGUE_ID,
+    )
+    biwenger_players = biwenger.get_all_players_data_map(config.ALL_PLAYERS_DATA_URL)
+    market_players = biwenger.get_market_players(config.MARKET_URL)
+
+    candidates = _build_candidates(market_players, biwenger_players, jp_index)
+
+    account_state = biwenger.get_account_state()
+    remaining_cash = int(account_state.get("cash") or 0)
+
+    day = _today_madrid()
+    already_bid = _already_bid_ids(day)
+
+    placed: list[dict] = []
+    skipped: list[dict] = []
+
+    for candidate in candidates:
+        if candidate["player_id"] in already_bid:
+            skipped.append(
+                {
+                    "player_id": candidate["player_id"],
+                    "name": candidate["name"],
+                    "reason": "ya pujado hoy",
+                }
+            )
+            continue
+
+        target_bid, label = tier_bid(
+            candidate["sf"], candidate["price"], remaining_cash
+        )
+        if target_bid is None:
+            # Below the SF floor — record as skipped only if it's borderline
+            # interesting (price < 30M and SF > 200) to keep the message short.
+            if candidate["sf"] > 200:
+                skipped.append(
+                    {
+                        "player_id": candidate["player_id"],
+                        "name": candidate["name"],
+                        "reason": label,
+                    }
+                )
+            continue
+        if target_bid <= 0 or target_bid > remaining_cash:
+            skipped.append(
+                {
+                    "player_id": candidate["player_id"],
+                    "name": candidate["name"],
+                    "reason": (
+                        f"bid {_euros(target_bid)} > cash {_euros(remaining_cash)}"
+                    ),
+                }
+            )
+            continue
+
+        try:
+            offer = biwenger.place_market_bid(
+                player_id=candidate["player_id"], amount=target_bid
+            )
+        except requests.RequestException as exc:
+            logger.warning(
+                "Auto-bid request rejected — continuing.",
+                extra={
+                    "player_id": candidate["player_id"],
+                    "player_name": candidate["name"],
+                    "bid": target_bid,
+                    "error": str(exc),
+                },
+            )
+            skipped.append(
+                {
+                    "player_id": candidate["player_id"],
+                    "name": candidate["name"],
+                    "reason": "Biwenger rechazó la puja",
+                }
+            )
+            continue
+
+        placed.append(
+            {
+                "player_id": candidate["player_id"],
+                "name": candidate["name"],
+                "sf": candidate["sf"],
+                "price": candidate["price"],
+                "bid": target_bid,
+                "tier_label": label,
+                "offer_id": offer.get("id"),
+            }
+        )
+        _log_bid(day, candidate, target_bid, offer)
+        remaining_cash -= target_bid
+
+    total_bid = sum(entry["bid"] for entry in placed)
+    text = _format_telegram_text(day, placed, skipped, total_bid, remaining_cash)
+    sent = _maybe_notify(text)
+
+    logger.info(
+        "Auto-bid run finished.",
+        extra={
+            "day": day,
+            "candidates": len(candidates),
+            "placed": len(placed),
+            "skipped": len(skipped),
+            "total_bid": total_bid,
+            "remaining_cash": remaining_cash,
+        },
+    )
+    return {
+        "sent": sent,
+        "day": day,
+        "candidates": len(candidates),
+        "bid_count": len(placed),
+        "skipped_count": len(skipped),
+        "total_bid_eur": total_bid,
+        "remaining_cash_eur": remaining_cash,
+        "bids": placed,
+    }

--- a/packages/biwenger_tools/api/tests/test_api.py
+++ b/packages/biwenger_tools/api/tests/test_api.py
@@ -121,6 +121,50 @@ def test_digests_daily_rejects_get(client):
     assert resp.status_code == 405  # method not allowed
 
 
+# --- /market/auto-bid ---
+
+
+def test_market_auto_bid_calls_run_auto_bid(client):
+    fake = {
+        "sent": 1,
+        "day": "2026-05-23",
+        "candidates": 7,
+        "bid_count": 2,
+        "skipped_count": 5,
+        "total_bid_eur": 12_000_000,
+        "remaining_cash_eur": 1_000_000,
+        "bids": [],
+    }
+    with patch(
+        "packages.biwenger_tools.api.app.auto_bid.run_auto_bid",
+        return_value=fake,
+    ) as mock_run:
+        resp = client.post("/market/auto-bid")
+    mock_run.assert_called_once()
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "ok"
+    assert body["bid_count"] == 2
+    assert body["total_bid_eur"] == 12_000_000
+
+
+def test_market_auto_bid_returns_500_on_exception(client):
+    with patch(
+        "packages.biwenger_tools.api.app.auto_bid.run_auto_bid",
+        side_effect=RuntimeError("biwenger 503"),
+    ):
+        resp = client.post("/market/auto-bid")
+    assert resp.status_code == 500
+    body = resp.get_json()
+    assert body["status"] == "error"
+    assert "biwenger 503" in body["error"]
+
+
+def test_market_auto_bid_rejects_get(client):
+    resp = client.get("/market/auto-bid")
+    assert resp.status_code == 405
+
+
 # --- /teams, /managers, /market, /lineups/auto-pick ---
 
 

--- a/packages/biwenger_tools/api/tests/test_auto_bid.py
+++ b/packages/biwenger_tools/api/tests/test_auto_bid.py
@@ -1,0 +1,387 @@
+"""Tests for `logic/auto_bid.py` — tier table + multi-bid loop.
+
+The tier rules are pinned to the user's spec exactly (memory
+`project_market_autobid`). Touching the tier numbers should fail one
+of these tests on purpose so a future change is forced to re-read the
+contract.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from packages.biwenger_tools.api.logic import auto_bid
+
+# --- tier_bid -------------------------------------------------------------
+
+
+def test_tier_all_in_uses_remaining_cash_regardless_of_price():
+    """SF > 800 must bid `remaining_cash`, NOT price+anything. A 26M player
+    against 30M cash → 30M bid (the user's call: never leave cash on the
+    table, never go negative on `maxBid`)."""
+    bid, label = auto_bid.tier_bid(sf=910, price=26_000_000, remaining_cash=30_000_000)
+    assert bid == 30_000_000
+    assert "T1" in label and "all-in" in label
+
+
+def test_tier_all_in_when_cash_is_zero_returns_zero_so_caller_skips():
+    """remaining_cash=0 still returns 0 (not None); the caller's
+    affordability check turns that into a skip with a "no cash" reason."""
+    bid, _ = auto_bid.tier_bid(sf=850, price=10_000_000, remaining_cash=0)
+    assert bid == 0
+
+
+def test_tier_plus_5m_band():
+    bid, label = auto_bid.tier_bid(sf=720, price=8_000_000, remaining_cash=50_000_000)
+    assert bid == 13_000_000  # 8M + 5M
+    assert "T2" in label
+
+
+def test_tier_plus_2m_band():
+    bid, label = auto_bid.tier_bid(sf=500, price=3_000_000, remaining_cash=50_000_000)
+    assert bid == 5_000_000  # 3M + 2M
+    assert "T3" in label
+
+
+def test_tier_below_floor_returns_none():
+    """SF ≤ 400 → skip (the user does not want low-rated noise)."""
+    bid, reason = auto_bid.tier_bid(sf=400, price=1_000_000, remaining_cash=50_000_000)
+    assert bid is None
+    assert "400" in reason
+
+
+@pytest.mark.parametrize(
+    "sf,expected_band",
+    [
+        (801, "T1"),  # boundary just above all-in
+        (800, "T2"),  # boundary: 800 is NOT all-in
+        (601, "T2"),
+        (600, "T3"),  # boundary: 600 falls to T3 band
+        (401, "T3"),
+        (400, None),  # boundary: 400 skipped
+    ],
+)
+def test_tier_boundaries(sf, expected_band):
+    """Pin the exact boundary semantics (strict `>` between bands)."""
+    bid, label = auto_bid.tier_bid(sf=sf, price=1_000_000, remaining_cash=50_000_000)
+    if expected_band is None:
+        assert bid is None
+    else:
+        assert expected_band in label
+
+
+# --- _build_candidates ----------------------------------------------------
+
+
+def _bw(player_id, name, price):
+    return {"id": player_id, "name": name, "price": price}
+
+
+def _sale(player_id, user=None):
+    sale = {"player": {"id": player_id}}
+    if user is not None:
+        sale["user"] = user
+    return sale
+
+
+def _jp_with_sf(name, sf):
+    return {"name": name, "slug": name.lower(), "predict": [{"type": 2, "rate": sf}]}
+
+
+def test_build_candidates_drops_user_listings_and_unmatched_players():
+    market = [
+        _sale(1),  # daily-market (computer-owned) → kept
+        _sale(2, user={"id": 999}),  # user listing → dropped
+        _sale(3),  # daily-market but no JP match → kept with sf=0
+        _sale(4),  # daily-market but missing from biwenger_players → dropped
+    ]
+    biwenger_players = {
+        1: _bw(1, "Vinicius", 10_000_000),
+        3: _bw(3, "Unknown", 1_000_000),
+    }
+    jp_index = {
+        "by_name": {"vinicius": _jp_with_sf("Vinicius", 900)},
+        "by_slug": {"vinicius": _jp_with_sf("Vinicius", 900)},
+    }
+    candidates = auto_bid._build_candidates(market, biwenger_players, jp_index)
+    ids = [c["player_id"] for c in candidates]
+    assert ids == [1, 3]  # sorted SF desc (900, 0)
+    assert candidates[0]["sf"] == 900
+    assert candidates[1]["sf"] == 0
+
+
+def test_build_candidates_sorts_by_sf_descending():
+    market = [_sale(i) for i in (10, 20, 30)]
+    biwenger_players = {i: _bw(i, f"P{i}", 1_000_000) for i in (10, 20, 30)}
+    jp = {
+        "by_name": {
+            "p10": _jp_with_sf("P10", 500),
+            "p20": _jp_with_sf("P20", 900),
+            "p30": _jp_with_sf("P30", 700),
+        },
+        "by_slug": {},
+    }
+    candidates = auto_bid._build_candidates(market, biwenger_players, jp)
+    assert [c["player_id"] for c in candidates] == [20, 30, 10]
+
+
+# --- _format_telegram_text -----------------------------------------------
+
+
+def test_format_telegram_text_renders_placed_skipped_and_totals():
+    placed = [
+        {"name": "Vinicius", "bid": 30_000_000, "tier_label": "T1 all-in (SF 910)"},
+        {
+            "name": "Lewandowski",
+            "bid": 13_000_000,
+            "tier_label": "T2 precio+5M (SF 720)",
+        },
+    ]
+    skipped = [
+        {"name": "Bellingham", "reason": "bid 14.000.000 € > cash 3.000.000 €"},
+    ]
+    text = auto_bid._format_telegram_text(
+        day="2026-05-23",
+        placed=placed,
+        skipped=skipped,
+        total_bid=43_000_000,
+        remaining_cash=3_000_000,
+    )
+    assert "Vinicius" in text
+    assert "30.000.000 €" in text
+    assert "Lewandowski" in text
+    assert "Bellingham" in text
+    assert "Total pujado: <b>43.000.000 €</b>" in text
+    assert "Cash restante: <b>3.000.000 €</b>" in text
+
+
+def test_format_telegram_text_handles_no_candidates():
+    text = auto_bid._format_telegram_text(
+        day="2026-05-23",
+        placed=[],
+        skipped=[],
+        total_bid=0,
+        remaining_cash=10_000_000,
+    )
+    assert "Sin candidatos" in text
+    assert "auto_bid_log/2026-05-23" in text
+
+
+# --- run_auto_bid (end-to-end with mocks) --------------------------------
+
+
+def _patches(target):
+    return f"packages.biwenger_tools.api.logic.auto_bid.{target}"
+
+
+@pytest.fixture
+def run_env():
+    """Pre-baked collaborator doubles for `run_auto_bid`.
+
+    Use as: `run_env(market_players=..., biwenger_players=..., jp_players=...,
+    cash=..., already_bid_ids=..., bid_side_effect=..., telegram=...)`. Yields
+    `(biwenger_mock, send_mock)` after wiring every external dependency.
+    """
+    from contextlib import ExitStack
+
+    def _enter(
+        *,
+        market_players,
+        biwenger_players,
+        jp_players,
+        cash,
+        already_bid_ids=None,
+        bid_side_effect=None,
+        telegram=True,
+    ):
+        stack = ExitStack()
+        mock_cfg = stack.enter_context(patch(_patches("config")))
+        stack.enter_context(patch(_patches("check_api_health")))
+        stack.enter_context(
+            patch(_patches("fetch_all_players"), return_value=jp_players)
+        )
+        mock_client_cls = stack.enter_context(patch(_patches("BiwengerClient")))
+        stack.enter_context(
+            patch(
+                _patches("_already_bid_ids"),
+                return_value=set(already_bid_ids or []),
+            )
+        )
+        stack.enter_context(patch(_patches("_log_bid")))
+        mock_send = stack.enter_context(patch(_patches("send_telegram_message")))
+
+        mock_cfg.JP_AUTH_TOKEN = "tok"
+        mock_cfg.JP_COMPETITION = 1
+        mock_cfg.JP_SCORE_TYPE = 2
+        mock_cfg.BIWENGER_EMAIL = "u"
+        mock_cfg.BIWENGER_PASSWORD = "p"
+        mock_cfg.LOGIN_URL = mock_cfg.ACCOUNT_URL = "x"
+        mock_cfg.LEAGUE_ID = "1"
+        mock_cfg.ALL_PLAYERS_DATA_URL = "x"
+        mock_cfg.MARKET_URL = "x"
+        mock_cfg.TELEGRAM_BOT_TOKEN = "tok" if telegram else ""
+        mock_cfg.TELEGRAM_CHAT_ID = "chat" if telegram else ""
+
+        biwenger = mock_client_cls.return_value
+        biwenger.get_all_players_data_map.return_value = biwenger_players
+        biwenger.get_market_players.return_value = market_players
+        biwenger.get_account_state.return_value = {"cash": cash, "max_bid": cash}
+        if bid_side_effect is not None:
+            biwenger.place_market_bid.side_effect = bid_side_effect
+        else:
+            biwenger.place_market_bid.return_value = {
+                "id": 999,
+                "status": "waiting",
+            }
+        return biwenger, mock_send, stack
+
+    with ExitStack() as outer:
+
+        def factory(**kwargs):
+            biwenger, mock_send, stack = _enter(**kwargs)
+            # Defer cleanup to the outer stack so the test can call the factory
+            # once and read the mocks without leaking patches.
+            outer.callback(stack.close)
+            return biwenger, mock_send
+
+        yield factory
+
+
+def test_run_auto_bid_places_tiered_bids_and_stops_when_cash_runs_out(run_env):
+    """Realistic end-to-end: 3 candidates. SF 910 all-ins the cash, the
+    next two get skipped because cash is now 0."""
+    market = [_sale(1), _sale(2), _sale(3)]
+    biwenger_players = {
+        1: _bw(1, "Vinicius", 12_000_000),
+        2: _bw(2, "Lewa", 8_000_000),
+        3: _bw(3, "Pedri", 3_000_000),
+    }
+    jp_players = [
+        _jp_with_sf("Vinicius", 910),
+        _jp_with_sf("Lewa", 720),
+        _jp_with_sf("Pedri", 500),
+    ]
+    biwenger, mock_send = run_env(
+        market_players=market,
+        biwenger_players=biwenger_players,
+        jp_players=jp_players,
+        cash=30_000_000,
+    )
+    result = auto_bid.run_auto_bid()
+
+    # 1 bid placed (Vinicius all-in 30M), Lewa+Pedri skipped (no cash left).
+    biwenger.place_market_bid.assert_called_once_with(player_id=1, amount=30_000_000)
+    assert result["bid_count"] == 1
+    assert result["total_bid_eur"] == 30_000_000
+    assert result["remaining_cash_eur"] == 0
+    assert result["skipped_count"] == 2  # Lewa + Pedri don't fit
+    assert result["sent"] == 1
+    mock_send.assert_called_once()
+
+
+def test_run_auto_bid_skips_already_bid_today(run_env):
+    """Cloud Scheduler retry on 5xx: the player already in today's log is
+    not re-bid even though they still match the tier rule."""
+    market = [_sale(1)]
+    biwenger_players = {1: _bw(1, "Vinicius", 5_000_000)}
+    jp_players = [_jp_with_sf("Vinicius", 910)]
+    biwenger, _ = run_env(
+        market_players=market,
+        biwenger_players=biwenger_players,
+        jp_players=jp_players,
+        cash=30_000_000,
+        already_bid_ids={1},
+    )
+    result = auto_bid.run_auto_bid()
+
+    biwenger.place_market_bid.assert_not_called()
+    assert result["bid_count"] == 0
+    assert result["skipped_count"] == 1
+
+
+def test_run_auto_bid_continues_when_biwenger_rejects_a_bid(run_env):
+    """A 4xx on one bid must not abort the loop — the next candidate still
+    gets its chance. Mirrors set_lineup's "log + continue" stance."""
+    market = [_sale(1), _sale(2)]
+    biwenger_players = {
+        1: _bw(1, "Vinicius", 1_000_000),
+        2: _bw(2, "Lewa", 1_000_000),
+    }
+    jp_players = [
+        _jp_with_sf("Vinicius", 720),  # T2 → bid 6M
+        _jp_with_sf("Lewa", 720),  # T2 → bid 6M
+    ]
+    err = requests.HTTPError("409 conflict")
+    biwenger, _ = run_env(
+        market_players=market,
+        biwenger_players=biwenger_players,
+        jp_players=jp_players,
+        cash=30_000_000,
+        bid_side_effect=[err, {"id": 1, "status": "waiting"}],
+    )
+    result = auto_bid.run_auto_bid()
+
+    assert biwenger.place_market_bid.call_count == 2
+    assert result["bid_count"] == 1  # Vinicius rejected, Lewa accepted
+    assert result["skipped_count"] == 1
+    # Cash only decremented by the successful bid.
+    assert result["remaining_cash_eur"] == 30_000_000 - 6_000_000
+
+
+def test_run_auto_bid_skips_send_when_telegram_creds_missing(run_env):
+    """No bot token → no Telegram call (still returns full summary)."""
+    market = [_sale(1)]
+    biwenger_players = {1: _bw(1, "Vinicius", 5_000_000)}
+    jp_players = [_jp_with_sf("Vinicius", 910)]
+    _, mock_send = run_env(
+        market_players=market,
+        biwenger_players=biwenger_players,
+        jp_players=jp_players,
+        cash=30_000_000,
+        telegram=False,
+    )
+    result = auto_bid.run_auto_bid()
+
+    mock_send.assert_not_called()
+    assert result["sent"] == 0
+    assert result["bid_count"] == 1
+
+
+# --- _log_bid + _already_bid_ids smoke -----------------------------------
+
+
+def test_already_bid_ids_returns_empty_set_on_firestore_error():
+    """Defensive: a Firestore outage must not stop the run silently. We
+    return an empty dedup set (worst case: a rare double-bid on a retry)
+    rather than skip every candidate."""
+    with patch(
+        _patches("firestore.list_documents"),
+        side_effect=RuntimeError("firestore down"),
+    ):
+        assert auto_bid._already_bid_ids("2026-05-23") == set()
+
+
+def test_log_bid_writes_expected_document():
+    """`_log_bid` must persist the player id (as doc id) plus bid metadata
+    so a retry can deduplicate against it."""
+    candidate = {"player_id": 42, "name": "Vinicius", "sf": 910, "price": 12_000_000}
+    offer = {"id": 99, "status": "waiting"}
+    with patch.object(auto_bid.firestore, "set_document") as mock_set:
+        auto_bid._log_bid("2026-05-23", candidate, 30_000_000, offer)
+    assert mock_set.call_count == 1
+    call_args = mock_set.call_args
+    collection_path = call_args.args[0]
+    doc_id = call_args.args[1]
+    payload = call_args.args[2]
+    assert collection_path == "auto_bid_log/2026-05-23/bids"
+    assert doc_id == "42"
+    assert payload["player_id"] == 42
+    assert payload["bid"] == 30_000_000
+    assert payload["offer_id"] == 99
+    assert payload["status"] == "waiting"
+    assert "created_at" in payload
+
+
+# Quiet unused import warning when running just this file.
+_ = MagicMock


### PR DESCRIPTION
## Summary
- New `POST /market/auto-bid` endpoint + `logic/auto_bid.py` module. Cloud Scheduler will hit it daily at 09:00 Madrid.
- Tier table (over Biwenger cf-base `price`):
  - **SF > 800** → bid = `remaining_cash` (all-in, price-agnostic; the user's call — never leave cash on the table, never go negative).
  - **600 < SF ≤ 800** → `price + 5M`.
  - **400 < SF ≤ 600** → `price + 2M`.
  - **SF ≤ 400** → skip.
- Walks candidates SF-DESC; skips when target_bid > remaining_cash (no downsizing). Continues on per-bid 4xx so a single rejection doesn't abort the loop.
- **Idempotency:** writes each successful bid to Firestore `auto_bid_log/{YYYY-MM-DD}/bids/{player_id}`, and dedups against that log at the start of every run. Cloud Scheduler retries 5xx — this makes the retry a no-op on the players that already went through.
- **Telegram summary** sent at the end: placed bids + skipped reasons + totals + remaining cash.
- **Docs:** `gcp.md` registers the new Scheduler job; `operations.md` documents the one-shot `gcloud scheduler jobs create http biwenger-auto-bid-trigger` command and lists the new endpoint.

> Stacked on top of #87 (the `place_market_bid` SDK addition). Once #87 merges, retarget this to `master`.

## Test plan
- [x] `bazel test //...` — all 6 test suites green (`core`, `api`, `bot`, `scraper_job`, `web`, `chucknorris_bot`).
- [x] `bazel test //packages/biwenger_tools/api:api_tests` covers tier boundaries, multi-bid stop-on-empty-cash, Firestore dedup, 4xx continuation, no-Telegram path, and the route handler itself.
- [x] `flake8` + `black --check` clean on all touched files.
- [ ] First production run (cron) will be the smoke test — Telegram message is the canary.