### PR TITLE
feat(bot): /pujar slash command + Pujar menu button

### DIFF
--- a/packages/biwenger_tools/bot/app.py
+++ b/packages/biwenger_tools/bot/app.py
@@ -42,6 +42,7 @@ _HELP_TEXT = (
     "/alinear — Aplica la mejor alineación posible\n"
     "/preview — Previsualiza la alineación sin aplicarla\n"
     "/recomendar — Qué fichar si me clausulan (top 3 por posición)\n"
+    "/pujar — Lanza el auto-bid del mercado diario por tiers\n"
     "/scrapper — Lanza el scraper a demanda (te avisa al acabar)\n"
     "/version — Versión desplegada del bot y de la API\n"
     "/help — Muestra este mensaje"
@@ -56,6 +57,7 @@ _ACTION_ROUTES: dict[str, tuple[str, str, dict | None]] = {
     "alinear": ("/lineups/auto-pick", "POST", None),
     "alinear_dry": ("/lineups/auto-pick", "POST", {"dry_run": "1"}),
     "recomendar": ("/budget/recommendations", "GET", None),
+    "pujar": ("/market/auto-bid", "POST", None),
     "scrapper": ("/scraper/trigger", "POST", None),
 }
 
@@ -269,6 +271,8 @@ def webhook():
         _dispatch_action("alinear_dry", "👀 Preview alineación")
     elif cmd == "/recomendar":
         _dispatch_action("recomendar", "💡 Recomendar")
+    elif cmd == "/pujar":
+        _dispatch_action("pujar", "💸 Pujar")
     elif cmd == "/scrapper":
         _dispatch_action("scrapper", "🧹 Scraper")
     elif cmd == "/help":

--- a/packages/biwenger_tools/bot/menu.py
+++ b/packages/biwenger_tools/bot/menu.py
@@ -19,6 +19,7 @@ MAIN_MENU_ACTIONS = [
     ("mercado", "🛒 Mercado"),
     ("alinear", "📋 Alinear"),
     ("recomendar", "💡 Recomendar"),
+    ("pujar", "💸 Pujar"),
     ("scrapper", "🧹 Scraper"),
 ]
 

--- a/packages/biwenger_tools/bot/setup_commands.py
+++ b/packages/biwenger_tools/bot/setup_commands.py
@@ -38,6 +38,10 @@ COMMANDS = [
         "description": "Qué fichar si me clausulan (top 3 por posición)",
     },
     {
+        "command": "pujar",
+        "description": "Lanza el auto-bid del mercado diario por tiers",
+    },
+    {
         "command": "scrapper",
         "description": "Lanza el scraper a demanda (te avisa al acabar)",
     },

--- a/packages/biwenger_tools/bot/tests/test_bot.py
+++ b/packages/biwenger_tools/bot/tests/test_bot.py
@@ -94,6 +94,7 @@ def test_wrong_chat_callback_is_silently_ignored(client):
         ("/alinear", "/lineups/auto-pick", "POST", None),
         ("/preview", "/lineups/auto-pick", "POST", {"dry_run": "1"}),
         ("/recomendar", "/budget/recommendations", "GET", None),
+        ("/pujar", "/market/auto-bid", "POST", None),
         ("/scrapper", "/scraper/trigger", "POST", None),
     ],
 )
@@ -183,11 +184,27 @@ def test_menu_sends_inline_keyboard(client):
     assert resp.status_code == 200
     markup = mock_send.call_args.kwargs.get("reply_markup")
     assert markup is not None
-    # 5 actions arranged in 2 columns → 3 rows
+    # 6 actions arranged in 2 columns → 3 rows
     assert len(markup["inline_keyboard"]) == 3
     flattened = [b["callback_data"] for row in markup["inline_keyboard"] for b in row]
     assert "menu:analizar" in flattened
+    assert "menu:pujar" in flattened
     assert "menu:scrapper" in flattened
+
+
+def test_menu_pujar_callback_dispatches_auto_bid(client):
+    """Tapping the "Pujar" button on the menu fires `/market/auto-bid`."""
+    with patch(
+        "packages.biwenger_tools.bot.app.answer_callback_query"
+    ) as mock_ack, patch(
+        "packages.biwenger_tools.bot.app.api_client.call_api"
+    ) as mock_call:
+        resp = _post(client, _callback_update(_VALID_CHAT, "menu:pujar"))
+    assert resp.status_code == 200
+    mock_ack.assert_called_once()
+    mock_call.assert_called_once_with(
+        _API_URL, "/market/auto-bid", method="POST", params=None
+    )
 
 
 def test_start_aliases_menu(client):


### PR DESCRIPTION
## Summary
- New `/pujar` slash command + 💸 Pujar button in the main inline menu. Both dispatch `POST /market/auto-bid` on biwenger-api — same path as the rest of the actions, no special-casing.
- Registers `/pujar` in `setup_commands.py` so the Telegram slash-command menu picks it up after the next bot deploy.
- Test coverage: parametrised text-command test now covers `/pujar`; new test for the menu callback (`menu:pujar`).

Useful for testing the auto-bid without waiting for the 09:00 cron, and for the rare case you want to re-run after a manual cash injection.

> Stacked on top of #88 (the `/market/auto-bid` endpoint). Once #88 merges, retarget this to `master`.

## Test plan
- [x] `bazel test //packages/biwenger_tools/bot:bot_tests` — all green.
- [x] `flake8` + `black --check` clean.
- [ ] After deploy, run `setup_commands.py` once so Telegram's slash menu shows /pujar.