### PR TITLE
feat(api): chain auto-bid into the daily digest

### DIFF
--- a/docs/gcp.md
+++ b/docs/gcp.md
@@ -12,8 +12,7 @@ Project: `biwenger-tools` · Region: `europe-southwest1` (Madrid)
 | Cloud Run (Services) | `chucknorris-bot` | Chuck Norris jokes Telegram bot |
 | Cloud Run (Jobs) | `biwenger-scraper-data` | Scrapes league messages → CSV → Google Drive |
 | Cloud Scheduler | `biwenger-scraper-data-scheduler-trigger` (`europe-west1`) | Triggers scraper job (cron weekly Sun 22:00) |
-| Cloud Scheduler | `biwenger-daily-digest-trigger` (`europe-west1`) | Triggers `biwenger-api/digests/daily` (daily 09:00 Madrid) |
-| Cloud Scheduler | `biwenger-auto-bid-trigger` (`europe-west1`) | Triggers `biwenger-api/market/auto-bid` (daily 09:00 Madrid) |
+| Cloud Scheduler | `biwenger-daily-digest-trigger` (`europe-west1`) | Triggers `biwenger-api/digests/daily` (daily 09:00 Madrid) — sends squad + market images and chains the auto-bid summary at the end |
 | Secret Manager | 4 secrets (see below) | Credentials and bot tokens |
 | Artifact Registry | `biwenger-docker` | Docker images for all Cloud Run services/jobs |
 | Cloud Logging | — | Automatic, structured logs via `get_logger()` |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -196,27 +196,8 @@ ID token whose service account has `roles/run.invoker` on `biwenger-api`.
     | `POST` | `/lineups/auto-pick` | Pick + apply lineup (was `/alinear`) |
     | `GET`  | `/budget/recommendations` | Top affordable clausulazo targets per position |
     | `POST` | `/scraper/trigger` | Queue a scraper job execution (bot's `/scrapper`) |
-    | `POST` | `/digests/daily` | Cron — my team + market (Scheduler only) |
-    | `POST` | `/market/auto-bid` | Cron — tiered auto-bid on the daily market (Scheduler only) |
-
-  * **Create the auto-bid Cloud Scheduler job (one-shot):**
-
-    ```bash
-      API_URL=$(gcloud run services describe biwenger-api --region europe-southwest1 --format='value(status.url)')
-      gcloud scheduler jobs create http biwenger-auto-bid-trigger \
-        --schedule="0 9 * * *" \
-        --time-zone="Europe/Madrid" \
-        --location=europe-west1 \
-        --uri="$API_URL/market/auto-bid" \
-        --http-method=POST \
-        --oidc-service-account-email=biwenger-scheduler@biwenger-tools.iam.gserviceaccount.com \
-        --oidc-token-audience="$API_URL" \
-        --attempt-deadline=120s
-    ```
-
-    Same service account + audience pattern as `biwenger-daily-digest-trigger`.
-    Idempotency is handled by the endpoint itself (Firestore `auto_bid_log/{date}`),
-    so a retry on transient 5xx is safe.
+    | `POST` | `/digests/daily` | Cron — my team + market images, then auto-bid summary (chained, Scheduler only) |
+    | `POST` | `/market/auto-bid` | Tiered auto-bid on the daily market — chained into `/digests/daily` at 09:00 Madrid; also exposed standalone for the bot's `/pujar` manual trigger |
 
   * **Smoke test:**
 

--- a/packages/biwenger_tools/api/logic/digests.py
+++ b/packages/biwenger_tools/api/logic/digests.py
@@ -1,8 +1,12 @@
-"""Daily digest logic — sends "my team + market" as PNGs to Telegram.
+"""Daily digest logic — sends "my team + market + auto-bid summary" to Telegram.
 
 Used by `POST /digests/daily`, which Cloud Scheduler hits once a day. The
 orchestration (JP health check, build index, Biwenger session, send) lives
 here so the Flask handler stays a thin shell that translates HTTP errors.
+
+The auto-bid step is chained at the end on purpose: a single daily cron
+gives the user a coherent morning message (squad → market → bids) in
+guaranteed order, instead of two independent Scheduler jobs racing.
 """
 
 import time
@@ -12,6 +16,7 @@ from core.sdk.jp import check_api_health, fetch_all_players
 from core.sdk.telegram import send_telegram_photo
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
+from packages.biwenger_tools.api.logic import auto_bid
 from packages.biwenger_tools.api.logic.image_formatter import build_table_image
 from packages.biwenger_tools.api.logic.player_matching import build_jp_index
 from packages.biwenger_tools.api.logic.rows import build_market_rows, build_squad_rows
@@ -73,8 +78,28 @@ def run_daily() -> dict:
         "Mercado",
     )
 
+    # Auto-bid chained as the final step so the chat reads: squad → market →
+    # bid summary in guaranteed order. Wrapped in a broad try/except — a
+    # broken auto-bid run must not lose the digest we already sent above.
+    auto_bid_result: dict
+    try:
+        auto_bid_result = auto_bid.run_auto_bid()
+    except Exception as exc:
+        logger.exception("Auto-bid step failed inside daily digest.")
+        auto_bid_result = {"error": str(exc)}
+
     logger.info(
         "Daily analysis sent.",
-        extra={"my_team": len(my_team), "market": len(market_rows)},
+        extra={
+            "my_team": len(my_team),
+            "market": len(market_rows),
+            "auto_bid_placed": auto_bid_result.get("bid_count"),
+            "auto_bid_skipped": auto_bid_result.get("skipped_count"),
+        },
     )
-    return {"sent": 2, "my_team": len(my_team), "market": len(market_rows)}
+    return {
+        "sent": 2,
+        "my_team": len(my_team),
+        "market": len(market_rows),
+        "auto_bid": auto_bid_result,
+    }

--- a/packages/biwenger_tools/api/tests/test_api.py
+++ b/packages/biwenger_tools/api/tests/test_api.py
@@ -89,7 +89,12 @@ def test_scraper_trigger_rejects_get(client):
 
 
 def test_digests_daily_calls_run_daily_and_returns_summary(client):
-    fake = {"sent": 2, "my_team": 12, "market": 8}
+    fake = {
+        "sent": 2,
+        "my_team": 12,
+        "market": 8,
+        "auto_bid": {"bid_count": 1, "skipped_count": 2, "total_bid_eur": 5_000_000},
+    }
     with patch(
         "packages.biwenger_tools.api.app.digests.run_daily",
         return_value=fake,
@@ -102,6 +107,7 @@ def test_digests_daily_calls_run_daily_and_returns_summary(client):
     assert body["sent"] == 2
     assert body["my_team"] == 12
     assert body["market"] == 8
+    assert body["auto_bid"]["bid_count"] == 1
 
 
 def test_digests_daily_returns_500_on_exception(client):
@@ -563,3 +569,92 @@ def test_run_daily_skips_send_when_telegram_creds_missing(client):
     assert result["sent"] == 0
     assert result["reason"] == "telegram_credentials_missing"
     mock_send.assert_not_called()
+
+
+def _digest_env(*, auto_bid_result=None, auto_bid_raises=None):
+    """Helper: wire `run_daily`'s collaborators so only auto_bid varies.
+
+    Returns the entered ExitStack — the caller must close it. Designed
+    for the two tests below that pin the chaining behaviour.
+    """
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    mock_cfg = stack.enter_context(patch(_patches("config")))
+    stack.enter_context(patch(_patches("check_api_health")))
+    stack.enter_context(patch(_patches("fetch_all_players"), return_value=[]))
+    stack.enter_context(
+        patch(_patches("build_jp_index"), return_value={"by_name": {}, "by_slug": {}})
+    )
+    mock_client = stack.enter_context(patch(_patches("BiwengerClient")))
+    mock_send = stack.enter_context(patch(_patches("_send_image")))
+    # `build_table_image` runs synchronously before `_send_image` — patching
+    # the renderer avoids matplotlib choking on the empty-row stub data.
+    stack.enter_context(patch(_patches("build_table_image"), return_value=b""))
+    if auto_bid_raises is not None:
+        mock_auto_bid = stack.enter_context(
+            patch(_patches("auto_bid.run_auto_bid"), side_effect=auto_bid_raises)
+        )
+    else:
+        mock_auto_bid = stack.enter_context(
+            patch(_patches("auto_bid.run_auto_bid"), return_value=auto_bid_result or {})
+        )
+
+    mock_cfg.JP_AUTH_TOKEN = "tok"
+    mock_cfg.JP_COMPETITION = 1
+    mock_cfg.JP_SCORE_TYPE = 2
+    mock_cfg.BIWENGER_EMAIL = "u"
+    mock_cfg.BIWENGER_PASSWORD = "p"
+    mock_cfg.LOGIN_URL = mock_cfg.ACCOUNT_URL = "x"
+    mock_cfg.LEAGUE_ID = "1"
+    mock_cfg.ALL_PLAYERS_DATA_URL = "x"
+    mock_cfg.USER_SQUAD_URL = "x/{manager_id}"
+    mock_cfg.MARKET_URL = "x"
+    mock_cfg.TELEGRAM_BOT_TOKEN = "tok"
+    mock_cfg.TELEGRAM_CHAT_ID = "chat"
+    mock_client.return_value.user_id = 1
+    mock_client.return_value.get_all_players_data_map.return_value = {}
+    mock_client.return_value.get_manager_squad.return_value = []
+    mock_client.return_value.get_market_players.return_value = []
+    return stack, mock_send, mock_auto_bid
+
+
+def test_run_daily_chains_auto_bid_after_sending_images():
+    """`run_daily` must call `auto_bid.run_auto_bid()` exactly once, after
+    both PNGs have been sent — that's what gives the chat a clean
+    squad → market → bids ordering."""
+    stack, mock_send, mock_auto_bid = _digest_env(
+        auto_bid_result={"bid_count": 2, "skipped_count": 3, "total_bid_eur": 4_000_000}
+    )
+    try:
+        from packages.biwenger_tools.api.logic import digests
+
+        result = digests.run_daily()
+    finally:
+        stack.close()
+
+    mock_auto_bid.assert_called_once()
+    # 2 image sends happened first (my team + market).
+    assert mock_send.call_count == 2
+    assert result["sent"] == 2
+    assert result["auto_bid"]["bid_count"] == 2
+
+
+def test_run_daily_swallows_auto_bid_failure_and_still_returns_digest_summary():
+    """A broken auto-bid run must not lose the digest we already sent. The
+    summary surfaces the error, but the route stays 200 OK."""
+    stack, mock_send, mock_auto_bid = _digest_env(
+        auto_bid_raises=RuntimeError("biwenger 503")
+    )
+    try:
+        from packages.biwenger_tools.api.logic import digests
+
+        result = digests.run_daily()
+    finally:
+        stack.close()
+
+    mock_auto_bid.assert_called_once()
+    assert mock_send.call_count == 2
+    assert result["sent"] == 2
+    assert "error" in result["auto_bid"]
+    assert "biwenger 503" in result["auto_bid"]["error"]


### PR DESCRIPTION
## Summary
- Encadena `auto_bid.run_auto_bid()` al final de `digests.run_daily`. Un único cron a las 09:00 Madrid → el chat de Telegram lee siempre en orden: <b>mi equipo → mercado → resumen de pujas</b>.
- La llamada al auto-bid va dentro de un `try/except` amplio: si revienta, el digest ya enviado no se pierde, el error se devuelve en la respuesta para observabilidad.
- Docs: se elimina el Scheduler `biwenger-auto-bid-trigger` standalone que había documentado en #88. El endpoint `/market/auto-bid` sigue existiendo — `/pujar` (PR #89) lo usa para el trigger manual.
- Tests: se cubre el chaining (`auto_bid` se llama una vez tras los dos `_send_image`), el swallowing del error, y se actualiza el contract test del route handler.

> Stacked sobre #89 (bot `/pujar`). Cuando #87/#88/#89 mergeen en orden, retargetear esto a `master`.

## Test plan
- [x] `bazel test //...` — las 6 suites verdes.
- [x] `flake8` + `black --check` clean.
- [ ] Verificación real en producción: el próximo run a las 09:00 mostrará los 3 mensajes en orden.