### PR TITLE
feat(cost): Firestore TTL on auto_bid_log + AR cleanup race fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -441,6 +441,14 @@ jobs:
     name: Clean up old images
     needs: [deploy-web, deploy-scraper, deploy-bot, deploy-api, deploy-chucknorris-bot]
     if: always() && (needs.deploy-web.result == 'success' || needs.deploy-scraper.result == 'success' || needs.deploy-bot.result == 'success' || needs.deploy-api.result == 'success' || needs.deploy-chucknorris-bot.result == 'success')
+    # Serialize cleanups across concurrent deploys. Without this, two cleanup
+    # runs racing on the same orphan digest would both call `gcloud images
+    # delete` — the loser hits NOT_FOUND and fails the job (observed on the
+    # 4-PR auto-bid stack merge, 2026-05-24). `cancel-in-progress: false`
+    # queues instead of cancelling so every deploy still gets a cleanup.
+    concurrency:
+      group: cleanup-artifact-registry
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -20,6 +20,7 @@ participacion/{season}/authors/{autor}
 clausulazos/{season}/transfers/{content_hash}
 tabla_justicia/{season}/teams/{equipo}
 palmares/{temporada}
+auto_bid_log/{YYYY-MM-DD}/bids/{player_id}
 ```
 
 There is an intermediate "season" document (`comunicados/{season}`,
@@ -119,6 +120,29 @@ Historical honours. One document per season (`24-25`, `23-24`, ...).
 chronological DESC, so `order_by("__name__")` returns e.g.
 `["25-26", "24-25", "23-24"]`.
 
+### `auto_bid_log/{YYYY-MM-DD}/bids/{player_id}` — Auto-bid run log
+
+One document per successful bid placed by `/market/auto-bid`. The run
+reads today's collection up-front and skips any player already bid, so
+a Cloud Scheduler retry of a half-completed run is a no-op on the
+players that already went through.
+
+| Field         | Type      | Notes |
+|---------------|-----------|-------|
+| `player_id`   | int       | Biwenger player id (same as the doc id) |
+| `name`        | string    | Player name at bid time (denormalised for the Telegram log) |
+| `sf`          | int       | SofaScore rating used to pick the tier |
+| `price`       | int       | Biwenger cf-base price (euros) at bid time |
+| `bid`         | int       | Amount we sent in the offer (euros) |
+| `offer_id`    | int       | Biwenger's `data.id` from the offer response |
+| `status`      | string    | Biwenger's `data.status` (e.g. `"waiting"`) |
+| `created_at`  | string    | ISO timestamp (Europe/Madrid) of the bid |
+| `expires_at`  | timestamp | TTL field — Firestore deletes the doc when this passes (90 days) |
+
+**Doc id:** the `player_id` as a string.
+**Retention:** managed by a TTL policy on the `bids` collection-group —
+see "TTL policies" below.
+
 ---
 
 ## Indexes
@@ -179,6 +203,35 @@ gcloud firestore indexes composite delete <id> --project=biwenger-tools
 When a query needs an index that does not exist, Firestore returns
 `FAILED_PRECONDITION` with a direct link to the console to create it.
 Building takes seconds to minutes depending on collection size.
+
+---
+
+## TTL policies
+
+Firestore deletes documents whose TTL field is in the past, free of
+charge (deletes are not billed). We use this to garden the auto-bid
+log so it stays small without a custom cleanup job.
+
+| Collection group | TTL field    | Set by                                | Retention |
+|------------------|--------------|---------------------------------------|-----------|
+| `bids`           | `expires_at` | `auto_bid._log_bid` (created_at + N)  | 90 days   |
+
+### Create / verify the policy
+
+```bash
+# One-shot: enable TTL on the `bids` collection-group
+gcloud firestore fields ttls update expires_at \
+  --collection-group=bids \
+  --enable-ttl \
+  --project=biwenger-tools
+
+# Inspect
+gcloud firestore fields ttls list --project=biwenger-tools
+```
+
+The TTL field must be a `timestamp` (not a string) — the SDK call in
+`auto_bid._log_bid` writes a `datetime` so Firestore stores it as a
+timestamp automatically.
 
 ---
 

--- a/packages/biwenger_tools/api/logic/auto_bid.py
+++ b/packages/biwenger_tools/api/logic/auto_bid.py
@@ -24,7 +24,7 @@ in that log before bidding, so a retry of a half-completed run does
 not double-bid the players that already went through.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
 import requests
@@ -60,6 +60,14 @@ TIER_PLUS_2M_SURCHARGE = 2_000_000
 # on 5xx — looking up the log before bidding makes a retried run a no-op
 # on the players that already went through.
 AUTO_BID_LOG_PATH = "auto_bid_log"
+
+# Per-bid Firestore TTL. The TTL policy on the `bids` collection-group
+# (configured once via `gcloud firestore fields ttls update expires_at
+# --collection-group=bids --enable-ttl`) deletes documents when the
+# `expires_at` timestamp passes. 90 days is enough to look back on
+# "what did the bot try yesterday/last week" without letting the
+# collection grow unbounded.
+_LOG_TTL_DAYS = 90
 
 
 def _today_madrid() -> str:
@@ -149,6 +157,7 @@ def _already_bid_ids(day: str) -> set[int]:
 
 def _log_bid(day: str, candidate: dict, bid_amount: int, offer: dict) -> None:
     """Record a successful bid so a retried run won't repeat it."""
+    now = datetime.now(MADRID_TZ)
     firestore.set_document(
         _log_collection_path(day),
         str(candidate["player_id"]),
@@ -160,7 +169,10 @@ def _log_bid(day: str, candidate: dict, bid_amount: int, offer: dict) -> None:
             "bid": bid_amount,
             "offer_id": offer.get("id"),
             "status": offer.get("status"),
-            "created_at": datetime.now(MADRID_TZ).isoformat(),
+            "created_at": now.isoformat(),
+            # Firestore TTL field — the policy on the `bids` collection-group
+            # deletes the doc once this timestamp is in the past.
+            "expires_at": now + timedelta(days=_LOG_TTL_DAYS),
         },
     )
 

--- a/packages/biwenger_tools/api/tests/test_auto_bid.py
+++ b/packages/biwenger_tools/api/tests/test_auto_bid.py
@@ -381,6 +381,14 @@ def test_log_bid_writes_expected_document():
     assert payload["offer_id"] == 99
     assert payload["status"] == "waiting"
     assert "created_at" in payload
+    # Firestore TTL contract: expires_at must be exactly _LOG_TTL_DAYS in the
+    # future, so the TTL policy on the `bids` collection-group gardens the
+    # docs after the chosen retention window.
+    from datetime import datetime, timedelta
+
+    expires = payload["expires_at"]
+    created = datetime.fromisoformat(payload["created_at"])
+    assert expires - created == timedelta(days=auto_bid._LOG_TTL_DAYS)
 
 
 # Quiet unused import warning when running just this file.

--- a/scripts/clean-images-artifact.sh
+++ b/scripts/clean-images-artifact.sh
@@ -49,8 +49,23 @@ for IMAGE in "${SIMPLE_IMAGES[@]}"; do
     while IFS= read -r DIGEST; do
         [ -z "$DIGEST" ] && continue
         echo "[ACTION] Deleting old digest: $IMAGE@$DIGEST"
-        run gcloud artifacts docker images delete "$REPO/$IMAGE@$DIGEST" \
-            --delete-tags --quiet
+        if [ "$DRY_RUN" = "1" ]; then
+            echo "[DRY_RUN] gcloud artifacts docker images delete $REPO/$IMAGE@$DIGEST --delete-tags --quiet"
+            continue
+        fi
+        # Tolerate the digest already being gone — happens when two concurrent
+        # cleanup runs target the same orphan (the GH Actions `concurrency`
+        # group should prevent this, but a CI race or a manual run in flight
+        # can still trigger it). Other gcloud errors stay fatal.
+        if ! out=$(gcloud artifacts docker images delete \
+                "$REPO/$IMAGE@$DIGEST" --delete-tags --quiet 2>&1); then
+            if echo "$out" | grep -qE 'NOT_FOUND|Requested entity was not found'; then
+                echo "[OK] $IMAGE@$DIGEST already gone — skipping."
+            else
+                echo "[ERROR] $out" >&2
+                exit 1
+            fi
+        fi
     done <<< "$DIGESTS_TO_DELETE"
     echo "[OK] $IMAGE cleaned."
 done


### PR DESCRIPTION
## Summary
Two cost-optimization recommendations from the Google Cloud WAF review of the auto-bid feature. Both reinforce the **€0/mes** goal.

### 1. Firestore TTL on `auto_bid_log`
- `auto_bid._log_bid` now writes `expires_at = created_at + 90 days` alongside `created_at`.
- New "TTL policies" section in `docs/firestore.md` covering the `bids` collection-group policy and the one-shot `gcloud firestore fields ttls update` command.
- Policy already enabled in prod and verified ACTIVE.

Why 90 days: enough retention to debug "what did the bot try last week" without letting the collection grow unbounded. At ≤5 bids/day this would otherwise leak ~1.8 MB after 10 years — not a cost problem in absolute terms, but a cleanliness problem in the Firestore console. TTL deletes are unbilled.

### 2. Artifact Registry cleanup race fix
Observed today (4 concurrent auto-bid stack merges → 2 cleanup job failures with `gcloud.artifacts.docker.images.delete: Requested entity was not found`). Two cleanup runs racing on the same orphan digest = one succeeds, the loser hits NOT_FOUND and fails the job. Cost impact today was zero (the last run succeeded), but accumulated failures could leak digests over time and push past the 500 MB free tier.

Two-layer fix:
- **GH Actions `concurrency` group** on the cleanup job so cleanups serialise across concurrent deploys. `cancel-in-progress: false` to queue (not cancel) so every deploy still gets one cleanup.
- **Script-level NOT_FOUND tolerance** in `clean-images-artifact.sh` simple-images loop — mirror of the existing multi-arch loop pattern. Other gcloud errors stay fatal.

## Test plan
- [x] `bazel test //...` — all 6 test suites green.
- [x] `flake8` + `black --check` clean.
- [x] `bash -n scripts/clean-images-artifact.sh` — shell syntax OK.
- [x] `gcloud firestore fields ttls list --project=biwenger-tools` shows `state: ACTIVE` on `bids`/`expires_at`.
- [ ] First post-deploy cron run will write the new `expires_at` field — check Firestore console after tomorrow 09:00 Madrid.