### PR TITLE
feat(auto-bid): T4 tier (SF 300-400) + anti-pattern jitter

### DIFF
--- a/packages/biwenger_tools/api/logic/auto_bid.py
+++ b/packages/biwenger_tools/api/logic/auto_bid.py
@@ -6,17 +6,20 @@ morning, attach SofaScore (Automanager) ratings from JP, and place a
 bid on each player according to the tier below — best score first,
 stopping when cash runs out.
 
-Tiers (over Biwenger's cf-base `price`, NOT `owner.price`):
+Tiers (over Biwenger's cf-base `price`, NOT `owner.price`). Every
+non-skipped bid carries a random 0–`BID_JITTER_MAX` € offset so the
+amounts don't look botty:
 
-    SF > 800             → bid = remaining_cash    (all-in, never maxBid)
-    600 < SF ≤ 800       → bid = price + 5_000_000  (aggressive)
-    400 < SF ≤ 600       → bid = price + 2_000_000
-    SF ≤ 400             → skip
+    SF > 800             → bid = remaining_cash - jitter   (all-in)
+    600 < SF ≤ 800       → bid = price + 5_000_000 + jitter (aggressive)
+    400 < SF ≤ 600       → bid = price + 2_000_000 + jitter
+    300 < SF ≤ 400       → bid = price +   500_000 + jitter (low conviction)
+    SF ≤ 300             → skip
 
 Hard rule across every tier: skip the player when the would-be bid
 exceeds `remaining_cash` — we never go negative. The all-in tier bids
 the full cash regardless of price (a 26M player against 30M cash is
-still a 30M bid, by the user's call).
+still a ~30M bid, by the user's call).
 
 Idempotency: Cloud Scheduler retries 5xx responses. We log placed bids
 to `auto_bid_log/{YYYY-MM-DD}` (one doc per player) and skip anything
@@ -24,6 +27,7 @@ in that log before bidding, so a retry of a half-completed run does
 not double-bid the players that already went through.
 """
 
+import random
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -53,8 +57,17 @@ logger = get_logger(__name__)
 TIER_ALL_IN_MIN = 800
 TIER_PLUS_5M_MIN = 600
 TIER_PLUS_2M_MIN = 400
+TIER_PLUS_500K_MIN = 300
 TIER_PLUS_5M_SURCHARGE = 5_000_000
 TIER_PLUS_2M_SURCHARGE = 2_000_000
+TIER_PLUS_500K_SURCHARGE = 500_000
+
+# Per-bid anti-pattern jitter. A bot that always bids in round euros
+# (10.000.000, 10.500.000, …) is a tell — humans dragging the slider
+# in the Biwenger UI never land on exact round numbers. Every bid gets
+# a random 0–1000 € offset so the trail looks human. The economic
+# impact is negligible (≤0.01% of any tier).
+BID_JITTER_MAX = 1000
 
 # Firestore path for today's per-player bid log. Cloud Scheduler retries
 # on 5xx — looking up the log before bidding makes a retried run a no-op
@@ -88,24 +101,37 @@ def _euros(n: int | None) -> str:
     return f"{s} €"
 
 
+def _jitter() -> int:
+    """Random 0–`BID_JITTER_MAX` € offset for a bid. Indirection makes the
+    randomness easy to pin from tests with a single `patch.object`."""
+    return random.randint(0, BID_JITTER_MAX)
+
+
 def tier_bid(sf: int, price: int, remaining_cash: int) -> tuple[Optional[int], str]:
     """Return `(target_bid, label)` for a player, or `(None, reason)` to skip.
 
     `target_bid` may exceed `remaining_cash` — the caller is in charge of
     the affordability check (so the skip reason can be richer than a
     bare None).
+
+    Every tier adds (or, for T1 all-in, subtracts) a random 0-`BID_JITTER_MAX`
+    € offset. The economic impact is < 0.01% of any tier but the bid trail
+    stops looking like a bot.
     """
+    jitter = _jitter()
     if sf > TIER_ALL_IN_MIN:
         # All-in on the cash we have right now. Price is irrelevant — the
         # user accepts paying 30M for a 26M player rather than leaving cash
-        # on the table. `remaining_cash` of 0 falls through to the
-        # affordability check below and gets reported as "sin cash".
-        return remaining_cash, f"T1 all-in (SF {sf})"
+        # on the table. Jitter SUBTRACTS here (can't bid > cash); the result
+        # stays strictly inside [remaining_cash - BID_JITTER_MAX, remaining_cash].
+        return max(0, remaining_cash - jitter), f"T1 all-in (SF {sf})"
     if sf > TIER_PLUS_5M_MIN:
-        return price + TIER_PLUS_5M_SURCHARGE, f"T2 precio+5M (SF {sf})"
+        return price + TIER_PLUS_5M_SURCHARGE + jitter, f"T2 precio+5M (SF {sf})"
     if sf > TIER_PLUS_2M_MIN:
-        return price + TIER_PLUS_2M_SURCHARGE, f"T3 precio+2M (SF {sf})"
-    return None, f"SF {sf} ≤ {TIER_PLUS_2M_MIN}"
+        return price + TIER_PLUS_2M_SURCHARGE + jitter, f"T3 precio+2M (SF {sf})"
+    if sf > TIER_PLUS_500K_MIN:
+        return price + TIER_PLUS_500K_SURCHARGE + jitter, f"T4 precio+500K (SF {sf})"
+    return None, f"SF {sf} ≤ {TIER_PLUS_500K_MIN}"
 
 
 def _build_candidates(

--- a/packages/biwenger_tools/api/tests/test_auto_bid.py
+++ b/packages/biwenger_tools/api/tests/test_auto_bid.py
@@ -14,41 +14,58 @@ import requests
 from packages.biwenger_tools.api.logic import auto_bid
 
 # --- tier_bid -------------------------------------------------------------
+#
+# Every tier carries a random 0-BID_JITTER_MAX € offset (anti-pattern), so
+# expected bid values are checked as RANGES, not exact equalities. The few
+# tests that need determinism patch `auto_bid._jitter` to a fixed return.
 
 
 def test_tier_all_in_uses_remaining_cash_regardless_of_price():
-    """SF > 800 must bid `remaining_cash`, NOT price+anything. A 26M player
-    against 30M cash → 30M bid (the user's call: never leave cash on the
-    table, never go negative on `maxBid`)."""
+    """SF > 800 must bid ~`remaining_cash` (minus jitter), NOT price+anything.
+    A 26M player against 30M cash → ~30M bid (never leave cash on the table,
+    never go negative on `maxBid`)."""
     bid, label = auto_bid.tier_bid(sf=910, price=26_000_000, remaining_cash=30_000_000)
-    assert bid == 30_000_000
+    assert 30_000_000 - auto_bid.BID_JITTER_MAX <= bid <= 30_000_000
     assert "T1" in label and "all-in" in label
 
 
 def test_tier_all_in_when_cash_is_zero_returns_zero_so_caller_skips():
-    """remaining_cash=0 still returns 0 (not None); the caller's
-    affordability check turns that into a skip with a "no cash" reason."""
+    """remaining_cash=0 still returns 0 (not negative — jitter is clamped at
+    0); the caller's affordability check turns that into a skip with a
+    "no cash" reason."""
     bid, _ = auto_bid.tier_bid(sf=850, price=10_000_000, remaining_cash=0)
     assert bid == 0
 
 
 def test_tier_plus_5m_band():
     bid, label = auto_bid.tier_bid(sf=720, price=8_000_000, remaining_cash=50_000_000)
-    assert bid == 13_000_000  # 8M + 5M
+    # 8M + 5M + jitter ∈ [13_000_000, 13_001_000]
+    assert 13_000_000 <= bid <= 13_000_000 + auto_bid.BID_JITTER_MAX
     assert "T2" in label
 
 
 def test_tier_plus_2m_band():
     bid, label = auto_bid.tier_bid(sf=500, price=3_000_000, remaining_cash=50_000_000)
-    assert bid == 5_000_000  # 3M + 2M
+    # 3M + 2M + jitter ∈ [5_000_000, 5_001_000]
+    assert 5_000_000 <= bid <= 5_000_000 + auto_bid.BID_JITTER_MAX
     assert "T3" in label
 
 
+def test_tier_plus_500k_band():
+    """T4: 300 < SF ≤ 400 → price + 500K + jitter. Covers the visual-green-
+    but-low-conviction band (PNG paints green at SF ≥ 300, this tier bids
+    a token amount on those instead of skipping them outright)."""
+    bid, label = auto_bid.tier_bid(sf=350, price=1_000_000, remaining_cash=50_000_000)
+    # 1M + 500K + jitter ∈ [1_500_000, 1_501_000]
+    assert 1_500_000 <= bid <= 1_500_000 + auto_bid.BID_JITTER_MAX
+    assert "T4" in label and "500K" in label
+
+
 def test_tier_below_floor_returns_none():
-    """SF ≤ 400 → skip (the user does not want low-rated noise)."""
-    bid, reason = auto_bid.tier_bid(sf=400, price=1_000_000, remaining_cash=50_000_000)
+    """SF ≤ 300 → skip (T4 floor; T3 boundary stayed at 400)."""
+    bid, reason = auto_bid.tier_bid(sf=300, price=1_000_000, remaining_cash=50_000_000)
     assert bid is None
-    assert "400" in reason
+    assert "300" in reason
 
 
 @pytest.mark.parametrize(
@@ -57,9 +74,11 @@ def test_tier_below_floor_returns_none():
         (801, "T1"),  # boundary just above all-in
         (800, "T2"),  # boundary: 800 is NOT all-in
         (601, "T2"),
-        (600, "T3"),  # boundary: 600 falls to T3 band
+        (600, "T3"),  # 600 falls to T3 band
         (401, "T3"),
-        (400, None),  # boundary: 400 skipped
+        (400, "T4"),  # NEW: 400 now lands in T4 (was skipped pre-T4)
+        (301, "T4"),
+        (300, None),  # boundary: 300 skipped (T4 floor strict `>`)
     ],
 )
 def test_tier_boundaries(sf, expected_band):
@@ -69,6 +88,30 @@ def test_tier_boundaries(sf, expected_band):
         assert bid is None
     else:
         assert expected_band in label
+
+
+def test_tier_jitter_is_within_advertised_range():
+    """Sample the jitter empirically over many runs; it must never escape
+    [0, BID_JITTER_MAX]. Without this guard a future widening (e.g.
+    BID_JITTER_MAX → 10_000) could nudge tier-bid values past the affordability
+    cap unnoticed."""
+    seen = set()
+    for _ in range(500):
+        bid, _ = auto_bid.tier_bid(sf=500, price=3_000_000, remaining_cash=50_000_000)
+        seen.add(bid - 5_000_000)
+    assert all(0 <= delta <= auto_bid.BID_JITTER_MAX for delta in seen)
+    # At least a couple of distinct values out of 500 — proof randomness is on.
+    assert len(seen) > 10
+
+
+def test_tier_jitter_subtracted_for_all_in():
+    """For T1 the jitter SUBTRACTS from cash so the bid never exceeds it.
+    Crucial — a bid > maxBid would be rejected by Biwenger."""
+    cash = 30_000_000
+    for _ in range(50):
+        bid, _ = auto_bid.tier_bid(sf=910, price=26_000_000, remaining_cash=cash)
+        assert bid <= cash
+        assert cash - auto_bid.BID_JITTER_MAX <= bid
 
 
 # --- _build_candidates ----------------------------------------------------
@@ -209,6 +252,9 @@ def run_env():
             )
         )
         stack.enter_context(patch(_patches("_log_bid")))
+        # Pin jitter to 0 so the run-level assertions can stay on exact euros.
+        # The jitter behaviour itself is covered by the tier_bid-level tests.
+        stack.enter_context(patch(_patches("_jitter"), return_value=0))
         mock_send = stack.enter_context(patch(_patches("send_telegram_message")))
 
         mock_cfg.JP_AUTH_TOKEN = "tok"


### PR DESCRIPTION
## Summary
Cierra el gap entre la imagen PNG del mercado (pinta verde en SF ≥ 300) y el floor del auto-bid (era SF > 400). Esta mañana Calvo (SF 400) y Eric Bailly (SF 381) salían verdes y nos los saltamos — con T4 ambos entran con una puja simbólica.

### Tier table actualizada

| Tier | SF | Puja |
|---|---|---|
| T1 | > 800 | `remaining_cash - jitter` (all-in) |
| T2 | 600-800 | `price + 5M + jitter` |
| T3 | 400-600 | `price + 2M + jitter` |
| **T4** (nuevo) | **300-400** | `price + 500K + jitter` |
| skip | ≤ 300 | — |

### Jitter anti-pattern

Cada puja lleva un offset aleatorio de **0-1000 €**. Una puja siempre redonda (10.000.000, 10.500.000, …) huele a bot — los humanos arrastrando el slider de Biwenger nunca aterrizan en redondo. Impacto económico: < 0.01% en cualquier tier.

- T1 (all-in): jitter SE RESTA al cash → la puja se queda ≤ `remaining_cash`.
- T2/T3/T4: jitter SE SUMA al surcharge → ej. T4 envía `price + 500_048` o `price + 501_000`.

### Boundary semantics (strict `>` se mantienen)
- SF = **400** ahora cae en T4 (Calvo de esta mañana entraría con `price + 500K + jitter`).
- SF = **300** sigue siendo skip (floor T4 estricto).

## Test plan
- [x] `bazel test //...` — las 6 suites verdes.
- [x] Per-tier asserts ahora son rangos `[nominal, nominal + BID_JITTER_MAX]` en lugar de igualdad exacta.
- [x] Tests nuevos para: banda T4, rango del jitter (muestreo 500x), T1 nunca excede cash bajo jitter.
- [x] Los tests E2E de `run_auto_bid` parchean `_jitter` a 0 → totales deterministas.
- [ ] Verificación real: próximo run a las 09:00 Madrid mostrará pujas con céntimos extra (`12.345.678 €` en vez de `12.345.000 €`).