### PR TITLE
feat(auto-bid,recomendar): inclusive tier boundaries + sole-GK house rule

### DIFF
--- a/packages/biwenger_tools/api/logic/auto_bid.py
+++ b/packages/biwenger_tools/api/logic/auto_bid.py
@@ -6,15 +6,16 @@ morning, attach SofaScore (Automanager) ratings from JP, and place a
 bid on each player according to the tier below — best score first,
 stopping when cash runs out.
 
-Tiers (over Biwenger's cf-base `price`, NOT `owner.price`). Every
-non-skipped bid carries a random 0–`BID_JITTER_MAX` € offset so the
-amounts don't look botty:
+Tiers (over Biwenger's cf-base `price`, NOT `owner.price`). Boundaries
+are INCLUSIVE on the lower end (a player at exactly 400 lands in T3,
+not T4). Every non-skipped bid carries a random 0–`BID_JITTER_MAX` €
+offset so the amounts don't look botty:
 
-    SF > 800             → bid = remaining_cash - jitter   (all-in)
-    600 < SF ≤ 800       → bid = price + 5_000_000 + jitter (aggressive)
-    400 < SF ≤ 600       → bid = price + 2_000_000 + jitter
-    300 < SF ≤ 400       → bid = price +   500_000 + jitter (low conviction)
-    SF ≤ 300             → skip
+    SF ≥ 800             → bid = remaining_cash - jitter   (all-in)
+    600 ≤ SF < 800       → bid = price + 5_000_000 + jitter (aggressive)
+    400 ≤ SF < 600       → bid = price + 2_000_000 + jitter
+    300 ≤ SF < 400       → bid = price +   500_000 + jitter (low conviction)
+    SF < 300             → skip
 
 Hard rule across every tier: skip the player when the would-be bid
 exceeds `remaining_cash` — we never go negative. The all-in tier bids
@@ -119,19 +120,19 @@ def tier_bid(sf: int, price: int, remaining_cash: int) -> tuple[Optional[int], s
     stops looking like a bot.
     """
     jitter = _jitter()
-    if sf > TIER_ALL_IN_MIN:
+    if sf >= TIER_ALL_IN_MIN:
         # All-in on the cash we have right now. Price is irrelevant — the
         # user accepts paying 30M for a 26M player rather than leaving cash
         # on the table. Jitter SUBTRACTS here (can't bid > cash); the result
         # stays strictly inside [remaining_cash - BID_JITTER_MAX, remaining_cash].
         return max(0, remaining_cash - jitter), f"T1 all-in (SF {sf})"
-    if sf > TIER_PLUS_5M_MIN:
+    if sf >= TIER_PLUS_5M_MIN:
         return price + TIER_PLUS_5M_SURCHARGE + jitter, f"T2 precio+5M (SF {sf})"
-    if sf > TIER_PLUS_2M_MIN:
+    if sf >= TIER_PLUS_2M_MIN:
         return price + TIER_PLUS_2M_SURCHARGE + jitter, f"T3 precio+2M (SF {sf})"
-    if sf > TIER_PLUS_500K_MIN:
+    if sf >= TIER_PLUS_500K_MIN:
         return price + TIER_PLUS_500K_SURCHARGE + jitter, f"T4 precio+500K (SF {sf})"
-    return None, f"SF {sf} ≤ {TIER_PLUS_500K_MIN}"
+    return None, f"SF {sf} < {TIER_PLUS_500K_MIN}"
 
 
 def _build_candidates(

--- a/packages/biwenger_tools/api/logic/recommendations.py
+++ b/packages/biwenger_tools/api/logic/recommendations.py
@@ -159,6 +159,9 @@ def _format_telegram_text(payload: dict) -> str:
     return "\n".join(lines)
 
 
+GK_POSITION_ID = 1
+
+
 def _gather_rivals(
     biwenger: BiwengerClient,
     biwenger_players: dict,
@@ -168,6 +171,9 @@ def _gather_rivals(
 
     Skips the logged-in user's own squad. My own squad is fetched separately
     in `run_recommendations` so we can compute Biwenger's max_bid from it.
+
+    Each row also carries `owner_gk_count` — used by the house rule that
+    forbids taking a rival's only goalkeeper (see `_filter_affordable`).
     """
     managers = biwenger.get_league_users(config.LEAGUE_DATA_URL)
     rivals: list[dict] = []
@@ -176,15 +182,23 @@ def _gather_rivals(
             continue
         squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, manager_id)
         rows = build_squad_rows(squad, biwenger_players, jp_index, include_clause=True)
+        gk_count = sum(1 for r in rows if r.get("position_id") == GK_POSITION_ID)
         for r in rows:
             r["owner"] = manager_name
+            r["owner_gk_count"] = gk_count
             rivals.append(r)
         time.sleep(0.3)
     return rivals
 
 
 def _filter_affordable(candidates: list[dict], my_ids: set, target: int) -> list[dict]:
-    """Keep candidates I can actually afford (clause ≤ target) and skip mine."""
+    """Keep candidates I can actually afford (clause ≤ target) and skip mine.
+
+    Also enforces the house rule that we never clauselazo a rival's only
+    goalkeeper — Biwenger would technically allow it but the league agreed
+    leaving someone with zero GKs is unsportsmanlike. The same rule does
+    not apply to outfield positions (rivals are expected to rebuild).
+    """
     out: list[dict] = []
     for row in candidates:
         if row.get("bw_id") in my_ids:
@@ -195,6 +209,12 @@ def _filter_affordable(candidates: list[dict], my_ids: set, target: int) -> list
         if clause <= 0 or clause > target:
             continue
         if _sf_of(row) <= 0:
+            continue
+        if (
+            row.get("position_id") == GK_POSITION_ID
+            and (row.get("owner_gk_count") or 0) <= 1
+        ):
+            # Owner only has this GK — house rule forbids taking it.
             continue
         out.append(row)
     return out

--- a/packages/biwenger_tools/api/tests/test_api.py
+++ b/packages/biwenger_tools/api/tests/test_api.py
@@ -1,6 +1,6 @@
 """Tests for the Biwenger API endpoints."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -390,7 +390,16 @@ def test_compute_dynamic_margin_scales_with_cash():
 # --- recommendations unit tests (filtering + grouping) ---
 
 
-def _row(bw_id, name, pos, alt=None, sf=300, clause=10_000_000, clausulable=True):
+def _row(
+    bw_id,
+    name,
+    pos,
+    alt=None,
+    sf=300,
+    clause=10_000_000,
+    clausulable=True,
+    owner_gk_count=2,
+):
     return {
         "bw_id": bw_id,
         "name": name,
@@ -402,6 +411,7 @@ def _row(bw_id, name, pos, alt=None, sf=300, clause=10_000_000, clausulable=True
         "Cláusula": f"{clause / 1_000_000:.1f}M",
         "clause_value": clause,
         "clausulable_now": clausulable,
+        "owner_gk_count": owner_gk_count,
     }
 
 
@@ -418,6 +428,79 @@ def test_filter_affordable_excludes_my_players_and_locked_and_too_expensive():
     ]
     out = recs._filter_affordable(rows, my_ids, target=50_000_000)
     assert [r["bw_id"] for r in out] == [4]
+
+
+def test_filter_affordable_excludes_rival_only_gk_house_rule():
+    """House rule: never clauselazo a rival's only goalkeeper. Biwenger
+    technically allows it but the league agreed leaving someone with zero
+    GKs is unsportsmanlike. The same rule does NOT apply to outfield
+    positions — a rival's only FWD is fair game."""
+    from packages.biwenger_tools.api.logic import recommendations as recs
+
+    rows = [
+        # Sole GK at the rival → filtered out by the house rule.
+        _row(100, "Dituro", pos=1, owner_gk_count=1, clause=8_000_000, sf=350),
+        # Rival with a backup GK → recommendable.
+        _row(101, "OtherGk", pos=1, owner_gk_count=2, clause=9_000_000, sf=350),
+        # The rule must not bleed into outfield: sole striker stays included.
+        _row(102, "SoleFwd", pos=4, owner_gk_count=1, clause=10_000_000, sf=400),
+    ]
+    out = recs._filter_affordable(rows, my_ids=set(), target=50_000_000)
+    assert [r["bw_id"] for r in out] == [101, 102]
+
+
+def test_gather_rivals_annotates_owner_gk_count(monkeypatch):
+    """`_gather_rivals` must tag every rival row with the owner's GK count
+    so the affordability filter can apply the house rule. Two managers,
+    one with 1 GK, one with 2."""
+    from packages.biwenger_tools.api.logic import recommendations as recs
+
+    biwenger = MagicMock()
+    biwenger.user_id = 0
+    biwenger.get_league_users.return_value = {1: "Ana", 2: "Beto"}
+    biwenger.get_manager_squad.side_effect = lambda url, mgr_id: {
+        1: [{"id": 11}, {"id": 12}],  # Ana: 1 GK + 1 DEF
+        2: [{"id": 21}, {"id": 22}, {"id": 23}],  # Beto: 2 GK + 1 FWD
+    }[mgr_id]
+    biwenger_players = {
+        11: {"id": 11, "name": "Ana-Gk", "position": 1, "price": 1, "altPositions": []},
+        12: {
+            "id": 12,
+            "name": "Ana-Def",
+            "position": 2,
+            "price": 1,
+            "altPositions": [],
+        },
+        21: {
+            "id": 21,
+            "name": "Beto-Gk1",
+            "position": 1,
+            "price": 1,
+            "altPositions": [],
+        },
+        22: {
+            "id": 22,
+            "name": "Beto-Gk2",
+            "position": 1,
+            "price": 1,
+            "altPositions": [],
+        },
+        23: {
+            "id": 23,
+            "name": "Beto-Fwd",
+            "position": 4,
+            "price": 1,
+            "altPositions": [],
+        },
+    }
+    monkeypatch.setattr(recs, "time", MagicMock())  # skip sleep
+
+    rivals = recs._gather_rivals(
+        biwenger, biwenger_players, jp_index={"by_name": {}, "by_slug": {}}
+    )
+
+    by_owner = {r["bw_id"]: r["owner_gk_count"] for r in rivals}
+    assert by_owner == {11: 1, 12: 1, 21: 2, 22: 2, 23: 2}
 
 
 def test_top_per_position_groups_by_primary_and_marks_multi():

--- a/packages/biwenger_tools/api/tests/test_auto_bid.py
+++ b/packages/biwenger_tools/api/tests/test_auto_bid.py
@@ -62,8 +62,8 @@ def test_tier_plus_500k_band():
 
 
 def test_tier_below_floor_returns_none():
-    """SF ≤ 300 → skip (T4 floor; T3 boundary stayed at 400)."""
-    bid, reason = auto_bid.tier_bid(sf=300, price=1_000_000, remaining_cash=50_000_000)
+    """SF < 300 → skip (T4 floor, inclusive)."""
+    bid, reason = auto_bid.tier_bid(sf=299, price=1_000_000, remaining_cash=50_000_000)
     assert bid is None
     assert "300" in reason
 
@@ -71,18 +71,23 @@ def test_tier_below_floor_returns_none():
 @pytest.mark.parametrize(
     "sf,expected_band",
     [
-        (801, "T1"),  # boundary just above all-in
-        (800, "T2"),  # boundary: 800 is NOT all-in
+        (801, "T1"),
+        (800, "T1"),  # 800 inclusive — lands in T1, not T2
+        (799, "T2"),
         (601, "T2"),
-        (600, "T3"),  # 600 falls to T3 band
+        (600, "T2"),  # 600 inclusive — T2, not T3
+        (599, "T3"),
         (401, "T3"),
-        (400, "T4"),  # NEW: 400 now lands in T4 (was skipped pre-T4)
+        (400, "T3"),  # 400 inclusive — T3, not T4 (user-requested boundary)
+        (399, "T4"),
         (301, "T4"),
-        (300, None),  # boundary: 300 skipped (T4 floor strict `>`)
+        (300, "T4"),  # 300 inclusive — T4, not skip
+        (299, None),  # below T4 floor → skip
     ],
 )
 def test_tier_boundaries(sf, expected_band):
-    """Pin the exact boundary semantics (strict `>` between bands)."""
+    """Pin the boundary semantics: thresholds are inclusive on the lower
+    end (`>=`). A player at exactly TIER_X_MIN lands in that tier."""
     bid, label = auto_bid.tier_bid(sf=sf, price=1_000_000, remaining_cash=50_000_000)
     if expected_band is None:
         assert bid is None


### PR DESCRIPTION
## Summary

### 1. Tier boundaries inclusive (`>` → `>=`)
Un jugador justo en el threshold cae en la tier más agresiva, no en la siguiente. SF=400 → **T3** (era T4); SF=600 → T2; SF=800 → T1; SF=300 → T4 (era skip). Más simple de razonar.

| Tier | Antes | Ahora |
|---|---|---|
| T1 | SF > 800 | **SF ≥ 800** |
| T2 | 600 < SF ≤ 800 | **600 ≤ SF < 800** |
| T3 | 400 < SF ≤ 600 | **400 ≤ SF < 600** |
| T4 | 300 < SF ≤ 400 | **300 ≤ SF < 400** |
| skip | SF ≤ 300 | SF < 300 |

Calvo (SF=400) esta mañana hubiera caído en T3 con esta regla y bidearía `price + 2M + jitter` en vez del `price + 500K + jitter` que le hubiera tocado en T4.

### 2. `/recomendar`: regla del portero único
Biwenger permite clausulazo del único portero del rival, pero la liga acordó que dejarlo sin portero es ir a degüello. Ahora `_gather_rivals` cuenta GKs por manager y `_filter_affordable` excluye candidatos GK cuyo dueño tiene ≤1 portero.

La regla es **solo GK** — outfields siguen siendo libres. El rival con un solo delantero sigue siendo objetivo legítimo.

Caso de hoy: Dituro era el único portero del rival → con este PR ya no aparece en /recomendar.

## Test plan
- [x] `bazel test //...` — las 6 suites verdes.
- [x] `test_tier_boundaries` extendido con los nuevos casos inclusivos (800, 600, 400, 300).
- [x] `test_filter_affordable_excludes_rival_only_gk_house_rule` pinea la regla GK y verifica que NO afecta a outfield.
- [x] `test_gather_rivals_annotates_owner_gk_count` verifica la propagación del count a cada row.
- [x] `flake8` + `black --check` clean.