### PR TITLE
chore: move Pending work out of CLAUDE.md into root PENDING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,20 +116,9 @@ still relevant, keep it. If the code exists and works, the plan is redundant —
 
 ## Pending work
 
-Long-running follow-ups that don't yet warrant a plan or PR. Keep this list short;
-remove items when they ship or stop being relevant. For "what has shipped", read
-`packages/biwenger_tools/release-notes.md` — single source of truth.
-
-- **Drive folder cleanup** (USER-OWNED, week of 2026-05-26) — when the league ends:
-  delete the Drive folder contents (the old CSVs the scraper used to upload), then
-  drop the `biwenger-tools-sa-regional` secret or repoint it to a Sheets-only SA
-  (Sheets API still authenticates through that mount for `ligas_especiales` /
-  `trofeos`).
-- **Move Drive/Sheets IDs out of BUILD.bazel** — Sheets IDs (`LIGAS_ESPECIALES_*`,
-  `TROFEOS_*`) are still hardcoded in `packages/biwenger_tools/web/BUILD.bazel`.
-  Env-var them when convenient. Low priority.
-- **Photo-recognition project** — tracked in `packages/my_photos/README.md`, not
-  here.
+Long-running follow-ups live in `PENDING.md` at the repo root. That file is
+never deleted; lines get pruned as items ship. For "what has shipped", read
+`packages/biwenger_tools/release-notes.md`.
 
 ## Memory
 

--- a/PENDING.md
+++ b/PENDING.md
@@ -1,0 +1,20 @@
+# Pending work
+
+Long-running follow-ups that don't yet warrant a plan or PR.
+
+**Rules of the file:**
+- Never deleted; lives at the repo root.
+- Lines are pruned as items ship or stop being relevant — keep it short.
+- "What has shipped" lives in `packages/biwenger_tools/release-notes.md` — do not duplicate here.
+
+---
+
+- **Drive folder cleanup** (USER-OWNED, week of 2026-05-26) — when the league ends:
+  delete the Drive folder contents (the old CSVs the scraper used to upload), then
+  drop the `biwenger-tools-sa-regional` secret or repoint it to a Sheets-only SA
+  (Sheets API still authenticates through that mount for `ligas_especiales` /
+  `trofeos`).
+- **Move Drive/Sheets IDs out of BUILD.bazel** — Sheets IDs (`LIGAS_ESPECIALES_*`,
+  `TROFEOS_*`) are still hardcoded in `packages/biwenger_tools/web/BUILD.bazel`.
+  Env-var them when convenient. Low priority.
+- **Photo-recognition project** — tracked in `packages/my_photos/README.md`, not here.


### PR DESCRIPTION
## Summary
CLAUDE.md is meant to read top-to-bottom as the canonical project charter (invariants, conventions, rules). A growing list of shifting follow-ups doesn't belong there.

New convention:
- **`PENDING.md`** at the repo root — never deleted, lines pruned in place as items ship.
- CLAUDE.md keeps a one-paragraph pointer so the file stays discoverable from the canon.

No behaviour change. Same three items live in the new file:
- Drive folder cleanup (USER-OWNED, week of 2026-05-26)
- Move Drive/Sheets IDs out of BUILD.bazel (low priority)
- Photo-recognition project pointer

## Test plan
- [x] `grep -n "Pending\|PENDING.md" CLAUDE.md` — only the pointer paragraph remains.
- [x] PENDING.md self-documents its own update rules at the top.
- [ ] Docs-only change, no deploy impact.