### PR TITLE
chore(web): env-var Sheets IDs out of BUILD.bazel + translate WORKSPACE to English

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -18,12 +18,6 @@ Long-running follow-ups that don't yet warrant a plan or PR.
   (Sheets API still authenticates through that mount for `ligas_especiales` /
   `trofeos`).
 
-## biwenger_tools/web
-
-- **Move Drive/Sheets IDs out of BUILD.bazel** — Sheets IDs (`LIGAS_ESPECIALES_*`,
-  `TROFEOS_*`) are still hardcoded in `packages/biwenger_tools/web/BUILD.bazel`.
-  Env-var them when convenient. Low priority.
-
 ## my_photos
 
 - **Photo-recognition project** — tracked in `packages/my_photos/README.md`, not here.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,2 +1,2 @@
-# Este fichero se deja intencionadamente vacío.
-# Bzlmod se encarga de gestionar las dependencias externas.
+# This file is intentionally left empty.
+# External dependencies are managed by Bzlmod (MODULE.bazel).

--- a/packages/biwenger_tools/web/BUILD.bazel
+++ b/packages/biwenger_tools/web/BUILD.bazel
@@ -13,8 +13,14 @@ python_service(
         "GCP_PROJECT_ID": "biwenger-tools",
         "CLOUD_RUN_JOB_NAME": "biwenger-scraper-data",
         "CLOUD_RUN_REGION": "europe-southwest1",
-        "LIGAS_ESPECIALES_SHEET_ID_25_26": "1ZaFZtKLFc0K4Ku099x3iV20OBkLZz9BEvojZpyOP0es",
-        "TROFEOS_SHEET_ID_25_26": "1-ahWDHUby8KRXUZPdJqI302gnNEQTBcr1MQgqJOlk5Y",
+        # Sheets IDs (LIGAS_ESPECIALES_*, TROFEOS_*) are injected at
+        # runtime — never hardcoded here:
+        #   - Production: `deploy.yml` passes them via `--set-env-vars`
+        #     from GH Actions secrets.
+        #   - Local: `.env` in this module (load_dotenv reads it).
+        # Keeping them out of BUILD.bazel avoids leaking the values
+        # into the source tree and the Docker image layers.
+        #
         # GOOGLE_APPLICATION_CREDENTIALS intentionally NOT set:
         # the Sheets client gets its SA file path explicitly via
         # `SERVICE_ACCOUNT_PATH` (mounted at /gdrive_sa from Secret


### PR DESCRIPTION
## Summary

### 1. Web — Sheets IDs out of BUILD.bazel
`LIGAS_ESPECIALES_SHEET_ID_25_26` and `TROFEOS_SHEET_ID_25_26` estaban hardcoded en `packages/biwenger_tools/web/BUILD.bazel::extra_env`, lo cual los baked en la imagen local y en las layers de Docker que suben a Artifact Registry. Los valores ya están duplicados en:

- **Local**: `packages/biwenger_tools/web/.env` (load_dotenv los recoge).
- **Producción**: `deploy.yml` los inyecta vía `--set-env-vars` desde GH Actions secrets.

Quitarlos del BUILD.bazel unifica la inyección como una sola decisión runtime (file local vs cloud prod), saca los valores del source tree y deja de filtrarlos en los layers de Docker. Comentario nuevo en el BUILD.bazel apunta a los dos sitios de inyección para que nadie los re-añada.

**Cierra el item de PENDING.md bajo `biwenger_tools/web`**.

### 2. WORKSPACE — traducir comentario al inglés
Archivo de 2 líneas que estaba en castellano. Traducido al inglés para alinearse con el resto del repo.

```diff
-# Este fichero se deja intencionadamente vacío.
-# Bzlmod se encarga de gestionar las dependencias externas.
+# This file is intentionally left empty.
+# External dependencies are managed by Bzlmod (MODULE.bazel).
```

## Test plan
- [x] `bazel build //packages/biwenger_tools/web:all` — green.
- [x] `bazel test //...` — 6 suites green.
- [x] `.env` y `deploy.yml` ya tienen los IDs; ninguna regresión esperada.
- [ ] Smoke post-deploy: cargar `/ligas-especiales` y `/trofeos` y verificar que renderizan datos (no "Sheet not found").