### PR TITLE
fix(pujar): unblock silent fail when Telegram rejects the summary

### DIFF
--- a/core/sdk/telegram.py
+++ b/core/sdk/telegram.py
@@ -24,13 +24,19 @@ def send_telegram_message(
     parse_mode: str = "HTML",
     disable_web_page_preview: bool = True,
     reply_markup: Optional[dict] = None,
-) -> None:
+) -> bool:
     """Sends a text message to a Telegram chat via the Bot API.
 
-    Truncates messages over TELEGRAM_MAX_MESSAGE_LENGTH chars. For long content
-    that needs splitting, do the splitting at the call site so each chunk
-    forms a coherent unit. `reply_markup` accepts a Telegram InlineKeyboard
-    dict (or any of the markup shapes the Bot API documents).
+    Returns ``True`` if the message was delivered, ``False`` on any
+    network or 4xx/5xx failure (also logged). Callers that need to
+    react to a failed delivery (the auto-bid endpoint surfaces it as
+    a 500 so the bot can notify the user) check the return value;
+    fire-and-forget callers can keep ignoring it.
+
+    Truncates messages over TELEGRAM_MAX_MESSAGE_LENGTH chars. For long
+    content that needs splitting, do the splitting at the call site so
+    each chunk forms a coherent unit. `reply_markup` accepts a Telegram
+    InlineKeyboard dict (or any of the markup shapes the Bot API documents).
     """
     if len(text) > TELEGRAM_MAX_MESSAGE_LENGTH:
         logger.warning(
@@ -52,8 +58,10 @@ def send_telegram_message(
         response = requests.post(url, json=payload, timeout=15)
         response.raise_for_status()
         logger.info("Telegram message sent.", extra={"chars": len(text)})
+        return True
     except requests.RequestException as e:
         logger.error("Failed to send Telegram message.", extra={"error": str(e)})
+        return False
 
 
 def answer_callback_query(

--- a/core/tests/test_telegram_notifier.py
+++ b/core/tests/test_telegram_notifier.py
@@ -22,8 +22,9 @@ def test_send_telegram_message_success(caplog):
             status_code=200,
         )
 
-        send_telegram_message(TEST_BOT_TOKEN, TEST_CHAT_ID, "hello <b>world</b>")
+        ok = send_telegram_message(TEST_BOT_TOKEN, TEST_CHAT_ID, "hello <b>world</b>")
 
+        assert ok is True
         assert m.called_once
         body = m.last_request.json()
         assert body["chat_id"] == TEST_CHAT_ID
@@ -47,10 +48,14 @@ def test_send_telegram_message_truncates_long_text():
         assert sent.endswith("...")
 
 
-def test_send_telegram_message_logs_error_on_api_failure(caplog):
+def test_send_telegram_message_returns_false_and_logs_on_api_failure(caplog):
+    """4xx/5xx must surface as `return False` (not just a log line) so
+    callers can decide whether to swallow or re-raise. Auto-bid uses
+    this to bubble HTML-parse 400s up to the bot as an actionable 500."""
     with requests_mock.Mocker() as m:
         m.post(TELEGRAM_SEND_MESSAGE_URL.format(token=TEST_BOT_TOKEN), status_code=500)
-        send_telegram_message(TEST_BOT_TOKEN, TEST_CHAT_ID, "hi")
+        ok = send_telegram_message(TEST_BOT_TOKEN, TEST_CHAT_ID, "hi")
+        assert ok is False
         assert any(
             "Failed to send Telegram message" in r.message for r in caplog.records
         )

--- a/packages/biwenger_tools/api/logic/auto_bid.py
+++ b/packages/biwenger_tools/api/logic/auto_bid.py
@@ -28,6 +28,7 @@ in that log before bidding, so a retry of a half-completed run does
 not double-bid the players that already went through.
 """
 
+import html
 import random
 from datetime import datetime, timedelta
 from typing import Optional
@@ -211,43 +212,67 @@ def _format_telegram_text(
     total_bid: int,
     remaining_cash: int,
 ) -> str:
-    """Render the per-run summary message the Telegram chat receives."""
+    """Render the per-run summary message the Telegram chat receives.
+
+    Every dynamic value flowing in (player names, tier labels, skip
+    reasons) is HTML-escaped because Telegram's HTML parser is strict:
+    a stray `<`/`>`/`&` in the body triggers a 400 Bad Request and the
+    whole message is dropped. The skip reason `"bid 1.000.000 € > cash
+    500.000 €"` exposed this on 2026-05-24 — `>` was read as the start
+    of a tag and the run failed silently.
+    """
+    esc = lambda s: html.escape(str(s), quote=False)  # noqa: E731
+
     header_date = datetime.now(MADRID_TZ).strftime("%d/%m %H:%M")
     lines = [f"💸 <b>Pujas automáticas en el mercado — {header_date}</b>", ""]
 
     for entry in placed:
         lines.append(
-            f"✅ Pujado <b>{_euros(entry['bid'])}</b> por "
-            f"<b>{entry['name']}</b> ({entry['tier_label']})"
+            f"✅ Pujado <b>{esc(_euros(entry['bid']))}</b> por "
+            f"<b>{esc(entry['name'])}</b> ({esc(entry['tier_label'])})"
         )
 
     if skipped:
         for entry in skipped:
-            lines.append(f"⏭️ Saltado <b>{entry['name']}</b> ({entry['reason']})")
+            lines.append(
+                f"⏭️ Saltado <b>{esc(entry['name'])}</b> ({esc(entry['reason'])})"
+            )
 
     if not placed and not skipped:
         lines.append("Sin candidatos en el mercado diario.")
 
     lines.append("")
     lines.append(
-        f"Total pujado: <b>{_euros(total_bid)}</b> · "
-        f"Cash restante: <b>{_euros(remaining_cash)}</b>"
+        f"Total pujado: <b>{esc(_euros(total_bid))}</b> · "
+        f"Cash restante: <b>{esc(_euros(remaining_cash))}</b>"
     )
     if not placed:
-        lines.append(f"<i>Log: auto_bid_log/{day}</i>")
+        lines.append(f"<i>Log: auto_bid_log/{esc(day)}</i>")
     return "\n".join(lines)
 
 
 def _maybe_notify(text: str) -> int:
-    """Send the summary to Telegram if creds are configured. Returns sent count."""
+    """Send the summary to Telegram if creds are configured. Returns sent count.
+
+    Raises ``RuntimeError`` if Telegram refuses the message (4xx parse
+    error, 5xx, timeout). The route handler converts that into a 500
+    so the bot can tell the user something went wrong instead of
+    leaving the chat with a "⏳ procesando…" message that never
+    resolves (regression spotted 2026-05-24, fixed in this commit).
+    """
     if not (config.TELEGRAM_BOT_TOKEN and config.TELEGRAM_CHAT_ID):
         logger.warning("Telegram credentials missing — skipping send.")
         return 0
-    send_telegram_message(
+    sent = send_telegram_message(
         bot_token=config.TELEGRAM_BOT_TOKEN,
         chat_id=config.TELEGRAM_CHAT_ID,
         text=text,
     )
+    if not sent:
+        raise RuntimeError(
+            "Telegram summary delivery failed — bids already placed "
+            "(see Firestore `auto_bid_log` + Cloud Logging)."
+        )
     return 1
 
 

--- a/packages/biwenger_tools/api/tests/test_auto_bid.py
+++ b/packages/biwenger_tools/api/tests/test_auto_bid.py
@@ -204,6 +204,46 @@ def test_format_telegram_text_renders_placed_skipped_and_totals():
     assert "Cash restante: <b>3.000.000 €</b>" in text
 
 
+def test_format_telegram_text_html_escapes_user_content():
+    """Regression for the 2026-05-24 silent fail: a skip reason like
+    `"bid 1.000.000 € > cash 500.000 €"` contains a literal `>` which
+    Telegram's HTML parser reads as a tag start → 400 Bad Request →
+    the whole message is dropped. Every dynamic value must be escaped."""
+    placed = [
+        {
+            # Name with `<` and `&` — the kind of edge case real-world
+            # data can include.
+            "name": "<Player & Co>",
+            "bid": 1_000_000,
+            "tier_label": "T3 precio+2M (SF 500)",
+        }
+    ]
+    skipped = [
+        {
+            "name": "Bellingham",
+            # The actual reason format from run_auto_bid — has literal `>`.
+            "reason": "bid 14.000.000 € > cash 3.000.000 €",
+        }
+    ]
+    text = auto_bid._format_telegram_text(
+        day="2026-05-24",
+        placed=placed,
+        skipped=skipped,
+        total_bid=1_000_000,
+        remaining_cash=3_000_000,
+    )
+    # Raw user-controlled `<`, `>`, `&` must NOT appear anywhere outside
+    # of our intentional `<b>...</b>` wrappers.
+    assert "&lt;Player &amp; Co&gt;" in text
+    assert "bid 14.000.000 € &gt; cash 3.000.000 €" in text
+    # The two literal `<` characters in our template must be exactly the
+    # ones we emitted (4 <b> open + 4 </b> close + 1 <b> in skipped + 1
+    # </b> in skipped + 2 in totals + 0 footer = 12 angle-bracket pairs).
+    assert text.count("<b>") == text.count("</b>")  # balanced template tags
+    # No unescaped `>` in the skipped-line reason payload.
+    assert "> cash" not in text
+
+
 def test_format_telegram_text_handles_no_candidates():
     text = auto_bid._format_telegram_text(
         day="2026-05-23",
@@ -397,6 +437,32 @@ def test_run_auto_bid_skips_send_when_telegram_creds_missing(run_env):
     mock_send.assert_not_called()
     assert result["sent"] == 0
     assert result["bid_count"] == 1
+
+
+def test_run_auto_bid_raises_when_telegram_send_returns_false(run_env):
+    """Regression for the 2026-05-24 silent fail: when Telegram refuses
+    the summary (4xx parse error → `send_telegram_message` returns False),
+    `run_auto_bid` must raise so the route returns 500 and the bot can
+    surface the failure to the user. Otherwise the "⏳ procesando…"
+    message hangs forever and the user is blind to the problem."""
+    market = [_sale(1)]
+    biwenger_players = {1: _bw(1, "Vinicius", 5_000_000)}
+    jp_players = [_jp_with_sf("Vinicius", 910)]
+    _, mock_send = run_env(
+        market_players=market,
+        biwenger_players=biwenger_players,
+        jp_players=jp_players,
+        cash=30_000_000,
+    )
+    # Pin the send to "failed" (False). Bids will have been placed by
+    # the time we hit the notify step — we keep the Firestore log as
+    # the audit trail.
+    mock_send.return_value = False
+
+    with pytest.raises(RuntimeError, match="Telegram summary delivery failed"):
+        auto_bid.run_auto_bid()
+
+    mock_send.assert_called_once()
 
 
 # --- _log_bid + _already_bid_ids smoke -----------------------------------

--- a/packages/biwenger_tools/bot/app.py
+++ b/packages/biwenger_tools/bot/app.py
@@ -14,6 +14,7 @@ acknowledges the tap, edits the picker into a "processing…" message and
 lets the api post the results.
 """
 
+import html
 import os
 
 from flask import Flask, request
@@ -136,10 +137,17 @@ def _dispatch_action(action_key: str, label: str) -> None:
             "Webhook: api call failed",
             extra={"action": action_key, "error": str(exc)},
         )
+        # Defensive HTML escape on `exc` — request body fragments and
+        # gcloud-style messages can contain `<`/`>`/`&` which would
+        # otherwise trigger a second Telegram 400 and leave the user
+        # with no feedback at all.
         send_telegram_message(
             bot_token=config.TELEGRAM_BOT_TOKEN,
             chat_id=config.TELEGRAM_CHAT_ID,
-            text=f"❌ Error al ejecutar <b>{label}</b>: <code>{exc}</code>",
+            text=(
+                f"❌ Error al ejecutar <b>{html.escape(label)}</b>: "
+                f"<code>{html.escape(str(exc))}</code>"
+            ),
         )
 
 

--- a/packages/biwenger_tools/bot/tests/test_bot.py
+++ b/packages/biwenger_tools/bot/tests/test_bot.py
@@ -135,6 +135,24 @@ def test_api_call_failure_sends_error_message(client):
     assert "permission denied" in error_text
 
 
+def test_api_call_failure_html_escapes_exception_message(client):
+    """The error message embeds `exc` inside `<code>...</code>`. If `exc`
+    itself contains `<` / `>` / `&` (e.g. an HTTP error body with markup),
+    the second Telegram send would also 400 and the user would see
+    nothing. Defensive escape keeps the failure path actionable."""
+    with patch(
+        "packages.biwenger_tools.bot.app.api_client.call_api",
+        side_effect=RuntimeError("500: <error>boom & boom</error>"),
+    ), patch("packages.biwenger_tools.bot.app.send_telegram_message") as mock_send:
+        resp = _post(client, _update(_VALID_CHAT, "/pujar"))
+    assert resp.status_code == 200
+    error_text = mock_send.call_args_list[1].kwargs.get("text", "")
+    # The exception text is escaped before landing in the body.
+    assert "&lt;error&gt;boom &amp; boom&lt;/error&gt;" in error_text
+    # The literal raw `<error>` substring must NOT leak through.
+    assert "<error>" not in error_text
+
+
 # --- /analizar opens the manager picker ---
 
 


### PR DESCRIPTION
## El bug
Esta mañana `/pujar` colocó 2 pujas en Biwenger correctamente pero Telegram devolvió **400 Bad Request** en el mensaje resumen. La causa exacta: el formato de skip reason `"bid X € > cash Y €"` contiene un `>` literal y Telegram lo lee como apertura de tag HTML → parse error → 400.

`send_telegram_message` se tragaba el HTTPError internamente, el api devolvía 200 al bot, y el bot se quedaba feliz. **El usuario vio "⏳ procesando…" y luego nada.**

Confirmado en Cloud Logging del run de las 10:35:46:
```
Placing market bid → Market bid accepted (x2)
Failed to send Telegram message (error=400 Bad Request)
Auto-bid run finished
biwenger-api call ok (200) ← bot no se enteró
```

## El fix — tres capas
1. **Root cause**: `auto_bid._format_telegram_text` ahora HTML-escapa CADA valor dinámico (nombres jugador, tier labels, skip reasons, euros). No más 400s por nuestro propio payload.
2. **Defensa**: `core.sdk.telegram.send_telegram_message` ahora devuelve `bool`. `_maybe_notify` lo lee y lanza `RuntimeError` si el envío falla. El route handler lo convierte en 500, el bot lo captura en su try/except existente, y al usuario le llega `❌ Error al ejecutar /pujar: ...`.
3. **Defensa adicional**: el bot escapa `exc` antes de meterlo en `<code>...</code>` para que un cuerpo HTTP con `<>&` no provoque un segundo 400 que también deje al usuario a ciegas.

El nuevo `bool` de `send_telegram_message` es backward-compat: el resto de callers (recommendations, actions, scraper, etc.) lo ignoran. Solo auto-bid opta por "raise on failure".

## Test plan
- [x] `bazel test //...` — 6 suites verdes.
- [x] `test_format_telegram_text_html_escapes_user_content` reproduce el patrón exacto del incidente.
- [x] `test_send_telegram_message_returns_false_and_logs_on_api_failure` pinea el nuevo contrato bool.
- [x] `test_run_auto_bid_raises_when_telegram_send_returns_false` pinea la propagación a 500.
- [x] `test_api_call_failure_html_escapes_exception_message` cubre el escape defensivo del bot.
- [ ] Validación real: próximo `/pujar` (manual o cron) debería resolverse — y si volviera a petar, esta vez sí llegaría mensaje de error.