### PR TITLE
feat(auto-bid): bid = min(price × multiplier, price + cap) per tier

### DIFF
--- a/packages/biwenger_tools/api/logic/auto_bid.py
+++ b/packages/biwenger_tools/api/logic/auto_bid.py
@@ -8,14 +8,22 @@ stopping when cash runs out.
 
 Tiers (over Biwenger's cf-base `price`, NOT `owner.price`). Boundaries
 are INCLUSIVE on the lower end (a player at exactly 400 lands in T3,
-not T4). Every non-skipped bid carries a random 0–`BID_JITTER_MAX` €
-offset so the amounts don't look botty:
+not T4). Each non-T1 tier uses `min(price × multiplier, price + cap)`:
+the multiplier dominates on cheap players (so a 750K T3 doesn't get a
+ridiculous +2M surcharge), the absolute cap dominates on expensive
+ones (a 10M T3 stops climbing at +2M instead of going to +50%). Every
+non-skipped bid then adds a 0–`BID_JITTER_MAX` € random offset so the
+amounts don't look botty:
 
-    SF ≥ 800             → bid = remaining_cash - jitter   (all-in)
-    600 ≤ SF < 800       → bid = price + 5_000_000 + jitter (aggressive)
-    400 ≤ SF < 600       → bid = price + 2_000_000 + jitter
-    300 ≤ SF < 400       → bid = price +   500_000 + jitter (low conviction)
+    SF ≥ 800             → bid = remaining_cash - jitter           (all-in)
+    600 ≤ SF < 800  (T2) → bid = min(price × 1.7, price + 5M) + jitter
+    400 ≤ SF < 600  (T3) → bid = min(price × 1.5, price + 2M) + jitter
+    300 ≤ SF < 400  (T4) → bid = min(price × 1.2, price + 500K) + jitter
     SF < 300             → skip
+
+Crossover prices (where multiplier == cap): T2 ≈ 7.14M, T3 = 4M,
+T4 = 2.5M. Below the crossover the multiplier wins (smaller bid);
+above it the cap wins.
 
 Hard rule across every tier: skip the player when the would-be bid
 exceeds `remaining_cash` — we never go negative. The all-in tier bids
@@ -54,15 +62,20 @@ from packages.biwenger_tools.api.player_formatting import SCORE_SF
 
 logger = get_logger(__name__)
 
-# Tier thresholds and surcharges. Kept as a module-level table so the
-# unit tests can pin every band without reaching into private helpers.
+# Tier thresholds + (multiplier, absolute cap) pairs. Kept as module-level
+# constants so the unit tests can pin every band without reaching into
+# private helpers. Each non-T1 tier bids `min(price × MULT, price + CAP)`
+# — see module docstring for the rationale + crossover prices.
 TIER_ALL_IN_MIN = 800
-TIER_PLUS_5M_MIN = 600
-TIER_PLUS_2M_MIN = 400
-TIER_PLUS_500K_MIN = 300
-TIER_PLUS_5M_SURCHARGE = 5_000_000
-TIER_PLUS_2M_SURCHARGE = 2_000_000
-TIER_PLUS_500K_SURCHARGE = 500_000
+TIER_T2_MIN = 600
+TIER_T3_MIN = 400
+TIER_T4_MIN = 300
+TIER_T2_MULTIPLIER = 1.7
+TIER_T3_MULTIPLIER = 1.5
+TIER_T4_MULTIPLIER = 1.2
+TIER_T2_CAP_SURCHARGE = 5_000_000
+TIER_T3_CAP_SURCHARGE = 2_000_000
+TIER_T4_CAP_SURCHARGE = 500_000
 
 # Per-bid anti-pattern jitter. A bot that always bids in round euros
 # (10.000.000, 10.500.000, …) is a tell — humans dragging the slider
@@ -109,6 +122,17 @@ def _jitter() -> int:
     return random.randint(0, BID_JITTER_MAX)
 
 
+def _capped_multiplier_bid(price: int, multiplier: float, cap_surcharge: int) -> int:
+    """`min(price × multiplier, price + cap_surcharge)`, cast to int.
+
+    The multiplier bounds the bid on cheap players (a 750K T3 player
+    bids 1.125M, not 2.75M); the absolute cap bounds expensive players
+    (a 10M T3 bids 12M, not 15M). Result is the smaller of the two."""
+    by_multiplier = int(price * multiplier)
+    by_cap = price + cap_surcharge
+    return min(by_multiplier, by_cap)
+
+
 def tier_bid(sf: int, price: int, remaining_cash: int) -> tuple[Optional[int], str]:
     """Return `(target_bid, label)` for a player, or `(None, reason)` to skip.
 
@@ -116,9 +140,11 @@ def tier_bid(sf: int, price: int, remaining_cash: int) -> tuple[Optional[int], s
     the affordability check (so the skip reason can be richer than a
     bare None).
 
-    Every tier adds (or, for T1 all-in, subtracts) a random 0-`BID_JITTER_MAX`
-    € offset. The economic impact is < 0.01% of any tier but the bid trail
-    stops looking like a bot.
+    Each non-T1 tier bids `min(price × multiplier, price + cap)` so that
+    a cheap player doesn't get an absurd absolute surcharge while an
+    expensive player doesn't run away with the multiplier. Every tier
+    adds (or, for T1 all-in, subtracts) a random 0-`BID_JITTER_MAX` €
+    offset so the bid trail stops looking like a bot.
     """
     jitter = _jitter()
     if sf >= TIER_ALL_IN_MIN:
@@ -127,13 +153,16 @@ def tier_bid(sf: int, price: int, remaining_cash: int) -> tuple[Optional[int], s
         # on the table. Jitter SUBTRACTS here (can't bid > cash); the result
         # stays strictly inside [remaining_cash - BID_JITTER_MAX, remaining_cash].
         return max(0, remaining_cash - jitter), f"T1 all-in (SF {sf})"
-    if sf >= TIER_PLUS_5M_MIN:
-        return price + TIER_PLUS_5M_SURCHARGE + jitter, f"T2 precio+5M (SF {sf})"
-    if sf >= TIER_PLUS_2M_MIN:
-        return price + TIER_PLUS_2M_SURCHARGE + jitter, f"T3 precio+2M (SF {sf})"
-    if sf >= TIER_PLUS_500K_MIN:
-        return price + TIER_PLUS_500K_SURCHARGE + jitter, f"T4 precio+500K (SF {sf})"
-    return None, f"SF {sf} < {TIER_PLUS_500K_MIN}"
+    if sf >= TIER_T2_MIN:
+        bid = _capped_multiplier_bid(price, TIER_T2_MULTIPLIER, TIER_T2_CAP_SURCHARGE)
+        return bid + jitter, f"T2 (SF {sf})"
+    if sf >= TIER_T3_MIN:
+        bid = _capped_multiplier_bid(price, TIER_T3_MULTIPLIER, TIER_T3_CAP_SURCHARGE)
+        return bid + jitter, f"T3 (SF {sf})"
+    if sf >= TIER_T4_MIN:
+        bid = _capped_multiplier_bid(price, TIER_T4_MULTIPLIER, TIER_T4_CAP_SURCHARGE)
+        return bid + jitter, f"T4 (SF {sf})"
+    return None, f"SF {sf} < {TIER_T4_MIN}"
 
 
 def _build_candidates(

--- a/packages/biwenger_tools/api/tests/test_auto_bid.py
+++ b/packages/biwenger_tools/api/tests/test_auto_bid.py
@@ -37,28 +37,60 @@ def test_tier_all_in_when_cash_is_zero_returns_zero_so_caller_skips():
     assert bid == 0
 
 
-def test_tier_plus_5m_band():
+def test_tier_t2_cap_wins_on_expensive_player():
+    """T2: at 8M price the cap (+5M = 13M) is cheaper than the multiplier
+    (8M × 1.7 = 13.6M), so the cap wins."""
     bid, label = auto_bid.tier_bid(sf=720, price=8_000_000, remaining_cash=50_000_000)
-    # 8M + 5M + jitter ∈ [13_000_000, 13_001_000]
+    # min(8M × 1.7, 8M + 5M) = min(13.6M, 13M) = 13M
     assert 13_000_000 <= bid <= 13_000_000 + auto_bid.BID_JITTER_MAX
     assert "T2" in label
 
 
-def test_tier_plus_2m_band():
-    bid, label = auto_bid.tier_bid(sf=500, price=3_000_000, remaining_cash=50_000_000)
-    # 3M + 2M + jitter ∈ [5_000_000, 5_001_000]
-    assert 5_000_000 <= bid <= 5_000_000 + auto_bid.BID_JITTER_MAX
+def test_tier_t2_multiplier_wins_on_cheap_player():
+    """T2: at 5M price the multiplier (5M × 1.7 = 8.5M) is cheaper than
+    the cap (5M + 5M = 10M), so the multiplier wins."""
+    bid, label = auto_bid.tier_bid(sf=720, price=5_000_000, remaining_cash=50_000_000)
+    # min(5M × 1.7, 5M + 5M) = min(8.5M, 10M) = 8.5M
+    assert 8_500_000 <= bid <= 8_500_000 + auto_bid.BID_JITTER_MAX
+    assert "T2" in label
+
+
+def test_tier_t3_multiplier_wins_on_cheap_player_regression_calvo():
+    """T3 regression for Calvo (2026-05-24): at 750K price the multiplier
+    (750K × 1.5 = 1.125M) is way cheaper than the cap (750K + 2M = 2.75M).
+    The +2M-on-a-750K-player surcharge was unreasonable; now we bid 1.125M
+    instead, which respects the player's actual market value."""
+    bid, label = auto_bid.tier_bid(sf=400, price=750_000, remaining_cash=50_000_000)
+    # min(750K × 1.5, 750K + 2M) = min(1.125M, 2.75M) = 1.125M
+    assert 1_125_000 <= bid <= 1_125_000 + auto_bid.BID_JITTER_MAX
     assert "T3" in label
 
 
-def test_tier_plus_500k_band():
-    """T4: 300 < SF ≤ 400 → price + 500K + jitter. Covers the visual-green-
-    but-low-conviction band (PNG paints green at SF ≥ 300, this tier bids
-    a token amount on those instead of skipping them outright)."""
+def test_tier_t3_cap_wins_on_expensive_player():
+    """T3: at 10M price the cap (+2M = 12M) is cheaper than the multiplier
+    (10M × 1.5 = 15M). Expensive players keep their conservative cap."""
+    bid, label = auto_bid.tier_bid(sf=500, price=10_000_000, remaining_cash=50_000_000)
+    # min(10M × 1.5, 10M + 2M) = min(15M, 12M) = 12M
+    assert 12_000_000 <= bid <= 12_000_000 + auto_bid.BID_JITTER_MAX
+    assert "T3" in label
+
+
+def test_tier_t4_multiplier_wins_on_cheap_player():
+    """T4 on a 1M price: multiplier (1M × 1.2 = 1.2M) beats cap (1M + 500K
+    = 1.5M). Cheap-low-conviction players get a proportional bid."""
     bid, label = auto_bid.tier_bid(sf=350, price=1_000_000, remaining_cash=50_000_000)
-    # 1M + 500K + jitter ∈ [1_500_000, 1_501_000]
-    assert 1_500_000 <= bid <= 1_500_000 + auto_bid.BID_JITTER_MAX
-    assert "T4" in label and "500K" in label
+    # min(1M × 1.2, 1M + 500K) = min(1.2M, 1.5M) = 1.2M
+    assert 1_200_000 <= bid <= 1_200_000 + auto_bid.BID_JITTER_MAX
+    assert "T4" in label
+
+
+def test_tier_t4_cap_wins_on_expensive_player():
+    """T4 on a 5M price: cap (+500K = 5.5M) beats multiplier (5M × 1.2
+    = 6M). The +500K low-conviction cap applies."""
+    bid, label = auto_bid.tier_bid(sf=350, price=5_000_000, remaining_cash=50_000_000)
+    # min(5M × 1.2, 5M + 500K) = min(6M, 5.5M) = 5.5M
+    assert 5_500_000 <= bid <= 5_500_000 + auto_bid.BID_JITTER_MAX
+    assert "T4" in label
 
 
 def test_tier_below_floor_returns_none():
@@ -99,11 +131,14 @@ def test_tier_jitter_is_within_advertised_range():
     """Sample the jitter empirically over many runs; it must never escape
     [0, BID_JITTER_MAX]. Without this guard a future widening (e.g.
     BID_JITTER_MAX → 10_000) could nudge tier-bid values past the affordability
-    cap unnoticed."""
+    cap unnoticed.
+
+    SF=500 + price=3M → T3 = min(3M × 1.5, 3M + 2M) = min(4.5M, 5M) = 4.5M.
+    The multiplier wins at this price so the nominal is 4.5M."""
     seen = set()
     for _ in range(500):
         bid, _ = auto_bid.tier_bid(sf=500, price=3_000_000, remaining_cash=50_000_000)
-        seen.add(bid - 5_000_000)
+        seen.add(bid - 4_500_000)
     assert all(0 <= delta <= auto_bid.BID_JITTER_MAX for delta in seen)
     # At least a couple of distinct values out of 500 — proof randomness is on.
     assert len(seen) > 10
@@ -393,15 +428,18 @@ def test_run_auto_bid_skips_already_bid_today(run_env):
 
 def test_run_auto_bid_continues_when_biwenger_rejects_a_bid(run_env):
     """A 4xx on one bid must not abort the loop — the next candidate still
-    gets its chance. Mirrors set_lineup's "log + continue" stance."""
+    gets its chance. Mirrors set_lineup's "log + continue" stance.
+
+    Both candidates are SF 720 at price 1M → T2 bid =
+    min(1M × 1.7, 1M + 5M) = 1.7M (multiplier wins on cheap players)."""
     market = [_sale(1), _sale(2)]
     biwenger_players = {
         1: _bw(1, "Vinicius", 1_000_000),
         2: _bw(2, "Lewa", 1_000_000),
     }
     jp_players = [
-        _jp_with_sf("Vinicius", 720),  # T2 → bid 6M
-        _jp_with_sf("Lewa", 720),  # T2 → bid 6M
+        _jp_with_sf("Vinicius", 720),  # T2 → bid 1.7M
+        _jp_with_sf("Lewa", 720),  # T2 → bid 1.7M
     ]
     err = requests.HTTPError("409 conflict")
     biwenger, _ = run_env(
@@ -416,8 +454,9 @@ def test_run_auto_bid_continues_when_biwenger_rejects_a_bid(run_env):
     assert biwenger.place_market_bid.call_count == 2
     assert result["bid_count"] == 1  # Vinicius rejected, Lewa accepted
     assert result["skipped_count"] == 1
-    # Cash only decremented by the successful bid.
-    assert result["remaining_cash_eur"] == 30_000_000 - 6_000_000
+    # Cash only decremented by the successful 1.7M bid (jitter pinned to 0
+    # in run_env, so the math is exact here).
+    assert result["remaining_cash_eur"] == 30_000_000 - 1_700_000
 
 
 def test_run_auto_bid_skips_send_when_telegram_creds_missing(run_env):


### PR DESCRIPTION
## Summary

La tabla previa usaba surcharges absolutos (T3 = +2M, T4 = +500K, etc.). Sobre jugadores baratos era desproporcionado — caso visto hoy con **Calvo (750K → bid 2.75M, +267%)** cuando el resto del mercado anda al +25%. En jugadores caros el surcharge estaba bien.

Cada tier no-T1 ahora puja el MENOR de:
- **`price × multiplier`** (proporcional, gana en jugadores baratos)
- **`price + cap_surcharge`** (absoluto, gana en jugadores caros)

| Tier | Multiplier | Cap | Crossover |
|---|---|---|---|
| T2 | × 1.7 | +5M | ≈ 7.14M |
| T3 | × 1.5 | +2M | 4M |
| T4 | × 1.2 | +500K | 2.5M |

T1 (all-in cash) sin cambios. Jitter sigue aplicándose (-jitter en T1, +jitter en el resto).

### Impacto en el snapshot de hoy

| Jugador | Tier | Antes | Ahora | Quién gana |
|---|---|---|---|---|
| Calvo (750K) | T3 | 2.75M (+267%) | **1.125M** (+50%) | multiplier |
| Eric Bailly (1.94M) | T4 | 2.44M | **2.33M** | multiplier |
| Player 8M | T2 | 13M | 13M (cap +5M) | cap |
| Player 10M | T3 | 12M | 12M (cap +2M) | cap |

Los labels en Telegram pierden los sufijos `precio+5M` / `precio+2M` / `precio+500K` (ya no describen la fórmula real). El docstring del módulo tiene la tabla completa; la línea del mensaje muestra el importe absoluto.

## Test plan
- [x] `bazel test //...` — 6 suites verdes.
- [x] Tests por tier en ambas direcciones: "multiplier wins on cheap" + "cap wins on expensive".
- [x] Regression test pin para Calvo: `tier_bid(sf=400, price=750_000) → 1.125M`.
- [x] `flake8` + `black --check` clean.
- [ ] Validación real: próximo `/pujar` con cualquier candidato T3/T4 barato debería verse proporcional.