### PR TITLE
feat(bot): persistent reply keyboard instead of /menu inline

### DIFF
--- a/packages/biwenger_tools/bot/app.py
+++ b/packages/biwenger_tools/bot/app.py
@@ -87,12 +87,18 @@ def _build_version_text() -> str:
 
 
 def _send_menu() -> None:
-    """Send the main inline-keyboard menu to the configured chat."""
+    """Attach the persistent reply keyboard to the chat.
+
+    Once Telegram receives this it pins the keyboard below the input
+    field (`is_persistent: true`); subsequent bot messages don't need
+    to re-attach it. Re-sending on demand (via `/menu` or `/start`) is
+    how the user re-pins it if it ever got dismissed.
+    """
     send_telegram_message(
         bot_token=config.TELEGRAM_BOT_TOKEN,
         chat_id=config.TELEGRAM_CHAT_ID,
         text="<b>¿Qué hacemos?</b>",
-        reply_markup=menu.main_menu_keyboard(),
+        reply_markup=menu.main_menu_reply_keyboard(),
     )
 
 
@@ -201,9 +207,9 @@ def _run_analizar(manager_value: str, edit_into: tuple[str, int] | None) -> None
 def _handle_callback(cb: dict) -> None:
     """Dispatch on the callback_data prefix.
 
-    `menu:analizar` opens the manager picker (a second keyboard).
-    `menu:<other>` fires the matching api endpoint.
-    `analizar:<id|all>` runs `/teams` with the filter.
+    Only `analizar:<id|all>` taps come through inline keyboards now;
+    the main menu is a persistent reply keyboard that posts plain text
+    handled by the message router instead.
     """
     answer_callback_query(config.TELEGRAM_BOT_TOKEN, cb["id"])
     data = cb.get("data", "")
@@ -212,23 +218,29 @@ def _handle_callback(cb: dict) -> None:
         return
     prefix, value = data.split(":", 1)
 
-    if prefix == "menu":
-        if value == "analizar":
-            _send_manager_picker()
-            return
-        if value in _ACTION_ROUTES:
-            label = next(lbl for key, lbl in menu.MAIN_MENU_ACTIONS if key == value)
-            _dispatch_action(value, label)
-            return
-        logger.info("Webhook: unknown menu action", extra={"value": value})
-        return
-
     if prefix == "analizar":
         edit_into = (cb["chat_id"], cb["message_id"]) if cb.get("message_id") else None
         _run_analizar(value, edit_into)
         return
 
     logger.info("Webhook: unhandled callback prefix", extra={"prefix": prefix})
+
+
+def _try_dispatch_label(text: str) -> bool:
+    """Reply-keyboard taps arrive as plain text matching a button label.
+
+    Returns True if the text matched a menu label and the action fired,
+    False otherwise (so the caller can fall through to slash-command
+    handling).
+    """
+    action_key = menu.LABEL_TO_ACTION.get(text)
+    if action_key is None:
+        return False
+    if action_key == "analizar":
+        _send_manager_picker()
+    else:
+        _dispatch_action(action_key, text)
+    return True
 
 
 @app.route("/telegram/webhook", methods=["POST"])
@@ -261,6 +273,12 @@ def webhook():
             "Webhook: ignoring message from unknown chat",
             extra={"chat_id": chat_id},
         )
+        return "", 200
+
+    # Persistent-reply-keyboard taps arrive as plain text equal to one of
+    # the menu labels. Try the label router first; fall through to slash
+    # commands if nothing matched.
+    if _try_dispatch_label(text):
         return "", 200
 
     cmd = parse_command(text)

--- a/packages/biwenger_tools/bot/menu.py
+++ b/packages/biwenger_tools/bot/menu.py
@@ -1,14 +1,14 @@
-"""Inline-keyboard builders for the bot's /menu UI.
+"""Keyboard builders for the bot UI.
 
-The webhook handler in ``app.py`` calls these to produce the dicts that
-Telegram's ``reply_markup`` expects. Keep them pure and stateless — the
-network round-trips happen there, not here.
+Two flavours of keyboard are used:
 
-`callback_data` strings are namespaced with a `"prefix:value"` form so
-the handler can dispatch on the prefix:
-
-- ``menu:<action>``     → main menu tap (analizar / mercado / …).
-- ``analizar:<id|all>`` → manager picker tap.
+- **Persistent reply keyboard** (`main_menu_reply_keyboard`) — sits
+  below the input field, always visible. The user taps a button and
+  the label text is sent as a regular message; the webhook handler
+  routes it via the label → action mapping. This is the primary UX.
+- **Inline keyboards** (`managers_keyboard`) — only used for the
+  manager picker, which is a one-shot two-step flow. `callback_data`
+  is `analizar:<id|all>` so the handler can dispatch on the prefix.
 """
 
 from typing import Iterable
@@ -23,19 +23,31 @@ MAIN_MENU_ACTIONS = [
     ("scrapper", "🧹 Scraper"),
 ]
 
+# Reverse map for the webhook handler: `"📊 Analizar"` → `"analizar"`.
+LABEL_TO_ACTION = {label: key for key, label in MAIN_MENU_ACTIONS}
 
-def main_menu_keyboard() -> dict:
-    """Two-column inline keyboard with every main-menu action."""
-    buttons = [
-        {"text": label, "callback_data": f"menu:{key}"}
-        for key, label in MAIN_MENU_ACTIONS
+
+def main_menu_reply_keyboard() -> dict:
+    """Two-column persistent reply keyboard with every main-menu action.
+
+    `is_persistent: true` keeps the keyboard visible across messages
+    until the bot sends a `ReplyKeyboardRemove`. Tapping a button posts
+    the label as a normal text message — the webhook routes it via
+    `LABEL_TO_ACTION`.
+    """
+    rows = [
+        [{"text": label} for _, label in MAIN_MENU_ACTIONS[i : i + 2]]
+        for i in range(0, len(MAIN_MENU_ACTIONS), 2)
     ]
-    rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
-    return {"inline_keyboard": rows}
+    return {
+        "keyboard": rows,
+        "is_persistent": True,
+        "resize_keyboard": True,
+    }
 
 
 def managers_keyboard(managers: Iterable[dict]) -> dict:
-    """Vertical keyboard with one button per manager + a "TODOS" row.
+    """Inline keyboard with one button per manager + a "TODOS" row.
 
     Each manager dict needs `id`, `name`, `is_me`. "Mi equipo" sits at
     the top (the api already orders the list that way), then the rivals,

--- a/packages/biwenger_tools/bot/tests/test_bot.py
+++ b/packages/biwenger_tools/bot/tests/test_bot.py
@@ -79,7 +79,7 @@ def test_wrong_chat_id_is_silently_ignored(client):
 
 def test_wrong_chat_callback_is_silently_ignored(client):
     with patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call:
-        resp = _post(client, _callback_update("999999", "menu:mercado"))
+        resp = _post(client, _callback_update("999999", "analizar:1"))
     assert resp.status_code == 200
     mock_call.assert_not_called()
 
@@ -193,75 +193,82 @@ def test_analizar_text_command_handles_manager_fetch_failure(client):
     assert "No pude cargar la lista" in text
 
 
-# --- /menu sends the main keyboard ---
+# --- /menu attaches the persistent reply keyboard ---
 
 
-def test_menu_sends_inline_keyboard(client):
+def test_menu_sends_persistent_reply_keyboard(client):
+    """`/menu` (and `/start` via the alias) attach the persistent reply
+    keyboard. Buttons carry the label as their `text` — Telegram sends
+    that text back to the bot when tapped (no callback_query)."""
     with patch("packages.biwenger_tools.bot.app.send_telegram_message") as mock_send:
         resp = _post(client, _update(_VALID_CHAT, "/menu"))
     assert resp.status_code == 200
     markup = mock_send.call_args.kwargs.get("reply_markup")
     assert markup is not None
+    assert markup.get("is_persistent") is True
+    assert markup.get("resize_keyboard") is True
     # 6 actions arranged in 2 columns → 3 rows
-    assert len(markup["inline_keyboard"]) == 3
-    flattened = [b["callback_data"] for row in markup["inline_keyboard"] for b in row]
-    assert "menu:analizar" in flattened
-    assert "menu:pujar" in flattened
-    assert "menu:scrapper" in flattened
-
-
-def test_menu_pujar_callback_dispatches_auto_bid(client):
-    """Tapping the "Pujar" button on the menu fires `/market/auto-bid`."""
-    with patch(
-        "packages.biwenger_tools.bot.app.answer_callback_query"
-    ) as mock_ack, patch(
-        "packages.biwenger_tools.bot.app.api_client.call_api"
-    ) as mock_call:
-        resp = _post(client, _callback_update(_VALID_CHAT, "menu:pujar"))
-    assert resp.status_code == 200
-    mock_ack.assert_called_once()
-    mock_call.assert_called_once_with(
-        _API_URL, "/market/auto-bid", method="POST", params=None
-    )
+    assert len(markup["keyboard"]) == 3
+    flattened = [b["text"] for row in markup["keyboard"] for b in row]
+    assert "📊 Analizar" in flattened
+    assert "💸 Pujar" in flattened
+    assert "🧹 Scraper" in flattened
 
 
 def test_start_aliases_menu(client):
     with patch("packages.biwenger_tools.bot.app.send_telegram_message") as mock_send:
         resp = _post(client, _update(_VALID_CHAT, "/start"))
     assert resp.status_code == 200
-    assert mock_send.call_args.kwargs.get("reply_markup") is not None
-
-
-# --- callback_query handling ---
-
-
-def test_menu_callback_dispatches_action(client):
-    """Tapping the "Mercado" button on the menu fires `/market`."""
-    with patch(
-        "packages.biwenger_tools.bot.app.answer_callback_query"
-    ) as mock_ack, patch(
-        "packages.biwenger_tools.bot.app.api_client.call_api"
-    ) as mock_call:
-        resp = _post(client, _callback_update(_VALID_CHAT, "menu:mercado"))
-    assert resp.status_code == 200
-    mock_ack.assert_called_once()
-    mock_call.assert_called_once_with(_API_URL, "/market", method="GET", params=None)
-
-
-def test_menu_analizar_callback_opens_picker(client):
-    """Tapping "Analizar" in the menu opens the manager picker."""
-    fake_managers = [{"id": 1, "name": "Jorge", "is_me": True}]
-    with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
-        "packages.biwenger_tools.bot.app.api_client.list_managers",
-        return_value=fake_managers,
-    ), patch("packages.biwenger_tools.bot.app.send_telegram_message") as mock_send:
-        resp = _post(client, _callback_update(_VALID_CHAT, "menu:analizar"))
-    assert resp.status_code == 200
     markup = mock_send.call_args.kwargs.get("reply_markup")
     assert markup is not None
-    flattened = [b["callback_data"] for row in markup["inline_keyboard"] for b in row]
-    assert "analizar:1" in flattened
-    assert "analizar:all" in flattened
+    assert markup.get("is_persistent") is True
+
+
+# --- Reply-keyboard label routing ---
+
+
+@pytest.mark.parametrize(
+    "label,path,method",
+    [
+        ("🛒 Mercado", "/market", "GET"),
+        ("📋 Alinear", "/lineups/auto-pick", "POST"),
+        ("💡 Recomendar", "/budget/recommendations", "GET"),
+        ("💸 Pujar", "/market/auto-bid", "POST"),
+        ("🧹 Scraper", "/scraper/trigger", "POST"),
+    ],
+)
+def test_reply_keyboard_label_dispatches_action(client, label, path, method):
+    """Tapping a button on the persistent keyboard sends the label as
+    plain text; the bot must route it to the matching api endpoint."""
+    with patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call:
+        resp = _post(client, _update(_VALID_CHAT, label))
+    assert resp.status_code == 200
+    mock_call.assert_called_once_with(_API_URL, path, method=method, params=None)
+
+
+def test_reply_keyboard_analizar_label_opens_picker(client):
+    """The '📊 Analizar' label opens the manager picker (no direct api
+    call), same as the `/analizar` slash command."""
+    fake_managers = [
+        {"id": 1, "name": "Jorge", "is_me": True},
+        {"id": 2, "name": "Pepe", "is_me": False},
+    ]
+    with patch(
+        "packages.biwenger_tools.bot.app.api_client.list_managers",
+        return_value=fake_managers,
+    ), patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call, patch(
+        "packages.biwenger_tools.bot.app.send_telegram_message"
+    ) as mock_send:
+        resp = _post(client, _update(_VALID_CHAT, "📊 Analizar"))
+    assert resp.status_code == 200
+    mock_call.assert_not_called()
+    markup = mock_send.call_args.kwargs.get("reply_markup")
+    assert markup is not None
+    # Manager picker is still INLINE (one-shot two-step flow).
+    assert "inline_keyboard" in markup
+
+
+# --- callback_query handling (inline keyboards — manager picker only) ---
 
 
 def test_analizar_id_callback_calls_teams_with_filter(client):


### PR DESCRIPTION
## Summary

El menú principal del bot ahora es una **reply keyboard persistente** (siempre visible debajo del input, estilo Weatherman / StoreBot), no un inline keyboard que aparece solo cuando tipeas /menu.

### Cambios de UX
- `/start` (o `/menu` como fallback) ancla la reply keyboard al chat. Telegram la mantiene visible entre mensajes (\`is_persistent: true\`).
- Cada botón envía su label como texto plano (\`📊 Analizar\`, \`🛒 Mercado\`, ...). El webhook handler enruta por label antes de los slash commands.
- \`📊 Analizar\` abre el manager picker (que sigue siendo inline keyboard — es un flujo de 2 pasos).
- Slash commands siguen funcionando si prefieres tipear.

### Cambios internos
- Nuevo \`menu.main_menu_reply_keyboard()\` y mapa inverso \`menu.LABEL_TO_ACTION\`.
- Nuevo \`_try_dispatch_label()\` en \`app.py\` antes del router de slash.
- Eliminado el handling del prefix \`menu:\` en \`_handle_callback\` (dead code: el menú principal ya no usa callbacks). Sólo queda \`analizar:<id|all>\` para el picker.

## Test plan
- [x] \`bazel test //...\` — 6 suites verdes.
- [x] Nuevos tests parametrizados cubren cada label → endpoint y el caso especial Analizar → picker.
- [x] \`flake8\` + \`black --check\` clean.
- [ ] Smoke post-deploy: \`/start\` debería pinear la keyboard; cualquier botón posterior debería disparar la acción sin tipear nada.