### PR TITLE
feat(api): propagate Telegram delivery failures across every caller

### DIFF
--- a/core/sdk/telegram.py
+++ b/core/sdk/telegram.py
@@ -118,8 +118,12 @@ def send_telegram_photo(
     chat_id: str,
     image_bytes: bytes,
     caption: str = "",
-) -> None:
-    """Sends a PNG image to a Telegram chat via sendPhoto."""
+) -> bool:
+    """Sends a PNG image to a Telegram chat via sendPhoto.
+
+    Returns ``True`` on success, ``False`` on any 4xx/5xx/network
+    failure (also logged). Same contract as `send_telegram_message`.
+    """
     url = f"https://api.telegram.org/bot{bot_token}/sendPhoto"
     try:
         response = requests.post(
@@ -130,8 +134,55 @@ def send_telegram_photo(
         )
         response.raise_for_status()
         logger.info("Telegram photo sent.", extra={"caption": caption[:40]})
+        return True
     except requests.RequestException as e:
         logger.error("Failed to send Telegram photo.", extra={"error": str(e)})
+        return False
+
+
+class TelegramDeliveryError(RuntimeError):
+    """Raised by the `_or_raise` helpers when Telegram refuses delivery.
+
+    Surfaces upstream so route handlers can return 500 and the bot can
+    post a fallback plaintext error to the user. Catch this specifically
+    (not bare `Exception`) when you need to differentiate Telegram
+    failures from upstream Biwenger/JP failures.
+    """
+
+
+def send_telegram_message_or_raise(
+    bot_token: str,
+    chat_id: str,
+    text: str,
+    parse_mode: str = "HTML",
+    disable_web_page_preview: bool = True,
+    reply_markup: Optional[dict] = None,
+) -> None:
+    """`send_telegram_message` that raises `TelegramDeliveryError` on
+    failure. Use this when the caller is a request handler that should
+    surface delivery failures as a non-2xx response."""
+    if not send_telegram_message(
+        bot_token=bot_token,
+        chat_id=chat_id,
+        text=text,
+        parse_mode=parse_mode,
+        disable_web_page_preview=disable_web_page_preview,
+        reply_markup=reply_markup,
+    ):
+        raise TelegramDeliveryError("Telegram message delivery failed")
+
+
+def send_telegram_photo_or_raise(
+    bot_token: str,
+    chat_id: str,
+    image_bytes: bytes,
+    caption: str = "",
+) -> None:
+    """`send_telegram_photo` that raises `TelegramDeliveryError` on
+    failure. Use in request handlers; the route returns 5xx and the
+    bot tells the user."""
+    if not send_telegram_photo(bot_token, chat_id, image_bytes, caption):
+        raise TelegramDeliveryError("Telegram photo delivery failed")
 
 
 def register_bot_commands(bot_token: str, commands: list[dict]) -> None:

--- a/packages/biwenger_tools/api/logic/actions.py
+++ b/packages/biwenger_tools/api/logic/actions.py
@@ -13,7 +13,10 @@ import requests
 
 from core.sdk.biwenger import BiwengerClient
 from core.sdk.jp import check_api_health, fetch_all_players
-from core.sdk.telegram import send_telegram_message, send_telegram_photo
+from core.sdk.telegram import (
+    send_telegram_message_or_raise,
+    send_telegram_photo_or_raise,
+)
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
 from packages.biwenger_tools.api.logic.image_formatter import build_table_image
@@ -28,8 +31,11 @@ logger = get_logger(__name__)
 
 
 def _send_image(token: str, chat_id: str, image: bytes, caption: str) -> None:
-    """sendPhoto + a small pause to stay under Telegram's send-rate cap."""
-    send_telegram_photo(token, chat_id, image, caption)
+    """sendPhoto + a small pause to stay under Telegram's send-rate cap.
+
+    Raises `TelegramDeliveryError` if Telegram rejects the photo; the
+    route handler surfaces it as a 500."""
+    send_telegram_photo_or_raise(token, chat_id, image, caption)
     time.sleep(0.5)
 
 
@@ -133,7 +139,7 @@ def run_teams(manager_id: int | None = None) -> dict:
     if manager_id is not None:
         # Single-manager mode: one image, no market.
         if manager_id not in managers:
-            send_telegram_message(
+            send_telegram_message_or_raise(
                 bot_token=token,
                 chat_id=chat_id,
                 text=(
@@ -272,7 +278,7 @@ def run_auto_pick_lineup(dry_run: bool = False) -> dict:
                 "names_by_position": _names_by_position(my_team),
             },
         )
-        send_telegram_message(
+        send_telegram_message_or_raise(
             bot_token=token,
             chat_id=chat_id,
             text="No se pudo calcular la alineacion (jugadores insuficientes).",
@@ -283,7 +289,7 @@ def run_auto_pick_lineup(dry_run: bool = False) -> dict:
         preview = format_lineup_message(result).replace(
             "✅ Alineación aplicada", "👀 <b>Preview</b> — no aplicada"
         )
-        send_telegram_message(bot_token=token, chat_id=chat_id, text=preview)
+        send_telegram_message_or_raise(bot_token=token, chat_id=chat_id, text=preview)
         logger.info(
             "Dry-run lineup preview sent.",
             extra={"formation": result["formation"], "total_sf": result["total_sf"]},
@@ -322,7 +328,7 @@ def run_auto_pick_lineup(dry_run: bool = False) -> dict:
         # Biwenger PUT retries internally on transient failures. If we land
         # here the retries also failed (or a 4xx like invalid captain).
         logger.error("set_lineup failed after retries.", extra={"error": str(exc)})
-        send_telegram_message(
+        send_telegram_message_or_raise(
             bot_token=token,
             chat_id=chat_id,
             text=(
@@ -334,7 +340,7 @@ def run_auto_pick_lineup(dry_run: bool = False) -> dict:
         )
         return {"sent": 1, "applied": False, "reason": "biwenger_put_failed"}
 
-    send_telegram_message(
+    send_telegram_message_or_raise(
         bot_token=token, chat_id=chat_id, text=format_lineup_message(result)
     )
     logger.info(

--- a/packages/biwenger_tools/api/logic/auto_bid.py
+++ b/packages/biwenger_tools/api/logic/auto_bid.py
@@ -51,7 +51,7 @@ from core.sdk.jp import (
     fetch_all_players,
     get_predict_rate,
 )
-from core.sdk.telegram import send_telegram_message
+from core.sdk.telegram import send_telegram_message_or_raise
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
 from packages.biwenger_tools.api.logic.player_matching import (
@@ -282,24 +282,20 @@ def _format_telegram_text(
 def _maybe_notify(text: str) -> int:
     """Send the summary to Telegram if creds are configured. Returns sent count.
 
-    Raises ``RuntimeError`` if Telegram refuses the message (4xx parse
-    error, 5xx, timeout). The route handler converts that into a 500
-    so the bot can post a fallback error message instead of leaving
-    the chat with an unresolved "⏳ procesando…".
+    Lets `TelegramDeliveryError` propagate when Telegram refuses the
+    message (4xx parse error, 5xx, timeout). The route handler turns
+    it into a 500 so the bot can post a fallback plaintext error to
+    the user instead of leaving the chat with an unresolved
+    "⏳ procesando…".
     """
     if not (config.TELEGRAM_BOT_TOKEN and config.TELEGRAM_CHAT_ID):
         logger.warning("Telegram credentials missing — skipping send.")
         return 0
-    sent = send_telegram_message(
+    send_telegram_message_or_raise(
         bot_token=config.TELEGRAM_BOT_TOKEN,
         chat_id=config.TELEGRAM_CHAT_ID,
         text=text,
     )
-    if not sent:
-        raise RuntimeError(
-            "Telegram summary delivery failed — bids already placed "
-            "(see Firestore `auto_bid_log` + Cloud Logging)."
-        )
     return 1
 
 

--- a/packages/biwenger_tools/api/logic/digests.py
+++ b/packages/biwenger_tools/api/logic/digests.py
@@ -13,7 +13,7 @@ import time
 
 from core.sdk.biwenger import BiwengerClient
 from core.sdk.jp import check_api_health, fetch_all_players
-from core.sdk.telegram import send_telegram_photo
+from core.sdk.telegram import send_telegram_photo_or_raise
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
 from packages.biwenger_tools.api.logic import auto_bid
@@ -25,8 +25,11 @@ logger = get_logger(__name__)
 
 
 def _send_image(token: str, chat_id: str, image: bytes, caption: str) -> None:
-    """sendPhoto + a small pause to stay under Telegram's send-rate cap."""
-    send_telegram_photo(token, chat_id, image, caption)
+    """sendPhoto + a small pause to stay under Telegram's send-rate cap.
+
+    Raises `TelegramDeliveryError` on Telegram refusal so the route
+    handler can surface it as a 500."""
+    send_telegram_photo_or_raise(token, chat_id, image, caption)
     time.sleep(0.5)
 
 

--- a/packages/biwenger_tools/api/logic/recommendations.py
+++ b/packages/biwenger_tools/api/logic/recommendations.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 from core.sdk.biwenger import BiwengerClient
 from core.sdk.jp import check_api_health, fetch_all_players, get_predict_rate
-from core.sdk.telegram import send_telegram_message
+from core.sdk.telegram import send_telegram_message_or_raise
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
 from packages.biwenger_tools.api.logic.player_matching import build_jp_index
@@ -304,7 +304,7 @@ def run_recommendations(
         return {"sent": 0, **payload}
 
     text = _format_telegram_text(payload)
-    send_telegram_message(
+    send_telegram_message_or_raise(
         bot_token=config.TELEGRAM_BOT_TOKEN,
         chat_id=config.TELEGRAM_CHAT_ID,
         text=text,

--- a/packages/biwenger_tools/api/tests/test_auto_bid.py
+++ b/packages/biwenger_tools/api/tests/test_auto_bid.py
@@ -335,7 +335,9 @@ def run_env():
         # Pin jitter to 0 so the run-level assertions can stay on exact euros.
         # The jitter behaviour itself is covered by the tier_bid-level tests.
         stack.enter_context(patch(_patches("_jitter"), return_value=0))
-        mock_send = stack.enter_context(patch(_patches("send_telegram_message")))
+        mock_send = stack.enter_context(
+            patch(_patches("send_telegram_message_or_raise"))
+        )
 
         mock_cfg.JP_AUTH_TOKEN = "tok"
         mock_cfg.JP_COMPETITION = 1
@@ -478,12 +480,14 @@ def test_run_auto_bid_skips_send_when_telegram_creds_missing(run_env):
     assert result["bid_count"] == 1
 
 
-def test_run_auto_bid_raises_when_telegram_send_returns_false(run_env):
-    """Regression for the 2026-05-24 silent fail: when Telegram refuses
-    the summary (4xx parse error → `send_telegram_message` returns False),
-    `run_auto_bid` must raise so the route returns 500 and the bot can
-    surface the failure to the user. Otherwise the "⏳ procesando…"
-    message hangs forever and the user is blind to the problem."""
+def test_run_auto_bid_raises_when_telegram_send_fails(run_env):
+    """Regression for the silent fail: when Telegram refuses the summary
+    (4xx parse error → `send_telegram_message_or_raise` raises
+    TelegramDeliveryError), `run_auto_bid` must let it propagate so the
+    route returns 500 and the bot can surface the failure to the user.
+    Otherwise "⏳ procesando…" hangs forever and the user is blind."""
+    from core.sdk.telegram import TelegramDeliveryError
+
     market = [_sale(1)]
     biwenger_players = {1: _bw(1, "Vinicius", 5_000_000)}
     jp_players = [_jp_with_sf("Vinicius", 910)]
@@ -493,12 +497,11 @@ def test_run_auto_bid_raises_when_telegram_send_returns_false(run_env):
         jp_players=jp_players,
         cash=30_000_000,
     )
-    # Pin the send to "failed" (False). Bids will have been placed by
-    # the time we hit the notify step — we keep the Firestore log as
-    # the audit trail.
-    mock_send.return_value = False
+    # Bids will have been placed by the time we hit the notify step —
+    # the Firestore log keeps the audit trail.
+    mock_send.side_effect = TelegramDeliveryError("delivery failed")
 
-    with pytest.raises(RuntimeError, match="Telegram summary delivery failed"):
+    with pytest.raises(TelegramDeliveryError):
         auto_bid.run_auto_bid()
 
     mock_send.assert_called_once()


### PR DESCRIPTION
Closes the silent-fail risk introduced as a remediation item in STATUS.md/PENDING.md. Only auto-bid raised on Telegram failure (PR #100); now recommendations, digests, /teams and /lineups/auto-pick all surface delivery failures as 500 so the bot can post a plaintext error fallback.

New typed exception `TelegramDeliveryError` + two `_or_raise` wrappers in core/sdk/telegram.py. Bool versions kept for fire-and-forget callers (scraper Cloud Run Job, bot ACK path).

## Test plan
- [x] `bazel test //...` — 6 suites green.
- [x] `flake8` + `black --check` clean.
- [x] Auto-bid raise test rewritten against the new exception type.