### PR TITLE
feat(chuck): persistent reply keyboard, matching biwenger_tools UX

### DIFF
--- a/core/sdk/telegram.py
+++ b/core/sdk/telegram.py
@@ -185,6 +185,23 @@ def send_telegram_photo_or_raise(
         raise TelegramDeliveryError("Telegram photo delivery failed")
 
 
+def build_persistent_reply_keyboard(labels: list[str], cols: int = 2) -> dict:
+    """Build a `ReplyKeyboardMarkup` dict laid out in `cols` columns.
+
+    Pinned via `is_persistent: true` so it stays below the input across
+    messages; `resize_keyboard: true` lets clients shrink button height
+    when the device is narrow. Tapping a button posts its label as a
+    plain text message — the webhook caller routes that text by exact
+    match. Shared by every bot that needs a native-feeling button menu.
+    """
+    rows = [labels[i : i + cols] for i in range(0, len(labels), cols)]
+    return {
+        "keyboard": [[{"text": label} for label in row] for row in rows],
+        "is_persistent": True,
+        "resize_keyboard": True,
+    }
+
+
 def register_bot_commands(bot_token: str, commands: list[dict]) -> None:
     """Registers bot commands so they appear in the Telegram '/' menu.
 

--- a/packages/biwenger_tools/bot/menu.py
+++ b/packages/biwenger_tools/bot/menu.py
@@ -13,6 +13,8 @@ Two flavours of keyboard are used:
 
 from typing import Iterable
 
+from core.sdk.telegram import build_persistent_reply_keyboard
+
 # Main-menu actions. Order matters — the rows in the keyboard mirror this.
 MAIN_MENU_ACTIONS = [
     ("analizar", "📊 Analizar"),
@@ -28,22 +30,8 @@ LABEL_TO_ACTION = {label: key for key, label in MAIN_MENU_ACTIONS}
 
 
 def main_menu_reply_keyboard() -> dict:
-    """Two-column persistent reply keyboard with every main-menu action.
-
-    `is_persistent: true` keeps the keyboard visible across messages
-    until the bot sends a `ReplyKeyboardRemove`. Tapping a button posts
-    the label as a normal text message — the webhook routes it via
-    `LABEL_TO_ACTION`.
-    """
-    rows = [
-        [{"text": label} for _, label in MAIN_MENU_ACTIONS[i : i + 2]]
-        for i in range(0, len(MAIN_MENU_ACTIONS), 2)
-    ]
-    return {
-        "keyboard": rows,
-        "is_persistent": True,
-        "resize_keyboard": True,
-    }
+    """Two-column persistent reply keyboard with every main-menu action."""
+    return build_persistent_reply_keyboard([label for _, label in MAIN_MENU_ACTIONS])
 
 
 def managers_keyboard(managers: Iterable[dict]) -> dict:

--- a/packages/chucknorris_bot/bot/app.py
+++ b/packages/chucknorris_bot/bot/app.py
@@ -12,7 +12,7 @@ from core.sdk.telegram import (
     validate_webhook_secret,
 )
 from core.utils import get_logger
-from packages.chucknorris_bot.bot import config
+from packages.chucknorris_bot.bot import config, menu
 
 logger = get_logger(__name__)
 
@@ -24,7 +24,7 @@ _CATEGORIES = {"science", "food", "animal", "dev"}
 
 _HELP_TEXT = (
     "<b>Chuck Norris Bot</b> 🤜\n\n"
-    "Send me a category and I'll hit you with a fact:\n\n"
+    "Tap a button or send a command:\n\n"
     "/random — random fact\n"
     "/science — science fact\n"
     "/food — food fact\n"
@@ -33,6 +33,30 @@ _HELP_TEXT = (
     "/version — deployed bot version\n"
     "/help — show this message"
 )
+
+
+def _send_joke(chat_id: str, category: str | None = None) -> None:
+    """Fetch + post one Chuck Norris fact."""
+    joke = _fetch_joke(category)
+    send_telegram_message(
+        bot_token=config.TELEGRAM_BOT_TOKEN,
+        chat_id=chat_id,
+        text=joke,
+    )
+
+
+def _send_welcome_with_keyboard(chat_id: str) -> None:
+    """Post the help text and pin the persistent reply keyboard.
+
+    Telegram keeps the keyboard visible across subsequent messages
+    (`is_persistent: true`); the bot doesn't need to re-attach it.
+    """
+    send_telegram_message(
+        bot_token=config.TELEGRAM_BOT_TOKEN,
+        chat_id=chat_id,
+        text=_HELP_TEXT,
+        reply_markup=menu.main_menu_reply_keyboard(),
+    )
 
 
 def _build_version_text() -> str:
@@ -79,14 +103,17 @@ def webhook():
     if not chat_id or not text:
         return "", 200
 
+    # Reply-keyboard taps arrive as plain text matching a button label.
+    # Route those before slash commands so the buttons feel native.
+    category = menu.LABEL_TO_CATEGORY.get(text)
+    if category is not None:
+        _send_joke(chat_id, None if category == "random" else category)
+        return "", 200
+
     cmd = parse_command(text)
 
     if cmd in ("/start", "/help"):
-        send_telegram_message(
-            bot_token=config.TELEGRAM_BOT_TOKEN,
-            chat_id=chat_id,
-            text=_HELP_TEXT,
-        )
+        _send_welcome_with_keyboard(chat_id)
     elif cmd == "/version":
         send_telegram_message(
             bot_token=config.TELEGRAM_BOT_TOKEN,
@@ -94,20 +121,9 @@ def webhook():
             text=_build_version_text(),
         )
     elif cmd == "/random":
-        joke = _fetch_joke()
-        send_telegram_message(
-            bot_token=config.TELEGRAM_BOT_TOKEN,
-            chat_id=chat_id,
-            text=joke,
-        )
+        _send_joke(chat_id)
     elif cmd in {f"/{cat}" for cat in _CATEGORIES}:
-        category = cmd[1:]
-        joke = _fetch_joke(category)
-        send_telegram_message(
-            bot_token=config.TELEGRAM_BOT_TOKEN,
-            chat_id=chat_id,
-            text=joke,
-        )
+        _send_joke(chat_id, cmd[1:])
     else:
         logger.info("Unknown command, ignoring.", extra={"text": text[:50]})
 

--- a/packages/chucknorris_bot/bot/menu.py
+++ b/packages/chucknorris_bot/bot/menu.py
@@ -1,0 +1,27 @@
+"""Persistent reply keyboard for the Chuck Norris bot.
+
+Same pattern as `biwenger_tools/bot/menu.py`: a list of
+`(category, label)` pairs drives both the keyboard layout and the
+label → action router consumed by the webhook handler.
+"""
+
+from core.sdk.telegram import build_persistent_reply_keyboard
+
+# Main-menu actions. Order matters — the keyboard rows mirror this.
+# Categories without an emoji button (version, help) stay accessible
+# via slash commands.
+MAIN_MENU_ACTIONS = [
+    ("random", "🎲 Random"),
+    ("science", "🧪 Science"),
+    ("food", "🍔 Food"),
+    ("animal", "🐾 Animal"),
+    ("dev", "💻 Dev"),
+]
+
+# Reverse map for the webhook handler: `"🎲 Random"` → `"random"`.
+LABEL_TO_CATEGORY = {label: key for key, label in MAIN_MENU_ACTIONS}
+
+
+def main_menu_reply_keyboard() -> dict:
+    """Two-column persistent reply keyboard with every fact category."""
+    return build_persistent_reply_keyboard([label for _, label in MAIN_MENU_ACTIONS])

--- a/packages/chucknorris_bot/bot/tests/test_app.py
+++ b/packages/chucknorris_bot/bot/tests/test_app.py
@@ -53,19 +53,57 @@ def test_correct_secret_returns_200(client):
 # --- Commands ---
 
 
-def test_help_sends_message(client):
+def test_help_attaches_persistent_reply_keyboard(client):
+    """`/help` (and `/start` via the alias) sends the welcome text +
+    the persistent reply keyboard so the fact-category buttons appear
+    natively below the input field."""
     with patch("packages.chucknorris_bot.bot.app.send_telegram_message") as mock_send:
         resp = _post(client, _update("123", "/help"))
     assert resp.status_code == 200
     mock_send.assert_called_once()
-    assert mock_send.call_args.kwargs["chat_id"] == "123"
+    markup = mock_send.call_args.kwargs.get("reply_markup")
+    assert markup is not None
+    assert markup.get("is_persistent") is True
+    flattened = [b["text"] for row in markup["keyboard"] for b in row]
+    assert "🎲 Random" in flattened
+    assert "💻 Dev" in flattened
 
 
-def test_start_sends_message(client):
+def test_start_attaches_persistent_reply_keyboard(client):
     with patch("packages.chucknorris_bot.bot.app.send_telegram_message") as mock_send:
         resp = _post(client, _update("123", "/start"))
     assert resp.status_code == 200
+    markup = mock_send.call_args.kwargs.get("reply_markup")
+    assert markup is not None
+    assert markup.get("is_persistent") is True
+
+
+# --- Reply-keyboard label routing ---
+
+
+@pytest.mark.parametrize(
+    "label,expected_category",
+    [
+        ("🎲 Random", None),  # random → no category arg to _fetch_joke
+        ("🧪 Science", "science"),
+        ("🍔 Food", "food"),
+        ("🐾 Animal", "animal"),
+        ("💻 Dev", "dev"),
+    ],
+)
+def test_reply_keyboard_label_dispatches_joke(client, label, expected_category):
+    """Tapping a keyboard button sends the label as plain text; the bot
+    routes it to `_fetch_joke(category)` and replies with the result."""
+    with patch(
+        "packages.chucknorris_bot.bot.app._fetch_joke", return_value="A joke."
+    ) as mock_fetch, patch(
+        "packages.chucknorris_bot.bot.app.send_telegram_message"
+    ) as mock_send:
+        resp = _post(client, _update("123", label))
+    assert resp.status_code == 200
+    mock_fetch.assert_called_once_with(expected_category)
     mock_send.assert_called_once()
+    assert mock_send.call_args.kwargs["text"] == "A joke."
 
 
 def test_version_returns_commit_and_deploy_time(client):
@@ -88,7 +126,8 @@ def test_random_fetches_and_sends(client):
     ) as mock_send:
         resp = _post(client, _update("123", "/random"))
     assert resp.status_code == 200
-    mock_fetch.assert_called_once_with()
+    # Goes through `_send_joke(chat_id, None)` → fetches with no category.
+    mock_fetch.assert_called_once_with(None)
     mock_send.assert_called_once()
     assert mock_send.call_args.kwargs["text"] == "A joke."
 


### PR DESCRIPTION
Unifies both bots on the persistent reply-keyboard pattern. Extracts the markup builder to `core.sdk.telegram.build_persistent_reply_keyboard` so neither bot duplicates the layout logic.

ChuckBot now pins a row of fact-category buttons (🎲 Random / 🧪 Science / 🍔 Food / 🐾 Animal / 💻 Dev) below the input field on /start or /help, matching the Biwenger Tools Bot UX in the screenshot.

## Test plan
- [x] `bazel test //...` — 6 suites green.
- [x] Chuck test suite: keyboard markup shape, parametrised label-to-category routing, /start + /help both pin the keyboard.
- [x] Biwenger bot tests unchanged (shared builder swap is a no-op for them).
- [x] `flake8` + `black --check` clean.