### PR TITLE
feat(bot): unify post-deploy setup via core.configure_bot_commands

### DIFF
--- a/core/sdk/telegram.py
+++ b/core/sdk/telegram.py
@@ -218,7 +218,12 @@ def register_bot_commands(bot_token: str, commands: list[dict]) -> None:
 
 
 def set_commands_menu_button(bot_token: str) -> None:
-    """Sets the bot's menu button to show the registered command list."""
+    """Sets the bot's menu button to show the registered command list.
+
+    Renders as a blue "Menú" pill on the left of the input. Mostly
+    superseded by `reset_menu_button_to_default` + a persistent reply
+    keyboard for a cleaner look (see `configure_bot_commands`).
+    """
     url = TELEGRAM_SET_MENU_BUTTON_URL.format(token=bot_token)
     try:
         response = requests.post(
@@ -228,6 +233,38 @@ def set_commands_menu_button(bot_token: str) -> None:
         logger.info("Menu button set to 'commands'.")
     except requests.RequestException as e:
         logger.error("Failed to set menu button.", extra={"error": str(e)})
+
+
+def reset_menu_button_to_default(bot_token: str) -> None:
+    """Resets the bot's menu button to Telegram's `default`.
+
+    Removes the blue "Menú" pill on the left of the input. The slash
+    autocomplete that pops up when the user types `/` is unaffected
+    — that comes from `register_bot_commands` (setMyCommands), not
+    from the menu button. Idempotent.
+    """
+    url = TELEGRAM_SET_MENU_BUTTON_URL.format(token=bot_token)
+    try:
+        response = requests.post(
+            url, json={"menu_button": {"type": "default"}}, timeout=15
+        )
+        response.raise_for_status()
+        logger.info("Menu button reset to 'default'.")
+    except requests.RequestException as e:
+        logger.error("Failed to reset menu button.", extra={"error": str(e)})
+
+
+def configure_bot_commands(bot_token: str, commands: list[dict]) -> None:
+    """Idiomatic post-deploy setup shared by every bot in this repo.
+
+    Registers `commands` for the slash autocomplete that Telegram pops
+    up when the user types `/`, and resets the left "Menú" pill to the
+    default — bots in this repo expose their main actions via a
+    persistent reply keyboard (`build_persistent_reply_keyboard`), so
+    a redundant pill on the left adds clutter without adding value.
+    """
+    register_bot_commands(bot_token, commands)
+    reset_menu_button_to_default(bot_token)
 
 
 def set_webhook(

--- a/packages/biwenger_tools/bot/setup_commands.py
+++ b/packages/biwenger_tools/bot/setup_commands.py
@@ -18,11 +18,7 @@ import os
 import sys
 
 from packages.biwenger_tools.bot import config
-from core.sdk.telegram import (
-    register_bot_commands,
-    set_commands_menu_button,
-    set_webhook,
-)
+from core.sdk.telegram import configure_bot_commands, set_webhook
 
 COMMANDS = [
     {"command": "menu", "description": "Menú visual con botones (recomendado)"},
@@ -56,11 +52,8 @@ def main():
         print("ERROR: TELEGRAM_BOT_TOKEN not set.", file=sys.stderr)
         sys.exit(1)
 
-    print("Registering commands…")
-    register_bot_commands(token, COMMANDS)
-
-    print("Setting menu button…")
-    set_commands_menu_button(token)
+    print("Configuring commands + resetting menu button to default…")
+    configure_bot_commands(token, COMMANDS)
 
     bot_url = os.getenv("BIWENGER_BOT_URL", "").strip()
     if bot_url:

--- a/packages/chucknorris_bot/bot/setup_commands.py
+++ b/packages/chucknorris_bot/bot/setup_commands.py
@@ -8,7 +8,7 @@ Requires TELEGRAM_BOT_TOKEN in the environment (or .env file).
 
 import sys
 
-from core.sdk.telegram import register_bot_commands, set_commands_menu_button
+from core.sdk.telegram import configure_bot_commands
 from packages.chucknorris_bot.bot import config
 
 COMMANDS = [
@@ -28,11 +28,8 @@ def main():
         print("ERROR: TELEGRAM_BOT_TOKEN not set.", file=sys.stderr)
         sys.exit(1)
 
-    print("Registering commands…")
-    register_bot_commands(token, COMMANDS)
-
-    print("Setting menu button…")
-    set_commands_menu_button(token)
+    print("Configuring commands + resetting menu button to default…")
+    configure_bot_commands(token, COMMANDS)
 
     print("Done.")
 


### PR DESCRIPTION
Closes the visual asymmetry between ChuckBot (showed "Menú" pill) and Biwenger Tools (didn't). Both now reset the menu button to "default" so the persistent reply keyboard is the single visual menu, and the slash autocomplete (typing `/`) still works.

New high-level helper in core: any future bot in this repo gets identical UX via `configure_bot_commands(token, COMMANDS)` + `build_persistent_reply_keyboard(labels)`.

## Test plan
- [x] `bazel test //...` — 6 suites green.
- [x] `flake8` + `black --check` clean.
- [ ] Post-deploy: both bots' CI step runs the new `configure_bot_commands`; the "Menú" pill should disappear from ChuckBot within seconds.