### PR TITLE
chore: translate remaining Spanish comments / docstrings to English

### DIFF
--- a/core/sdk/biwenger.py
+++ b/core/sdk/biwenger.py
@@ -16,8 +16,8 @@ logger = get_logger(__name__)
 # right move is to retry rather than fail the whole `/alinear` flow.
 _LINEUP_RETRY_BACKOFFS = (2, 5, 10)
 
-# --- URLs públicas del API de Biwenger ---
-# Cualquier paquete puede importar estas constantes en lugar de redefinirlas.
+# --- Public Biwenger API URLs ---
+# Any package can import these constants instead of redefining them.
 BIWENGER_API_BASE = "https://biwenger.as.com/api/v2"
 BIWENGER_CF_BASE = "https://cf.biwenger.com/api/v2"
 

--- a/core/sdk/jp.py
+++ b/core/sdk/jp.py
@@ -158,10 +158,10 @@ def fetch_all_players(
 
 
 def get_predict_rate(player: dict, score_type: int = 2) -> Optional[int]:
-    """Extrae el rate de predicción para el sistema de puntuación dado.
+    """Return the prediction rate for the requested scoring system.
 
-    Devuelve None si el jugador no tiene partido (predict vacío) o el tipo
-    pedido no aparece.
+    Returns None when the player has no scheduled match (empty `predict`)
+    or the requested score_type is not present.
     """
     for entry in player.get("predict") or []:
         if entry.get("type") == score_type:

--- a/packages/biwenger_tools/api/logic/player_matching.py
+++ b/packages/biwenger_tools/api/logic/player_matching.py
@@ -1,8 +1,8 @@
 from unidecode import unidecode
 
-# Mapeo manual Biwenger -> JP para casos en los que ninguna estrategia
-# automática funciona (nombres completamente distintos, apodos, alias).
-# Las claves están normalizadas (lowercase + sin acentos).
+# Hand-maintained Biwenger → JP name overrides for the cases where no
+# automatic strategy matches (completely different spellings, nicknames,
+# aliases). Keys are normalised (lowercase, accents stripped).
 PLAYER_NAME_MAPPINGS = {
     # Vinicius en Biwenger ↔ "Vini Jr" en JP
     "vinicius jr": "vini jr",
@@ -18,16 +18,16 @@ PLAYER_NAME_MAPPINGS = {
 
 
 def normalize_name(name: str) -> str:
-    """Normaliza nombres: minúsculas, sin acentos, recortado."""
+    """Normalise a name: lowercase, accent-stripped, trimmed."""
     return unidecode(name.lower().strip())
 
 
 def build_jp_index(jp_players: list[dict]) -> dict:
-    """Construye índices del listado JP para acelerar el matching.
+    """Build lookup indexes over a JP player list to speed up matching.
 
-    Devuelve dict con dos claves:
-      - 'by_name': nombre normalizado -> jugador JP
-      - 'by_slug': slug normalizado -> jugador JP (fallback)
+    Returns a dict with two keys:
+      - 'by_name': normalised name → JP player
+      - 'by_slug': normalised slug → JP player (fallback)
     """
     by_name: dict[str, dict] = {}
     by_slug: dict[str, dict] = {}
@@ -42,16 +42,16 @@ def build_jp_index(jp_players: list[dict]) -> dict:
 
 
 def find_player_match(biwenger_name: str, jp_index: dict) -> dict | None:
-    """Busca el jugador JP que corresponde al nombre Biwenger dado.
+    """Find the JP player that matches the given Biwenger name.
 
-    Prueba en orden:
-      1. Coincidencia directa por nombre normalizado
-      2. Mapeo manual de excepciones (PLAYER_NAME_MAPPINGS)
-      3. Coincidencia por slug
-      4. Transformaciones automáticas (apellido, nombre, "i. apellido")
-      5. Subconjunto de tokens
+    Tries in order:
+      1. Exact match on the normalised name.
+      2. Manual override (PLAYER_NAME_MAPPINGS).
+      3. Match by slug.
+      4. Automatic transformations (last name, first name, "i. last").
+      5. Token-subset match.
 
-    Devuelve el dict del jugador JP o None si no hay coincidencia.
+    Returns the JP player dict, or None if nothing matches.
     """
     by_name = jp_index["by_name"]
     by_slug = jp_index["by_slug"]
@@ -68,7 +68,7 @@ def find_player_match(biwenger_name: str, jp_index: dict) -> dict | None:
     if norm in by_slug:
         return by_slug[norm]
 
-    # Slug suele ser sin espacios; probar también la variante sin espacios
+    # Slugs typically have no spaces; try the no-space variant too.
     no_spaces = norm.replace(" ", "")
     if no_spaces in by_slug:
         return by_slug[no_spaces]

--- a/packages/biwenger_tools/scraper_job/logic/processing.py
+++ b/packages/biwenger_tools/scraper_job/logic/processing.py
@@ -11,7 +11,7 @@ logger = get_logger(__name__)
 
 
 def categorize_title(title):
-    """Clasifica un mensaje según su título."""
+    """Classify a board message by its title prefix."""
     if not title:
         return "comunicado"
     normalized_title = unidecode.unidecode(title.strip().upper())
@@ -91,10 +91,10 @@ def _parse_clause_item(item: dict, fecha: str, players_map: dict) -> Clausulazo:
 
 
 def parse_clausulazos(raw_data: dict, players_map: dict) -> list:
-    """Transforma la respuesta cruda de la API en una lista de Clausulazo.
+    """Transform the raw API response into a list of `Clausulazo` models.
 
-    Cada entry puede contener varios clausulazos en su campo `content`. Una
-    entry malformada se ignora y se loguea — el resto de entries sí se procesan.
+    Each entry can contain several clausulazos in its `content` field. A
+    malformed entry is logged and skipped — the rest still get processed.
     """
     entries = raw_data.get("data", [])
     if isinstance(entries, dict):
@@ -126,7 +126,7 @@ def parse_clausulazos(raw_data: dict, players_map: dict) -> list:
 
 
 def build_tabla_justicia(clausulazos: list) -> list:
-    """Construye el resumen de ataques realizados y recibidos por cada equipo.
+    """Build the per-team summary of clausulazos given and received.
 
     Returns list[JusticeEntry] sorted by total_hechos descending.
     """

--- a/packages/biwenger_tools/web/config.py
+++ b/packages/biwenger_tools/web/config.py
@@ -1,10 +1,9 @@
-# config.py
 import os
 import sys
 
 from dotenv import load_dotenv
 
-# Carga las variables del archivo .env si existe (para desarrollo local)
+# Pulls vars from a local .env when present (used for local dev).
 load_dotenv()
 
 # --- GOOGLE SHEETS SERVICE ACCOUNT ---
@@ -14,11 +13,11 @@ SERVICE_ACCOUNT_PATH = "/gdrive_sa/biwenger-tools-sa.json"
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
 
 
-# --- CONFIGURACIÓN DE TEMPORADA ---
-# Para cambiar de temporada: actualizar TEMPORADA_ACTUAL en deploy.yml (env global)
-# o via: gcloud run services update ... --update-env-vars TEMPORADA_ACTUAL=26-27
+# --- Season configuration ---
+# To roll over a season: bump TEMPORADA_ACTUAL in deploy.yml (global env)
+# or via: gcloud run services update ... --update-env-vars TEMPORADA_ACTUAL=26-27
 TEMPORADA_ACTUAL = os.getenv("TEMPORADA_ACTUAL", "25-26")
-# Añadir la nueva temporada aquí al inicio de cada año (ver docs/operations.md).
+# Prepend the new season at the start of each year (see docs/operations.md).
 TEMPORADAS_DISPONIBLES = ["24-25", "25-26"]
 
 # Per-season Sheet IDs for the Lloros Awards pages. Hand-edited in Sheets
@@ -38,7 +37,7 @@ GCP_PROJECT_ID = os.getenv("GCP_PROJECT_ID")
 CLOUD_RUN_JOB_NAME = os.getenv("CLOUD_RUN_JOB_NAME")
 CLOUD_RUN_REGION = os.getenv("CLOUD_RUN_REGION", "europe-southwest1")
 
-# --- SECRETOS DE LA APLICACIÓN ---
+# --- Application secrets ---
 # Refuse to start without a SECRET_KEY in production. A predictable default
 # (the old "default-dev-key") makes Flask session cookies trivially forgeable,
 # so we never want it to silently leak into a real deploy.
@@ -55,9 +54,9 @@ if not SECRET_KEY:
 
 ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD")
 
-# --- VERSIÓN DESPLEGADA (short SHA, 7 chars) ---
+# --- Deployed version metadata (short SHA, 7 chars) ---
 GIT_COMMIT = os.getenv("GIT_COMMIT", "local")
 DEPLOY_TIME = os.getenv("DEPLOY_TIME", "")
 
-# --- CONFIGURACIÓN NO CRÍTICA (valores fijos) ---
+# --- Non-critical configuration (hardcoded defaults) ---
 MESSAGES_PER_PAGE = 7


### PR DESCRIPTION
Closes the language-standardisation item from PENDING.md. Telegram strings + domain identifiers stay Spanish on purpose (user chat + Firestore schema contract). Tests + lint still green.