### PR TITLE
feat(core): shared HTTP retry helper + applied to Biwenger POSTs

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -48,10 +48,21 @@ py_library(
 )
 
 py_library(
+    name = "http",
+    srcs = ["sdk/http.py"],
+    deps = [
+        ":_init",
+        "@pypi//requests",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
     name = "biwenger",
     srcs = ["sdk/biwenger.py"],
     deps = [
         ":_init",
+        ":http",
         "@pypi//requests",
     ],
     visibility = ["//visibility:public"],
@@ -86,6 +97,7 @@ py_library(
         ":biwenger",
         ":firestore",
         ":gcp",
+        ":http",
         ":jp",
         ":telegram",
     ],

--- a/core/sdk/biwenger.py
+++ b/core/sdk/biwenger.py
@@ -2,19 +2,14 @@
 
 import json
 import re
-import time
 from typing import Optional, Union
 
 import requests
 
+from core.sdk.http import retry_http_request
 from core.utils import get_logger
 
 logger = get_logger(__name__)
-
-# Backoff schedule (seconds) for transient network failures on the lineup PUT.
-# Biwenger has occasionally dropped TCP mid-response — when that happens, the
-# right move is to retry rather than fail the whole `/alinear` flow.
-_LINEUP_RETRY_BACKOFFS = (2, 5, 10)
 
 # --- Public Biwenger API URLs ---
 # Any package can import these constants instead of redefining them.
@@ -278,6 +273,11 @@ class BiwengerClient:
         listings use `to=<seller_user_id>`; those are out of scope for
         auto-bid and should be filtered out by the caller.
 
+        Wrapped in `retry_http_request` so a transient Biwenger 5xx /
+        network blip doesn't lose a bid the auto-bid loop already
+        decided to place. 4xx (player gone, higher bid in, etc.) still
+        surfaces immediately so the caller can `skip + continue`.
+
         Returns the `data` dict from Biwenger's response (includes the
         offer `id`, useful for diagnostics).
         """
@@ -291,8 +291,10 @@ class BiwengerClient:
             "Placing market bid.",
             extra={"player_id": player_id, "amount": amount},
         )
-        response = self.session.post(offers_url, json=payload)
-        response.raise_for_status()
+        response = retry_http_request(
+            lambda: self.session.post(offers_url, json=payload, timeout=30),
+            label="market bid POST",
+        )
         data = response.json().get("data", {}) or {}
         logger.info(
             "Market bid accepted.",
@@ -356,10 +358,9 @@ class BiwengerClient:
         send `0`, which matches the "no captain selected" convention the
         Biwenger payload accepts.
 
-        Retries the PUT on transient network errors (Connection reset, read
-        timeout, etc.) with the backoff schedule in `_LINEUP_RETRY_BACKOFFS`.
-        A 4xx response (e.g. invalid captain) is treated as terminal — those
-        won't get better on retry. Only network-level failures are retried.
+        Wrapped in `retry_http_request`: 5xx + network errors retry with
+        backoff, 4xx (invalid captain, malformed payload) surface
+        immediately so the caller can fail fast.
         """
         payload = {
             "lineup": {
@@ -378,55 +379,12 @@ class BiwengerClient:
                 "captain": captain,
             },
         )
-
-        last_exc: Optional[requests.RequestException] = None
-        for attempt, backoff in enumerate((0,) + _LINEUP_RETRY_BACKOFFS, start=1):
-            if backoff:
-                logger.warning(
-                    "Lineup PUT transient failure — retrying.",
-                    extra={
-                        "attempt": attempt,
-                        "backoff_s": backoff,
-                        "error": str(last_exc),
-                    },
-                )
-                time.sleep(backoff)
-            try:
-                response = self.session.put(lineup_url, json=payload, timeout=30)
-            except requests.RequestException as exc:
-                last_exc = exc
-                continue
-
-            if not response.ok:
-                logger.error(
-                    "Lineup PUT returned non-2xx.",
-                    extra={
-                        "status": response.status_code,
-                        "body": response.text[:500],
-                    },
-                )
-                # 4xx is a terminal error (invalid payload, wrong captain, etc.)
-                # 5xx is worth retrying — Biwenger backend may recover.
-                if 400 <= response.status_code < 500:
-                    response.raise_for_status()
-                last_exc = requests.HTTPError(
-                    f"Biwenger HTTP {response.status_code}", response=response
-                )
-                continue
-
-            logger.info(
-                "Lineup set.",
-                extra={"formation": formation, "captain": captain, "attempts": attempt},
-            )
-            return response.json()
-
-        # Out of retries.
-        logger.error(
-            "Lineup PUT failed after retries.",
-            extra={
-                "attempts": len(_LINEUP_RETRY_BACKOFFS) + 1,
-                "error": str(last_exc),
-            },
+        response = retry_http_request(
+            lambda: self.session.put(lineup_url, json=payload, timeout=30),
+            label="lineup PUT",
         )
-        assert last_exc is not None
-        raise last_exc
+        logger.info(
+            "Lineup set.",
+            extra={"formation": formation, "captain": captain},
+        )
+        return response.json()

--- a/core/sdk/http.py
+++ b/core/sdk/http.py
@@ -1,0 +1,120 @@
+"""HTTP utilities shared by SDK clients.
+
+Currently exposes `retry_http_request`: a single retry loop that wraps
+calls against external APIs we don't own (Biwenger, JP, Telegram).
+
+The retry policy is opinionated for this kind of caller:
+- **Retried**: network errors (timeout, connection reset, DNS) and 5xx
+  responses — the server might recover on the next attempt.
+- **Fail-fast**: 4xx responses — they won't get better; the request is
+  semantically wrong.
+
+Why a shared helper instead of a library: keeps the dep footprint
+small (we already use `requests`, no need for tenacity/backoff) and
+gives every SDK the same observable behaviour in Cloud Logging.
+"""
+
+import time
+from typing import Callable, Tuple
+
+import requests
+
+from core.utils import get_logger
+
+logger = get_logger(__name__)
+
+# Default backoff schedule (seconds). Three retries: roughly 2 + 5 + 10
+# = 17 s of total wait, fits inside Cloud Run request budgets and the
+# bot's 10 min api timeout. Override per-call when needed.
+DEFAULT_BACKOFFS: Tuple[int, ...] = (2, 5, 10)
+
+
+def retry_http_request(
+    request_fn: Callable[[], requests.Response],
+    *,
+    label: str = "request",
+    backoffs: Tuple[int, ...] = DEFAULT_BACKOFFS,
+) -> requests.Response:
+    """Run `request_fn` with backoff on transient failures.
+
+    `request_fn` must return a `requests.Response` (or raise a
+    `requests.RequestException`). The helper handles the retry loop and
+    surfaces the final exception when all retries are exhausted.
+
+    `label` is included in log messages so a Cloud Logging search by
+    operation ("lineup PUT", "market bid POST") returns the right
+    trail.
+    """
+    attempts = (0,) + tuple(backoffs)
+    last_exc: requests.RequestException | None = None
+
+    for attempt, backoff in enumerate(attempts, start=1):
+        if backoff:
+            logger.warning(
+                "%s transient failure — retrying.",
+                label,
+                extra={
+                    "label": label,
+                    "attempt": attempt,
+                    "backoff_s": backoff,
+                    "error": str(last_exc) if last_exc else "",
+                },
+            )
+            time.sleep(backoff)
+
+        try:
+            response = request_fn()
+        except requests.RequestException as exc:
+            last_exc = exc
+            continue
+
+        if response.ok:
+            if attempt > 1:
+                logger.info(
+                    "%s succeeded after retry.",
+                    label,
+                    extra={"label": label, "attempts": attempt},
+                )
+            return response
+
+        # 4xx is terminal — the request is semantically wrong, retrying
+        # won't fix it. Surface the HTTPError immediately.
+        if 400 <= response.status_code < 500:
+            logger.error(
+                "%s returned non-retryable %d.",
+                label,
+                response.status_code,
+                extra={
+                    "label": label,
+                    "status": response.status_code,
+                    "body": response.text[:500],
+                },
+            )
+            response.raise_for_status()
+
+        # 5xx → record and try again.
+        last_exc = requests.HTTPError(
+            f"{label} HTTP {response.status_code}", response=response
+        )
+        logger.warning(
+            "%s returned retryable %d.",
+            label,
+            response.status_code,
+            extra={
+                "label": label,
+                "status": response.status_code,
+                "body": response.text[:500],
+            },
+        )
+
+    logger.error(
+        "%s exhausted retries.",
+        label,
+        extra={
+            "label": label,
+            "attempts": len(attempts),
+            "error": str(last_exc),
+        },
+    )
+    assert last_exc is not None
+    raise last_exc

--- a/core/tests/test_http_retry.py
+++ b/core/tests/test_http_retry.py
@@ -1,0 +1,72 @@
+"""Tests for `core.sdk.http.retry_http_request`."""
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from core.sdk.http import retry_http_request
+
+
+def _resp(status: int = 200, body: str = "ok"):
+    r = requests.Response()
+    r.status_code = status
+    r._content = body.encode()
+    return r
+
+
+def test_returns_immediately_on_first_success():
+    fn = MagicMock(return_value=_resp(200))
+    response = retry_http_request(fn, label="t", backoffs=(0, 0))
+    assert response.status_code == 200
+    assert fn.call_count == 1  # no retry on success
+
+
+def test_fail_fast_on_4xx_without_retrying():
+    """4xx is the caller's mistake — retrying never helps. Raise immediately."""
+    fn = MagicMock(return_value=_resp(400, "bad request"))
+    with pytest.raises(requests.HTTPError):
+        retry_http_request(fn, label="t", backoffs=(0, 0))
+    assert fn.call_count == 1
+
+
+def test_retries_on_5xx_then_succeeds():
+    """5xx is retryable — server may recover."""
+    fn = MagicMock(side_effect=[_resp(503), _resp(200)])
+    response = retry_http_request(fn, label="t", backoffs=(0,))
+    assert response.status_code == 200
+    assert fn.call_count == 2
+
+
+def test_retries_on_network_error_then_succeeds():
+    fn = MagicMock(
+        side_effect=[requests.ConnectionError("boom"), _resp(200)],
+    )
+    response = retry_http_request(fn, label="t", backoffs=(0,))
+    assert response.status_code == 200
+    assert fn.call_count == 2
+
+
+def test_raises_after_exhausted_retries_on_persistent_5xx():
+    fn = MagicMock(return_value=_resp(500, "boom"))
+    with pytest.raises(requests.HTTPError):
+        retry_http_request(fn, label="t", backoffs=(0, 0))
+    assert fn.call_count == 3  # initial + 2 retries
+
+
+def test_raises_after_exhausted_retries_on_persistent_network_error():
+    err = requests.Timeout("slow")
+    fn = MagicMock(side_effect=err)
+    with pytest.raises(requests.Timeout):
+        retry_http_request(fn, label="t", backoffs=(0, 0))
+    assert fn.call_count == 3
+
+
+def test_label_appears_in_logs(caplog):
+    """The `label` arg is what makes Cloud Logging searchable per operation."""
+    import logging
+
+    caplog.set_level(logging.WARNING)
+    fn = MagicMock(side_effect=[_resp(503), _resp(200)])
+    retry_http_request(fn, label="lineup PUT", backoffs=(0,))
+    assert any("lineup PUT" in r.message for r in caplog.records)


### PR DESCRIPTION
Closes the retry-helper item from PENDING.md. Extracts the retry loop out of `set_lineup` into a generic `core.sdk.http.retry_http_request` and applies it to `place_market_bid`. Same opinionated policy: network + 5xx retry, 4xx fail-fast. Catches the inconsistency that `place_market_bid` didn't retry while `set_lineup` did.