### PR TITLE
refactor(api): extract OrchestratorContext — kill setup duplication

### DIFF
--- a/packages/biwenger_tools/api/logic/actions.py
+++ b/packages/biwenger_tools/api/logic/actions.py
@@ -11,8 +11,6 @@ import time
 
 import requests
 
-from core.sdk.biwenger import BiwengerClient
-from core.sdk.jp import check_api_health, fetch_all_players
 from core.sdk.telegram import (
     send_telegram_message_or_raise,
     send_telegram_photo_or_raise,
@@ -24,7 +22,11 @@ from packages.biwenger_tools.api.logic.lineup import (
     format_lineup_message,
     pick_lineup,
 )
-from packages.biwenger_tools.api.logic.player_matching import build_jp_index
+from packages.biwenger_tools.api.logic.orchestration import (
+    build_biwenger_session,
+    build_context,
+    require_telegram,
+)
 from packages.biwenger_tools.api.logic.rows import build_market_rows, build_squad_rows
 
 logger = get_logger(__name__)
@@ -84,39 +86,8 @@ def _names_by_position(rows: list[dict]) -> dict:
     return {str(k): v for k, v in by_pos.items()}
 
 
-def _prepare_context():
-    """Boilerplate shared by every action: JP health, JP index, Biwenger client.
-
-    Returns `(biwenger, biwenger_players, jp_index)`.
-    """
-    check_api_health(
-        config.JP_AUTH_TOKEN,
-        competition=config.JP_COMPETITION,
-        score_type=config.JP_SCORE_TYPE,
-    )
-    jp_players = fetch_all_players(
-        config.JP_AUTH_TOKEN,
-        competition=config.JP_COMPETITION,
-        score_type=config.JP_SCORE_TYPE,
-    )
-    jp_index = build_jp_index(jp_players)
-
-    biwenger = BiwengerClient(
-        config.BIWENGER_EMAIL,
-        config.BIWENGER_PASSWORD,
-        config.LOGIN_URL,
-        config.ACCOUNT_URL,
-        config.LEAGUE_ID,
-    )
-    biwenger_players = biwenger.get_all_players_data_map(config.ALL_PLAYERS_DATA_URL)
-    return biwenger, biwenger_players, jp_index
-
-
-def _require_telegram() -> tuple[str, str] | None:
-    if not (config.TELEGRAM_BOT_TOKEN and config.TELEGRAM_CHAT_ID):
-        logger.warning("Telegram credentials missing — skipping send.")
-        return None
-    return config.TELEGRAM_BOT_TOKEN, config.TELEGRAM_CHAT_ID
+# Shared setup helpers live in `orchestration` — `build_context()` for the
+# JP+Biwenger combo, `require_telegram()` for the credential gate.
 
 
 def run_teams(manager_id: int | None = None) -> dict:
@@ -128,8 +99,13 @@ def run_teams(manager_id: int | None = None) -> dict:
       Clausulable/Cláusula columns are included for rivals (not for
       yourself — you already know your own clauses).
     """
-    biwenger, biwenger_players, jp_index = _prepare_context()
-    telegram = _require_telegram()
+    ctx = build_context()
+    biwenger, biwenger_players, jp_index = (
+        ctx.biwenger,
+        ctx.biwenger_players,
+        ctx.jp_index,
+    )
+    telegram = require_telegram()
     if telegram is None:
         return {"sent": 0, "reason": "telegram_credentials_missing"}
     token, chat_id = telegram
@@ -215,13 +191,7 @@ def list_managers() -> dict:
     effects — the bot uses the response to build an inline keyboard.
     Mine is flagged so the bot can present it as "🛡️ Mi equipo".
     """
-    biwenger = BiwengerClient(
-        config.BIWENGER_EMAIL,
-        config.BIWENGER_PASSWORD,
-        config.LOGIN_URL,
-        config.ACCOUNT_URL,
-        config.LEAGUE_ID,
-    )
+    biwenger = build_biwenger_session()
     managers = biwenger.get_league_users(config.LEAGUE_DATA_URL)
     items = [
         {"id": mgr_id, "name": name, "is_me": mgr_id == biwenger.user_id}
@@ -233,8 +203,13 @@ def list_managers() -> dict:
 
 def run_market() -> dict:
     """Send only the transfer market — used by /market (was /mercado)."""
-    biwenger, biwenger_players, jp_index = _prepare_context()
-    telegram = _require_telegram()
+    ctx = build_context()
+    biwenger, biwenger_players, jp_index = (
+        ctx.biwenger,
+        ctx.biwenger_players,
+        ctx.jp_index,
+    )
+    telegram = require_telegram()
     if telegram is None:
         return {"sent": 0, "reason": "telegram_credentials_missing"}
     token, chat_id = telegram
@@ -253,8 +228,13 @@ def run_auto_pick_lineup(dry_run: bool = False) -> dict:
     skips the Biwenger PUT and sends the would-be lineup to Telegram as
     a preview — useful before a high-stakes matchday.
     """
-    biwenger, biwenger_players, jp_index = _prepare_context()
-    telegram = _require_telegram()
+    ctx = build_context()
+    biwenger, biwenger_players, jp_index = (
+        ctx.biwenger,
+        ctx.biwenger_players,
+        ctx.jp_index,
+    )
+    telegram = require_telegram()
     if telegram is None:
         return {"sent": 0, "reason": "telegram_credentials_missing"}
     token, chat_id = telegram

--- a/packages/biwenger_tools/api/logic/auto_bid.py
+++ b/packages/biwenger_tools/api/logic/auto_bid.py
@@ -45,19 +45,12 @@ import requests
 
 from core.constants import MADRID_TZ
 from core.sdk import firestore
-from core.sdk.biwenger import BiwengerClient
-from core.sdk.jp import (
-    check_api_health,
-    fetch_all_players,
-    get_predict_rate,
-)
+from core.sdk.jp import get_predict_rate
 from core.sdk.telegram import send_telegram_message_or_raise
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
-from packages.biwenger_tools.api.logic.player_matching import (
-    build_jp_index,
-    find_player_match,
-)
+from packages.biwenger_tools.api.logic.orchestration import build_context
+from packages.biwenger_tools.api.logic.player_matching import find_player_match
 from packages.biwenger_tools.api.player_formatting import SCORE_SF
 
 logger = get_logger(__name__)
@@ -306,32 +299,13 @@ def run_auto_bid() -> dict:
     Biwenger session + N `POST /api/v2/offers`, Firestore writes per
     successful bid, one Telegram message.
     """
-    check_api_health(
-        config.JP_AUTH_TOKEN,
-        competition=config.JP_COMPETITION,
-        score_type=config.JP_SCORE_TYPE,
-    )
-    jp_players = fetch_all_players(
-        config.JP_AUTH_TOKEN,
-        competition=config.JP_COMPETITION,
-        score_type=config.JP_SCORE_TYPE,
-    )
-    jp_index = build_jp_index(jp_players)
+    ctx = build_context()
+    market_players = ctx.biwenger.get_market_players(config.MARKET_URL)
+    candidates = _build_candidates(market_players, ctx.biwenger_players, ctx.jp_index)
 
-    biwenger = BiwengerClient(
-        config.BIWENGER_EMAIL,
-        config.BIWENGER_PASSWORD,
-        config.LOGIN_URL,
-        config.ACCOUNT_URL,
-        config.LEAGUE_ID,
-    )
-    biwenger_players = biwenger.get_all_players_data_map(config.ALL_PLAYERS_DATA_URL)
-    market_players = biwenger.get_market_players(config.MARKET_URL)
-
-    candidates = _build_candidates(market_players, biwenger_players, jp_index)
-
-    account_state = biwenger.get_account_state()
+    account_state = ctx.biwenger.get_account_state()
     remaining_cash = int(account_state.get("cash") or 0)
+    biwenger = ctx.biwenger  # alias for the bid loop below
 
     day = _today_madrid()
     already_bid = _already_bid_ids(day)

--- a/packages/biwenger_tools/api/logic/digests.py
+++ b/packages/biwenger_tools/api/logic/digests.py
@@ -1,24 +1,22 @@
 """Daily digest logic — sends "my team + market + auto-bid summary" to Telegram.
 
 Used by `POST /digests/daily`, which Cloud Scheduler hits once a day. The
-orchestration (JP health check, build index, Biwenger session, send) lives
-here so the Flask handler stays a thin shell that translates HTTP errors.
-
-The auto-bid step is chained at the end on purpose: a single daily cron
+auto-bid step is chained at the end on purpose: a single daily cron
 gives the user a coherent morning message (squad → market → bids) in
 guaranteed order, instead of two independent Scheduler jobs racing.
 """
 
 import time
 
-from core.sdk.biwenger import BiwengerClient
-from core.sdk.jp import check_api_health, fetch_all_players
 from core.sdk.telegram import send_telegram_photo_or_raise
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
 from packages.biwenger_tools.api.logic import auto_bid
 from packages.biwenger_tools.api.logic.image_formatter import build_table_image
-from packages.biwenger_tools.api.logic.player_matching import build_jp_index
+from packages.biwenger_tools.api.logic.orchestration import (
+    build_context,
+    require_telegram,
+)
 from packages.biwenger_tools.api.logic.rows import build_market_rows, build_squad_rows
 
 logger = get_logger(__name__)
@@ -33,63 +31,39 @@ def _send_image(token: str, chat_id: str, image: bytes, caption: str) -> None:
     time.sleep(0.5)
 
 
-def run_daily() -> dict:
-    """Send my squad + market images. Returns a small summary for the response.
-
-    Side effects: hits JP, hits Biwenger, sends 2 PNGs to Telegram.
-    """
-    check_api_health(
-        config.JP_AUTH_TOKEN,
-        competition=config.JP_COMPETITION,
-        score_type=config.JP_SCORE_TYPE,
-    )
-    jp_players = fetch_all_players(
-        config.JP_AUTH_TOKEN,
-        competition=config.JP_COMPETITION,
-        score_type=config.JP_SCORE_TYPE,
-    )
-    jp_index = build_jp_index(jp_players)
-
-    biwenger = BiwengerClient(
-        config.BIWENGER_EMAIL,
-        config.BIWENGER_PASSWORD,
-        config.LOGIN_URL,
-        config.ACCOUNT_URL,
-        config.LEAGUE_ID,
-    )
-    biwenger_players = biwenger.get_all_players_data_map(config.ALL_PLAYERS_DATA_URL)
-
-    if not (config.TELEGRAM_BOT_TOKEN and config.TELEGRAM_CHAT_ID):
-        logger.warning("Telegram credentials missing — skipping send.")
-        return {"sent": 0, "reason": "telegram_credentials_missing"}
-
-    my_squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, biwenger.user_id)
-    my_team = build_squad_rows(my_squad, biwenger_players, jp_index)
-    _send_image(
-        config.TELEGRAM_BOT_TOKEN,
-        config.TELEGRAM_CHAT_ID,
-        build_table_image(my_team, "Mi equipo"),
-        "Mi equipo",
-    )
-
-    market_players = biwenger.get_market_players(config.MARKET_URL)
-    market_rows = build_market_rows(market_players, biwenger_players, jp_index)
-    _send_image(
-        config.TELEGRAM_BOT_TOKEN,
-        config.TELEGRAM_CHAT_ID,
-        build_table_image(market_rows, "Mercado"),
-        "Mercado",
-    )
-
-    # Auto-bid chained as the final step so the chat reads: squad → market →
-    # bid summary in guaranteed order. Wrapped in a broad try/except — a
-    # broken auto-bid run must not lose the digest we already sent above.
-    auto_bid_result: dict
+def _safe_run_auto_bid() -> dict:
+    """Wrap `auto_bid.run_auto_bid` so a broken run does not invalidate
+    the digest we already sent. The error surfaces in the response."""
     try:
-        auto_bid_result = auto_bid.run_auto_bid()
+        return auto_bid.run_auto_bid()
     except Exception as exc:
         logger.exception("Auto-bid step failed inside daily digest.")
-        auto_bid_result = {"error": str(exc)}
+        return {"error": str(exc)}
+
+
+def run_daily() -> dict:
+    """Send my squad + market images, then chain the auto-bid summary.
+
+    Side effects: hits JP, hits Biwenger, sends 2 PNGs + 1 text message
+    to Telegram (via the auto-bid step).
+    """
+    ctx = build_context()
+    telegram = require_telegram()
+    if telegram is None:
+        return {"sent": 0, "reason": "telegram_credentials_missing"}
+    token, chat_id = telegram
+
+    my_squad = ctx.biwenger.get_manager_squad(
+        config.USER_SQUAD_URL, ctx.biwenger.user_id
+    )
+    my_team = build_squad_rows(my_squad, ctx.biwenger_players, ctx.jp_index)
+    _send_image(token, chat_id, build_table_image(my_team, "Mi equipo"), "Mi equipo")
+
+    market_players = ctx.biwenger.get_market_players(config.MARKET_URL)
+    market_rows = build_market_rows(market_players, ctx.biwenger_players, ctx.jp_index)
+    _send_image(token, chat_id, build_table_image(market_rows, "Mercado"), "Mercado")
+
+    auto_bid_result = _safe_run_auto_bid()
 
     logger.info(
         "Daily analysis sent.",

--- a/packages/biwenger_tools/api/logic/orchestration.py
+++ b/packages/biwenger_tools/api/logic/orchestration.py
@@ -1,0 +1,92 @@
+"""Shared boilerplate every action / digest / recommendation needs.
+
+Until 2026-05-24 four call sites (`actions._prepare_context`,
+`digests.run_daily`, `recommendations.run_recommendations`,
+`auto_bid.run_auto_bid`) each reimplemented the same 4-step setup:
+JP health probe + fetch all players + build JP index + open a
+Biwenger session. This module centralises that.
+
+Two entry points cover every caller:
+
+- `build_context()` — full setup (JP + Biwenger session + players map).
+  Used by every endpoint that does real work against the Biwenger /
+  JP graph.
+- `build_biwenger_session()` — Biwenger session only (no JP, no
+  players map). Used by `list_managers` which only needs the league
+  users list.
+
+Plus `require_telegram()` for the same opt-in skip-if-credentials-
+missing branch that every Telegram-emitting handler needs.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from core.sdk.biwenger import BiwengerClient
+from core.sdk.jp import check_api_health, fetch_all_players
+from core.utils import get_logger
+from packages.biwenger_tools.api import config
+from packages.biwenger_tools.api.logic.player_matching import build_jp_index
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class OrchestratorContext:
+    """Bundle of collaborators every endpoint needs.
+
+    `biwenger_players` is the cf-base player database keyed by id —
+    callers should always read prices/positions from here (see memory
+    `project_biwenger_prices` for the cf-base vs owner.price rule).
+    """
+
+    biwenger: BiwengerClient
+    biwenger_players: dict
+    jp_index: dict
+
+
+def build_context() -> OrchestratorContext:
+    """JP health + JP players + JP index + Biwenger session + players map."""
+    check_api_health(
+        config.JP_AUTH_TOKEN,
+        competition=config.JP_COMPETITION,
+        score_type=config.JP_SCORE_TYPE,
+    )
+    jp_players = fetch_all_players(
+        config.JP_AUTH_TOKEN,
+        competition=config.JP_COMPETITION,
+        score_type=config.JP_SCORE_TYPE,
+    )
+    jp_index = build_jp_index(jp_players)
+
+    biwenger = build_biwenger_session()
+    biwenger_players = biwenger.get_all_players_data_map(config.ALL_PLAYERS_DATA_URL)
+    return OrchestratorContext(
+        biwenger=biwenger,
+        biwenger_players=biwenger_players,
+        jp_index=jp_index,
+    )
+
+
+def build_biwenger_session() -> BiwengerClient:
+    """Biwenger session only — for handlers that don't need JP / player map."""
+    return BiwengerClient(
+        config.BIWENGER_EMAIL,
+        config.BIWENGER_PASSWORD,
+        config.LOGIN_URL,
+        config.ACCOUNT_URL,
+        config.LEAGUE_ID,
+    )
+
+
+def require_telegram() -> Optional[Tuple[str, str]]:
+    """Return `(bot_token, chat_id)` if both are configured, else None.
+
+    A None return is the signal handlers use to short-circuit before
+    doing any work — useful in local dev where Telegram credentials
+    are intentionally empty.
+    """
+    if not (config.TELEGRAM_BOT_TOKEN and config.TELEGRAM_CHAT_ID):
+        logger.warning("Telegram credentials missing — skipping send.")
+        return None
+    return config.TELEGRAM_BOT_TOKEN, config.TELEGRAM_CHAT_ID

--- a/packages/biwenger_tools/api/logic/recommendations.py
+++ b/packages/biwenger_tools/api/logic/recommendations.py
@@ -18,11 +18,14 @@ import time
 from typing import Optional
 
 from core.sdk.biwenger import BiwengerClient
-from core.sdk.jp import check_api_health, fetch_all_players, get_predict_rate
+from core.sdk.jp import get_predict_rate
 from core.sdk.telegram import send_telegram_message_or_raise
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
-from packages.biwenger_tools.api.logic.player_matching import build_jp_index
+from packages.biwenger_tools.api.logic.orchestration import (
+    build_context,
+    require_telegram,
+)
 from packages.biwenger_tools.api.logic.rows import build_squad_rows
 from packages.biwenger_tools.api.player_formatting import POSITION_SHORT, SCORE_SF
 
@@ -236,34 +239,16 @@ def run_recommendations(
     caller passes an explicit value, that value wins (after clamping
     happens in the route handler).
     """
-    check_api_health(
-        config.JP_AUTH_TOKEN,
-        competition=config.JP_COMPETITION,
-        score_type=config.JP_SCORE_TYPE,
-    )
-    jp_players = fetch_all_players(
-        config.JP_AUTH_TOKEN,
-        competition=config.JP_COMPETITION,
-        score_type=config.JP_SCORE_TYPE,
-    )
-    jp_index = build_jp_index(jp_players)
+    ctx = build_context()
 
-    biwenger = BiwengerClient(
-        config.BIWENGER_EMAIL,
-        config.BIWENGER_PASSWORD,
-        config.LOGIN_URL,
-        config.ACCOUNT_URL,
-        config.LEAGUE_ID,
+    # Fetch my squad once: needed for max_bid AND to mark my players as
+    # excluded from the rival pool.
+    my_squad = ctx.biwenger.get_manager_squad(
+        config.USER_SQUAD_URL, ctx.biwenger.user_id
     )
-    biwenger_players = biwenger.get_all_players_data_map(config.ALL_PLAYERS_DATA_URL)
-
-    # Fetch my squad once: needed to compute max_bid AND to mark my players
-    # as excluded from the rival pool. We hit /user/{me}?fields=players(*)
-    # via the same paginated client method as the rest.
-    my_squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, biwenger.user_id)
     my_ids = {p.get("id") for p in my_squad if p.get("id") is not None}
 
-    account_state = biwenger.get_account_state(my_squad, biwenger_players)
+    account_state = ctx.biwenger.get_account_state(my_squad, ctx.biwenger_players)
     cash, max_bid = account_state["cash"], account_state["max_bid"]
 
     margin_source = "auto" if margin is None else "manual"
@@ -272,7 +257,7 @@ def run_recommendations(
     margin = max(0, margin)
     target = cash + margin
 
-    rivals = _gather_rivals(biwenger, biwenger_players, jp_index)
+    rivals = _gather_rivals(ctx.biwenger, ctx.biwenger_players, ctx.jp_index)
     affordable = _filter_affordable(rivals, my_ids, target)
     recommendations = _pick_top_per_position(affordable, top)
 
@@ -299,14 +284,11 @@ def run_recommendations(
         },
     )
 
-    if not (config.TELEGRAM_BOT_TOKEN and config.TELEGRAM_CHAT_ID):
-        logger.warning("Telegram credentials missing — skipping send.")
+    telegram = require_telegram()
+    if telegram is None:
         return {"sent": 0, **payload}
+    token, chat_id = telegram
 
     text = _format_telegram_text(payload)
-    send_telegram_message_or_raise(
-        bot_token=config.TELEGRAM_BOT_TOKEN,
-        chat_id=config.TELEGRAM_CHAT_ID,
-        text=text,
-    )
+    send_telegram_message_or_raise(bot_token=token, chat_id=chat_id, text=text)
     return {"sent": 1, **payload}

--- a/packages/biwenger_tools/api/tests/test_auto_bid.py
+++ b/packages/biwenger_tools/api/tests/test_auto_bid.py
@@ -320,11 +320,21 @@ def run_env():
     ):
         stack = ExitStack()
         mock_cfg = stack.enter_context(patch(_patches("config")))
-        stack.enter_context(patch(_patches("check_api_health")))
-        stack.enter_context(
-            patch(_patches("fetch_all_players"), return_value=jp_players)
+        # `build_context()` returns the full orchestration context — patch
+        # it once and feed a mock-Biwenger through. Beats patching the four
+        # individual JP / Biwenger setup calls separately.
+        biwenger = MagicMock()
+        from packages.biwenger_tools.api.logic.orchestration import (
+            OrchestratorContext,
         )
-        mock_client_cls = stack.enter_context(patch(_patches("BiwengerClient")))
+        from packages.biwenger_tools.api.logic.player_matching import build_jp_index
+
+        ctx = OrchestratorContext(
+            biwenger=biwenger,
+            biwenger_players=biwenger_players,
+            jp_index=build_jp_index(jp_players),
+        )
+        stack.enter_context(patch(_patches("build_context"), return_value=ctx))
         stack.enter_context(
             patch(
                 _patches("_already_bid_ids"),
@@ -339,20 +349,10 @@ def run_env():
             patch(_patches("send_telegram_message_or_raise"))
         )
 
-        mock_cfg.JP_AUTH_TOKEN = "tok"
-        mock_cfg.JP_COMPETITION = 1
-        mock_cfg.JP_SCORE_TYPE = 2
-        mock_cfg.BIWENGER_EMAIL = "u"
-        mock_cfg.BIWENGER_PASSWORD = "p"
-        mock_cfg.LOGIN_URL = mock_cfg.ACCOUNT_URL = "x"
-        mock_cfg.LEAGUE_ID = "1"
-        mock_cfg.ALL_PLAYERS_DATA_URL = "x"
         mock_cfg.MARKET_URL = "x"
         mock_cfg.TELEGRAM_BOT_TOKEN = "tok" if telegram else ""
         mock_cfg.TELEGRAM_CHAT_ID = "chat" if telegram else ""
 
-        biwenger = mock_client_cls.return_value
-        biwenger.get_all_players_data_map.return_value = biwenger_players
         biwenger.get_market_players.return_value = market_players
         biwenger.get_account_state.return_value = {"cash": cash, "max_bid": cash}
         if bid_side_effect is not None:

--- a/packages/biwenger_tools/api/tests/test_digests.py
+++ b/packages/biwenger_tools/api/tests/test_digests.py
@@ -6,37 +6,35 @@ its swallow-on-failure behaviour. The HTTP route is tested in
 """
 
 from contextlib import ExitStack
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
 def _patches(target):
     return f"packages.biwenger_tools.api.logic.digests.{target}"
 
 
+def _build_ctx(biwenger):
+    """Wrap a Biwenger mock in an OrchestratorContext for `build_context` to
+    return. Pulled out so every test stays on the same wiring."""
+    from packages.biwenger_tools.api.logic.orchestration import OrchestratorContext
+
+    return OrchestratorContext(
+        biwenger=biwenger,
+        biwenger_players={},
+        jp_index={"by_name": {}, "by_slug": {}},
+    )
+
+
 def test_run_daily_skips_send_when_telegram_creds_missing():
+    biwenger = MagicMock()
+    biwenger.user_id = 1
     with patch(_patches("config")) as mock_cfg, patch(
-        _patches("check_api_health")
-    ), patch(_patches("fetch_all_players"), return_value=[]), patch(
-        _patches("build_jp_index"), return_value={"by_name": {}, "by_slug": {}}
-    ), patch(
-        _patches("BiwengerClient")
-    ) as mock_client, patch(
+        _patches("build_context"), return_value=_build_ctx(biwenger)
+    ), patch(_patches("require_telegram"), return_value=None) as mock_creds, patch(
         _patches("_send_image")
     ) as mock_send:
-        mock_cfg.JP_AUTH_TOKEN = "tok"
-        mock_cfg.JP_COMPETITION = 1
-        mock_cfg.JP_SCORE_TYPE = 2
-        mock_cfg.BIWENGER_EMAIL = "u"
-        mock_cfg.BIWENGER_PASSWORD = "p"
-        mock_cfg.LOGIN_URL = mock_cfg.ACCOUNT_URL = "x"
-        mock_cfg.LEAGUE_ID = "1"
-        mock_cfg.ALL_PLAYERS_DATA_URL = "x"
         mock_cfg.USER_SQUAD_URL = "x/{manager_id}"
         mock_cfg.MARKET_URL = "x"
-        mock_cfg.TELEGRAM_BOT_TOKEN = ""
-        mock_cfg.TELEGRAM_CHAT_ID = ""
-        mock_client.return_value.user_id = 1
-        mock_client.return_value.get_all_players_data_map.return_value = {}
 
         from packages.biwenger_tools.api.logic import digests
 
@@ -44,22 +42,25 @@ def test_run_daily_skips_send_when_telegram_creds_missing():
     assert result["sent"] == 0
     assert result["reason"] == "telegram_credentials_missing"
     mock_send.assert_not_called()
+    mock_creds.assert_called_once()
 
 
 def _digest_env(*, auto_bid_result=None, auto_bid_raises=None):
-    """Helper: wire `run_daily`'s collaborators so only auto_bid varies.
-
-    Returns the entered ExitStack — the caller must close it. Designed
-    for the two tests below that pin the chaining behaviour.
-    """
+    """Helper: wire `run_daily`'s collaborators so only auto_bid varies."""
     stack = ExitStack()
     mock_cfg = stack.enter_context(patch(_patches("config")))
-    stack.enter_context(patch(_patches("check_api_health")))
-    stack.enter_context(patch(_patches("fetch_all_players"), return_value=[]))
+    biwenger = MagicMock()
+    biwenger.user_id = 1
+    biwenger.get_manager_squad.return_value = []
+    biwenger.get_market_players.return_value = []
     stack.enter_context(
-        patch(_patches("build_jp_index"), return_value={"by_name": {}, "by_slug": {}})
+        patch(_patches("build_context"), return_value=_build_ctx(biwenger))
     )
-    mock_client = stack.enter_context(patch(_patches("BiwengerClient")))
+    # `require_telegram` reads orchestration.config — patch the helper itself
+    # to dodge the cross-module config indirection.
+    stack.enter_context(
+        patch(_patches("require_telegram"), return_value=("tok", "chat"))
+    )
     mock_send = stack.enter_context(patch(_patches("_send_image")))
     # `build_table_image` runs synchronously before `_send_image` — patching
     # the renderer avoids matplotlib choking on the empty-row stub data.
@@ -73,22 +74,8 @@ def _digest_env(*, auto_bid_result=None, auto_bid_raises=None):
             patch(_patches("auto_bid.run_auto_bid"), return_value=auto_bid_result or {})
         )
 
-    mock_cfg.JP_AUTH_TOKEN = "tok"
-    mock_cfg.JP_COMPETITION = 1
-    mock_cfg.JP_SCORE_TYPE = 2
-    mock_cfg.BIWENGER_EMAIL = "u"
-    mock_cfg.BIWENGER_PASSWORD = "p"
-    mock_cfg.LOGIN_URL = mock_cfg.ACCOUNT_URL = "x"
-    mock_cfg.LEAGUE_ID = "1"
-    mock_cfg.ALL_PLAYERS_DATA_URL = "x"
     mock_cfg.USER_SQUAD_URL = "x/{manager_id}"
     mock_cfg.MARKET_URL = "x"
-    mock_cfg.TELEGRAM_BOT_TOKEN = "tok"
-    mock_cfg.TELEGRAM_CHAT_ID = "chat"
-    mock_client.return_value.user_id = 1
-    mock_client.return_value.get_all_players_data_map.return_value = {}
-    mock_client.return_value.get_manager_squad.return_value = []
-    mock_client.return_value.get_market_players.return_value = []
     return stack, mock_send, mock_auto_bid
 
 


### PR DESCRIPTION
Closes the largest refactor item from PENDING.md. Four endpoints (`run_teams`, `run_auto_pick_lineup`, `run_daily`, `run_recommendations`, `run_auto_bid`) each reimplemented the same JP+Biwenger setup; now they all go through `orchestration.build_context()` + `require_telegram()`.

LOC drops in actions / auto_bid / digests / recommendations sum to -84; orchestration adds 92 → net -8 with a single source of truth. Tests patch `build_context` directly instead of the underlying primitives — shorter and robust to future changes.