### PR TITLE
chore: finalize STATUS + PENDING after closing every audit follow-up

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -17,32 +17,6 @@ Long-running follow-ups that don't yet warrant a plan or PR.
   drop the `biwenger-tools-sa-regional` secret or repoint it to a Sheets-only SA
   (Sheets API still authenticates through that mount for `ligas_especiales` /
   `trofeos`).
-- **Standardise language in code** — comments, docstrings, variable names and log
-  messages should be English everywhere. Telegram user-facing strings stay in
-  Spanish (intentional, user-facing). Today there's a mix (some Spanish in
-  variable names, ES/EN mixed in log messages).
-- **Retry helper + apply consistently to outbound Biwenger POSTs** — today only
-  `set_lineup` retries (hand-coded `_LINEUP_RETRY_BACKOFFS`). `place_market_bid`
-  and the rest fail-fast on 5xx, which masks transient Biwenger blips. Wrap in a
-  shared helper (tenacity or homegrown) and apply consistently.
-- **Define an SLO + document it** — target ~5 min end-to-end for the daily
-  process (JP fetch + Biwenger session + market read + N bids + Telegram). Land
-  in `CLAUDE.md` or a new `docs/slo.md`. Today there's no articulated contract,
-  so "system OK" is undefined.
-- **Audit Claude memory** (`~/.claude/projects/-Users-jorge-Projects-lillorepo/memory/`) —
-  promote anything load-bearing into `CLAUDE.md`; delete entries we've stopped
-  using. Single source of truth principle, applied to memory.
-
-## biwenger_tools/api
-
-- **Refactor long orchestration functions** — `run_auto_bid` (166 LOC),
-  `run_auto_pick_lineup` (207 LOC) and `run_daily` (121 LOC) each mix
-  setup + business logic + side effects + error handling. Extract a
-  `_OrchestratorContext` (JP+Biwenger+Firestore) and pure helpers so the
-  orchestration is testable in isolation.
-- **Split `test_api.py`** (~757 LOC) into focused files: `test_routes.py`,
-  `test_recommendations.py`, `test_digests.py`. The auto-bid tests already
-  live in `test_auto_bid.py` — same pattern for the rest.
 
 ## my_photos
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,10 +3,13 @@
 Living maturity report for `lillorepo`. Updated as items from `PENDING.md` ship.
 For a feature-by-feature timeline, read `packages/biwenger_tools/release-notes.md`.
 
-**Current score: 8.7 / 10** (post bot reply-keyboard + Telegram-fail propagation across all callers).
-**Projected score after the PENDING follow-ups: ~9.45 / 10.**
+**Current score: 9.4 / 10** (every PENDING follow-up shipped: orchestration
+refactor, retry helper, Telegram-fail propagation, test_api split, language
+standardisation, SLO doc, memory audit, reply keyboard, bot setup unification).
+**Cap under current constraints: ~9.5 / 10.**
 
-The remaining 0.55 is a deliberate cap (see _Accepted gaps_ below).
+The remaining 0.1 is a deliberate cap (see _Accepted gaps_ below) — closing
+it would require leaving the €0/month free tier.
 
 ---
 


### PR DESCRIPTION
Docs-only. Score moves 8.7 → 9.4. PENDING.md slims to the 2 genuinely open items (Drive cleanup + photo project pointer).