### PR TITLE
chore: trim verbose comments + fix scraper clausulazos count to NEW only

### DIFF
--- a/core/sdk/http.py
+++ b/core/sdk/http.py
@@ -1,17 +1,6 @@
 """HTTP utilities shared by SDK clients.
 
-Currently exposes `retry_http_request`: a single retry loop that wraps
-calls against external APIs we don't own (Biwenger, JP, Telegram).
-
-The retry policy is opinionated for this kind of caller:
-- **Retried**: network errors (timeout, connection reset, DNS) and 5xx
-  responses — the server might recover on the next attempt.
-- **Fail-fast**: 4xx responses — they won't get better; the request is
-  semantically wrong.
-
-Why a shared helper instead of a library: keeps the dep footprint
-small (we already use `requests`, no need for tenacity/backoff) and
-gives every SDK the same observable behaviour in Cloud Logging.
+`retry_http_request` retries on network errors + 5xx, fails fast on 4xx.
 """
 
 import time

--- a/core/sdk/telegram.py
+++ b/core/sdk/telegram.py
@@ -141,13 +141,7 @@ def send_telegram_photo(
 
 
 class TelegramDeliveryError(RuntimeError):
-    """Raised by the `_or_raise` helpers when Telegram refuses delivery.
-
-    Surfaces upstream so route handlers can return 500 and the bot can
-    post a fallback plaintext error to the user. Catch this specifically
-    (not bare `Exception`) when you need to differentiate Telegram
-    failures from upstream Biwenger/JP failures.
-    """
+    """Raised by the `_or_raise` helpers when Telegram refuses delivery."""
 
 
 def send_telegram_message_or_raise(
@@ -158,9 +152,7 @@ def send_telegram_message_or_raise(
     disable_web_page_preview: bool = True,
     reply_markup: Optional[dict] = None,
 ) -> None:
-    """`send_telegram_message` that raises `TelegramDeliveryError` on
-    failure. Use this when the caller is a request handler that should
-    surface delivery failures as a non-2xx response."""
+    """`send_telegram_message` that raises `TelegramDeliveryError` on failure."""
     if not send_telegram_message(
         bot_token=bot_token,
         chat_id=chat_id,
@@ -178,21 +170,15 @@ def send_telegram_photo_or_raise(
     image_bytes: bytes,
     caption: str = "",
 ) -> None:
-    """`send_telegram_photo` that raises `TelegramDeliveryError` on
-    failure. Use in request handlers; the route returns 5xx and the
-    bot tells the user."""
+    """`send_telegram_photo` that raises `TelegramDeliveryError` on failure."""
     if not send_telegram_photo(bot_token, chat_id, image_bytes, caption):
         raise TelegramDeliveryError("Telegram photo delivery failed")
 
 
 def build_persistent_reply_keyboard(labels: list[str], cols: int = 2) -> dict:
-    """Build a `ReplyKeyboardMarkup` dict laid out in `cols` columns.
-
-    Pinned via `is_persistent: true` so it stays below the input across
-    messages; `resize_keyboard: true` lets clients shrink button height
-    when the device is narrow. Tapping a button posts its label as a
-    plain text message — the webhook caller routes that text by exact
-    match. Shared by every bot that needs a native-feeling button menu.
+    """`ReplyKeyboardMarkup` laid out in `cols` columns, pinned via
+    `is_persistent: true`. Tapping a button posts its label as plain
+    text — webhook callers route by exact match.
     """
     rows = [labels[i : i + cols] for i in range(0, len(labels), cols)]
     return {

--- a/packages/biwenger_tools/api/logic/auto_bid.py
+++ b/packages/biwenger_tools/api/logic/auto_bid.py
@@ -300,12 +300,11 @@ def run_auto_bid() -> dict:
     successful bid, one Telegram message.
     """
     ctx = build_context()
-    market_players = ctx.biwenger.get_market_players(config.MARKET_URL)
+    biwenger = ctx.biwenger
+    market_players = biwenger.get_market_players(config.MARKET_URL)
     candidates = _build_candidates(market_players, ctx.biwenger_players, ctx.jp_index)
 
-    account_state = ctx.biwenger.get_account_state()
-    remaining_cash = int(account_state.get("cash") or 0)
-    biwenger = ctx.biwenger  # alias for the bid loop below
+    remaining_cash = int(biwenger.get_account_state().get("cash") or 0)
 
     day = _today_madrid()
     already_bid = _already_bid_ids(day)

--- a/packages/biwenger_tools/api/logic/digests.py
+++ b/packages/biwenger_tools/api/logic/digests.py
@@ -32,8 +32,7 @@ def _send_image(token: str, chat_id: str, image: bytes, caption: str) -> None:
 
 
 def _safe_run_auto_bid() -> dict:
-    """Wrap `auto_bid.run_auto_bid` so a broken run does not invalidate
-    the digest we already sent. The error surfaces in the response."""
+    """Run auto-bid but never raise — the digest above already shipped."""
     try:
         return auto_bid.run_auto_bid()
     except Exception as exc:

--- a/packages/biwenger_tools/api/logic/orchestration.py
+++ b/packages/biwenger_tools/api/logic/orchestration.py
@@ -1,22 +1,10 @@
-"""Shared boilerplate every action / digest / recommendation needs.
+"""Shared setup for endpoints that talk to JP + Biwenger.
 
-Until 2026-05-24 four call sites (`actions._prepare_context`,
-`digests.run_daily`, `recommendations.run_recommendations`,
-`auto_bid.run_auto_bid`) each reimplemented the same 4-step setup:
-JP health probe + fetch all players + build JP index + open a
-Biwenger session. This module centralises that.
-
-Two entry points cover every caller:
-
-- `build_context()` — full setup (JP + Biwenger session + players map).
-  Used by every endpoint that does real work against the Biwenger /
-  JP graph.
-- `build_biwenger_session()` — Biwenger session only (no JP, no
-  players map). Used by `list_managers` which only needs the league
-  users list.
-
-Plus `require_telegram()` for the same opt-in skip-if-credentials-
-missing branch that every Telegram-emitting handler needs.
+- `build_context()` — full setup: JP health probe, JP index,
+  Biwenger session, players map.
+- `build_biwenger_session()` — Biwenger only, for handlers that
+  don't need JP.
+- `require_telegram()` — `(token, chat_id)` if configured, else None.
 """
 
 from dataclasses import dataclass
@@ -36,8 +24,8 @@ class OrchestratorContext:
     """Bundle of collaborators every endpoint needs.
 
     `biwenger_players` is the cf-base player database keyed by id —
-    callers should always read prices/positions from here (see memory
-    `project_biwenger_prices` for the cf-base vs owner.price rule).
+    callers must read prices and positions from here (the per-league
+    `owner.price` is unreliable for server-side caps).
     """
 
     biwenger: BiwengerClient
@@ -80,12 +68,7 @@ def build_biwenger_session() -> BiwengerClient:
 
 
 def require_telegram() -> Optional[Tuple[str, str]]:
-    """Return `(bot_token, chat_id)` if both are configured, else None.
-
-    A None return is the signal handlers use to short-circuit before
-    doing any work — useful in local dev where Telegram credentials
-    are intentionally empty.
-    """
+    """Return `(bot_token, chat_id)` if both are configured, else None."""
     if not (config.TELEGRAM_BOT_TOKEN and config.TELEGRAM_CHAT_ID):
         logger.warning("Telegram credentials missing — skipping send.")
         return None

--- a/packages/biwenger_tools/scraper_job/main.py
+++ b/packages/biwenger_tools/scraper_job/main.py
@@ -122,20 +122,32 @@ def _write_collection(collection: str, pairs: list[tuple[str, dict]]) -> None:
     )
 
 
+def _existing_clausulazo_ids(season: str) -> set[str]:
+    """Doc ids of clausulazos already in Firestore for the season."""
+    collection = firestore.get_client().collection(f"clausulazos/{season}/transfers")
+    return {snap.id for snap in collection.select([]).stream()}
+
+
 def _write_clausulazos_and_tabla(biwenger: BiwengerClient, cfg) -> int:
     """Pull the clausulazos feed, derive the justice table, write both.
 
-    Returns the total number of clausulazos written so `main()` can
-    surface the count in the Telegram notify.
+    Returns the number of clausulazos that did not exist in Firestore
+    before this run (i.e. new since the last scraper execution).
     """
     logger.info("Processing clausulazos...")
     players_map = biwenger.get_all_players_data_map(cfg.ALL_PLAYERS_DATA_URL)
     raw = biwenger.get_all_clausulazos(cfg.CLAUSULAZOS_URL)
     clausulazos = parse_clausulazos(raw, players_map)
     tabla_justicia = build_tabla_justicia(clausulazos)
-    logger.info("Clausulazos processed.", extra={"count": len(clausulazos)})
 
     season = cfg.TEMPORADA_ACTUAL
+    existing_ids = _existing_clausulazo_ids(season)
+    new_count = sum(1 for c in clausulazos if _clausulazo_doc_id(c) not in existing_ids)
+    logger.info(
+        "Clausulazos processed.",
+        extra={"total": len(clausulazos), "new": new_count},
+    )
+
     _write_collection(
         f"clausulazos/{season}/transfers",
         [(_clausulazo_doc_id(c), c.to_firestore()) for c in clausulazos],
@@ -145,7 +157,7 @@ def _write_clausulazos_and_tabla(biwenger: BiwengerClient, cfg) -> int:
         [(e.equipo, e.to_firestore()) for e in tabla_justicia if e.equipo],
     )
     logger.info("Clausulazos and tabla_justicia written to Firestore.")
-    return len(clausulazos)
+    return new_count
 
 
 def _notify(text: str) -> None:
@@ -221,8 +233,11 @@ def main() -> None:
         messages_part = f"{new_count} mensaje{msg_s} nuevo{msg_s}"
     else:
         messages_part = "sin mensajes nuevos"
-    cl_s = "s" if clausulazos_count != 1 else ""
-    clausulazos_part = f"{clausulazos_count} clausulazo{cl_s}"
+    if clausulazos_count > 0:
+        cl_s = "s" if clausulazos_count != 1 else ""
+        clausulazos_part = f"{clausulazos_count} clausulazo{cl_s} nuevo{cl_s}"
+    else:
+        clausulazos_part = "sin clausulazos nuevos"
     body = (
         f"🧹 <b>Scraper OK</b> · {messages_part} · "
         f"{clausulazos_part} · {elapsed:.0f}s"

--- a/packages/biwenger_tools/scraper_job/tests/test_main.py
+++ b/packages/biwenger_tools/scraper_job/tests/test_main.py
@@ -160,8 +160,9 @@ def test_main_sends_telegram_on_success(mock_external_deps):
     text = mock_send.call_args.kwargs.get("text", "")
     assert "Scraper OK" in text
     assert "sin mensajes nuevos" in text
-    # Clausulazos count is always reported, even when 0.
-    assert "0 clausulazos" in text
+    # New-clausulazos count is always reported; the test mock returns
+    # an empty clausulazos feed so the count is 0.
+    assert "sin clausulazos nuevos" in text
 
 
 def test_main_sends_telegram_and_reraises_on_error(mock_external_deps):


### PR DESCRIPTION
Two quick fixes spotted in review:

1. **Comments** — drop dated narrative ("Until 2026-05-24") and over-explained docstrings introduced in recent refactor PRs. Keep technical contracts only.
2. **Scraper notify** — "109 clausulazos" was the TOTAL in the feed, not new since last run. Now reads existing doc ids from Firestore before the wipe+bulk-write and reports only what is new (same shape as the message-count copy).