### PR TITLE
feat(palmares): per-user richer card + season-rollover automation + scraper cronica fix

### DIFF
--- a/.claude/skills/season-rollover/SKILL.md
+++ b/.claude/skills/season-rollover/SKILL.md
@@ -40,60 +40,75 @@ list unless a future grep finds new references.
 
 Extract the current season value from `deploy.yml`. If the new season matches the current one, warn the user and stop.
 
-# Step 2b — Generate palmares rows for the ending season
+# Step 2b — Generate the palmares Firestore doc for the ending season
 
-Before changing any files, fetch end-of-season data from the Biwenger API and produce the
-CSV rows the user needs to paste into `palmares.csv` in Google Drive
-(filename is `config.PALMARES_FILENAME` — currently `palmares.csv`).
+Before changing any files, fetch end-of-season data from the Biwenger API and write
+the Firestore document at `palmares/<season>` with the full per-user standings table.
+Firestore is the only destination — the web reads from there directly.
 
 ## Precondition check
 
-Look for `BIWENGER_EMAIL`, `BIWENGER_PASSWORD`, and `LEAGUE_ID` in the environment or in
-`packages/biwenger_tools/web/.env`. If any are missing, skip the auto-fetch entirely and
-tell the user they will need to fill in the palmares rows manually.
+Look for `BIWENGER_EMAIL` and `BIWENGER_PASSWORD` in the environment or in
+`packages/biwenger_tools/scraper_job/.env` (the api module's .env works too —
+they share the same Biwenger credentials). `LEAGUE_ID` defaults to
+`core.constants.LEAGUE_ID` if not set in the environment. If the Biwenger
+credentials are missing, skip the auto-fetch entirely and tell the user
+they will need to write the palmares doc manually in the Firestore console.
+
+For `--write-firestore` the script needs ADC: a local `gcloud auth
+application-default login` against the project that hosts the palmares
+Firestore (the same one the web reads from).
+
+## Ask about abandoned accounts
+
+Before running the fetch, ask the user if anyone deleted their Biwenger account during
+the season — those accounts disappear from the standings/report APIs, so they need to be
+injected manually. Collect a list of `NAME=TEAM=REASON` triples — the team is the
+Biwenger team name the abandoned account had (so the palmarés card still shows it);
+leave the team slot empty if unknown.
 
 ## Auto-fetch
 
-If credentials are available, run the fetch script:
+If credentials are available, source the env file and run the fetch script. Pass each
+abandoned account with one `--abandoned-user` flag. First run without
+`--write-firestore` so the user can review the JSON preview, then re-run with the
+flag to push:
 
 ```bash
-cd <repo_root>
-BIWENGER_EMAIL=<email> BIWENGER_PASSWORD=<password> LEAGUE_ID=<id> \
-  python .claude/skills/season-rollover/scripts/fetch_palmares.py <current_season>
+set -a && source packages/biwenger_tools/scraper_job/.env && set +a
+
+# Preview (no Firestore write)
+python .claude/skills/season-rollover/scripts/fetch_palmares.py <current_season> \
+  --abandoned-user "Alberto=#NOALOSCLAUSULAZOS=abandono"
+
+# Push to Firestore once the preview looks right
+python .claude/skills/season-rollover/scripts/fetch_palmares.py <current_season> \
+  --abandoned-user "Alberto=#NOALOSCLAUSULAZOS=abandono" \
+  --write-firestore
 ```
 
-Or, if `.env` files are present, source them first:
+The script combines three Biwenger endpoints (standings, report/rounds,
+report/roundPoints) and outputs two blocks:
 
-```bash
-set -a && source packages/biwenger_tools/web/.env && set +a
-python .claude/skills/season-rollover/scripts/fetch_palmares.py <current_season>
-```
+1. **Firestore doc preview** — the full document at `palmares/<season>` with the
+   per-user standings table (points, best/worst round, rounds won, average position).
+2. **Per-user table** — terminal-friendly summary.
 
-The script outputs ready-to-paste CSV rows for:
-- `campeon`, `subcampeon`, `tercero`, `farolillo`, `puntuacion` — from standings API
-- `clausulazos_total` — count of all release-clause transfers this season
-- Placeholder rows for `record_puntos`, `jornadas_ganadas`, `multa`, `sancion` (manual)
+If the script fails (auth error, network issue), continue with the rollover anyway
+and tell the user to write the doc manually in the Firestore console under
+`palmares/<season>`. The required field shape is documented in `core.domain.models`
+(`Palmares.to_firestore()` / `SeasonStanding.to_firestore()`).
 
-If the script fails (auth error, network issue), continue with the rollover anyway.
-Warn the user and print a blank template they can fill in manually:
-
-```
-<season>,campeon,RELLENAR
-<season>,subcampeon,RELLENAR
-<season>,tercero,RELLENAR
-<season>,puntuacion,RELLENAR
-<season>,farolillo,RELLENAR
-<season>,clausulazos_total,RELLENAR
-<season>,record_puntos,"RELLENAR — Jugador — X puntos (JY)"
-<season>,jornadas_ganadas,"RELLENAR — Jugador — N jornadas"
-<season>,multa,RELLENAR_O_BORRAR
-<season>,sancion,RELLENAR_O_BORRAR
-```
+If `palmares/<season>` already exists, `--write-firestore` refuses to overwrite
+and exits non-zero with a clear message. Add `--force` if a deliberate rewrite
+is needed (e.g. you corrected an `--abandoned-user` typo and want to push the
+fix). Default behaviour is "write once, never clobber".
 
 ## Output
 
-Present the rows to the user in the response. They paste them manually at the end of
-`palmares.csv` in Google Drive. Do not upload or modify Drive files automatically.
+Show the user the Firestore doc preview and the per-user table. If `--write-firestore`
+landed, mention the doc has been written; otherwise tell them to either re-run with
+the flag or paste the JSON in the Firestore console manually.
 
 # Step 3 — Create a branch
 
@@ -166,9 +181,9 @@ Automated changes prepared by the `season-rollover` skill.
 ### Not included (local only, gitignored)
 - `web/.env` and `scraper_job/.env` — updated locally, not committed
 
-### Palmares rows (paste manually into Drive)
-The CSV rows for the ending season were generated by `fetch_palmares.py` and are printed
-above. Paste them at the end of `palmares.csv` in Google Drive before or after merging.
+### Palmares
+The Firestore doc `palmares/<current>` was written by `fetch_palmares.py` (or printed
+above for manual paste into the Firestore console if `--write-firestore` was skipped).
 
 ### After merging
 CI will deploy both services automatically with `TEMPORADA_ACTUAL=<new>`.

--- a/.claude/skills/season-rollover/scripts/fetch_palmares.py
+++ b/.claude/skills/season-rollover/scripts/fetch_palmares.py
@@ -1,46 +1,319 @@
+"""Fetch end-of-season palmares data and write the palmarés record.
+
+Combines three Biwenger endpoints for the current season:
+
+  * standings        — final position, team name, total points
+  * report/rounds    — jornadas ganadas + posición media (per user)
+  * report/roundPoints — total points, mejor jornada, peor jornada (per user)
+
+Resolves real names by user_id via ``core.constants.LEAGUE_MEMBERS``. Emits:
+
+  * A pretty-printed Firestore document preview (the doc the web reads from)
+  * A per-user summary table for terminal review
+  * Optionally writes the doc to Firestore at ``palmares/<season>``
+
+Usage::
+
+    python fetch_palmares.py <season> \\
+        [--abandoned-user "<real_name>=<reason>"]... \\
+        [--write-firestore]
+
+Required env (Biwenger): BIWENGER_EMAIL, BIWENGER_PASSWORD.
+``LEAGUE_ID`` defaults to ``core.constants.LEAGUE_ID``.
+Required env (--write-firestore): GOOGLE_CLOUD_PROJECT (e.g. biwenger-tools).
+
+The --abandoned-user flag injects a row at the bottom of the standings table
+for accounts deleted mid-season (the user_id is no longer in Biwenger). Use
+it once per abandoned member with the shape ``NAME=TEAM=REASON``, e.g.
+``--abandoned-user "Alberto=#NOALOSCLAUSULAZOS=abandono"``. Leave the team
+slot empty if unknown: ``"Someone==abandono"``.
 """
-Fetch end-of-season palmares data from the Biwenger API and emit CSV rows.
 
-Usage:
-    python .claude/skills/season-rollover/scripts/fetch_palmares.py <season>
-
-Example:
-    python .claude/skills/season-rollover/scripts/fetch_palmares.py 25-26
-
-Required env vars (same as scraper_job):
-    BIWENGER_EMAIL, BIWENGER_PASSWORD, LEAGUE_ID
-
-Outputs ready-to-paste CSV rows to stdout. Read-only — touches nothing in Biwenger.
-"""
-
+import argparse
+import json
 import os
 import sys
 
 # Allow running from repo root without installing packages.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../../"))
 
+from core.constants import LEAGUE_ID as DEFAULT_LEAGUE_ID  # noqa: E402
+from core.constants import LEAGUE_MEMBERS  # noqa: E402
+from core.domain.models import Palmares, SeasonStanding  # noqa: E402
 from core.sdk.biwenger import (  # noqa: E402
-    BiwengerClient,
-    LOGIN_URL,
     ACCOUNT_URL,
-    league_standings_url,
+    LOGIN_URL,
+    BiwengerClient,
     clausulazos_url,
+    league_round_points_report_url,
+    league_round_report_url,
+    league_standings_url,
 )
 
 
-def main() -> None:
-    if len(sys.argv) != 2:
-        print("Usage: python fetch_palmares.py <season>  (e.g. 25-26)")
-        sys.exit(1)
+def _to_int(value, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
 
-    season = sys.argv[1]
+
+def _to_float(value, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _build_standings_table(
+    standings: list,
+    rounds_rows: list,
+    points_rows: list,
+) -> list[SeasonStanding]:
+    """Cross-reference the three endpoints by user_id."""
+    by_user_rounds = {r.get("Usuario", {}).get("id"): r for r in rounds_rows}
+    by_user_points = {r.get("Usuario", {}).get("id"): r for r in points_rows}
+
+    table: list[SeasonStanding] = []
+    for entry in standings:
+        uid = entry.get("id")
+        if not uid:
+            continue
+        rounds = by_user_rounds.get(uid, {})
+        points = by_user_points.get(uid, {})
+        table.append(
+            SeasonStanding(
+                position=_to_int(entry.get("position")),
+                user_id=int(uid),
+                team_name=entry.get("name", ""),
+                real_name=LEAGUE_MEMBERS.get(int(uid), ""),
+                points=_to_int(entry.get("points") or points.get("Puntos")),
+                best_round=_to_int(points.get("Mejor jornada")),
+                worst_round=_to_int(points.get("Peor jornada")),
+                rounds_won=_to_int(rounds.get("Jornadas ganadas")),
+                avg_position=_to_float(rounds.get("Posición media")),
+            )
+        )
+    return table
+
+
+def _append_abandoned(
+    table: list[SeasonStanding],
+    abandoned: list[tuple[str, str, str]],
+) -> None:
+    """Append rows for accounts deleted mid-season.
+
+    Abandoned rows go after the real standings, so they end up in the last
+    positions and inherit the farolillo — league rule: ``el que se levanta
+    de la mesa pierde``.
+    """
+    next_position = max((s.position for s in table), default=0) + 1
+    for real_name, team_name, reason in abandoned:
+        table.append(
+            SeasonStanding(
+                position=next_position,
+                user_id=0,
+                team_name=team_name or "—",
+                real_name=real_name,
+                note=reason,
+            )
+        )
+        next_position += 1
+
+
+def _compute_aggregates(table: list[SeasonStanding]) -> dict:
+    """Aggregate fields rendered in the right-hand 'Datos de la Temporada' block."""
+    active = [s for s in table if s.user_id]
+    if not active:
+        return {"record_puntos": "", "jornadas_ganadas": ""}
+
+    record_holder = max(active, key=lambda s: s.best_round)
+    rounds_winner = max(active, key=lambda s: s.rounds_won)
+
+    record_label = (record_holder.real_name or record_holder.team_name or "").lower()
+    winner_label = (rounds_winner.real_name or rounds_winner.team_name or "").lower()
+    record_puntos = (
+        f"{record_holder.best_round} @{record_label}"
+        if record_holder.best_round and record_label
+        else ""
+    )
+    jornadas_ganadas = (
+        f"{rounds_winner.rounds_won} @{winner_label}"
+        if rounds_winner.rounds_won and winner_label
+        else ""
+    )
+    return {
+        "record_puntos": record_puntos,
+        "jornadas_ganadas": jornadas_ganadas,
+    }
+
+
+def _build_palmares(
+    season: str,
+    table: list[SeasonStanding],
+    clausulazos_total: int,
+) -> Palmares:
+    """Roll the table into the Palmares document the web reads.
+
+    League payout rule (Mochileros):
+      - Half win — invited to lunch by the losers.
+      - Half lose — pay their own + pay for the winners.
+      - With an odd number of players, the single middle position is
+        neutral and pays only its own.
+
+    Concretely (``N`` = number of finishers including abandoned rows):
+      - ``losers_count = N // 2``
+      - ``neutros_count = N % 2`` (0 if even, 1 if odd)
+      - ``winners_count = N - losers_count - neutros_count``
+
+    Examples — N=6 → 3+0+3; N=7 → 3+1+3; N=8 → 4+0+4.
+
+    Mapping to the Palmares fields:
+      - ``campeon`` / ``subcampeon`` / ``tercero`` → positions 1, 2, 3
+        (podium medals; extra winners beyond 3rd don't get a labelled slot).
+      - ``multas`` → every losing position, in ascending order. The last
+        entry of this list is the farolillo (cosmetic distinction only,
+        rendered with the 🔴 icon at template level). League rule applies:
+        an abandoned account ends up last and inherits the farolillo.
+      - ``neutros`` → the single neutral position when N is odd; empty
+        when N is even.
+
+    Records (``record_puntos`` / ``jornadas_ganadas``) only consider active
+    users — abandoned rows have zeros for both, so they never claim them.
+    """
+    sorted_table = sorted(table, key=lambda s: s.position)
+    by_position = {s.position: s for s in sorted_table}
+    aggregates = _compute_aggregates(table)
+
+    n = len(sorted_table)
+    losers_count = n // 2
+    neutros_count = n % 2
+    losers_slice = sorted_table[n - losers_count :] if losers_count else []
+    neutros_slice = (
+        sorted_table[n - losers_count - neutros_count : n - losers_count]
+        if neutros_count
+        else []
+    )
+
+    return Palmares(
+        temporada=season,
+        campeon=_label(by_position.get(1)),
+        subcampeon=_label(by_position.get(2)),
+        tercero=_label(by_position.get(3)),
+        multas=[_label(s) for s in losers_slice],
+        neutros=[_label(s) for s in neutros_slice],
+        puntuacion="personalizada",
+        record_puntos=aggregates["record_puntos"],
+        jornadas_ganadas=aggregates["jornadas_ganadas"],
+        clausulazos_total=str(clausulazos_total),
+        standings_table=table,
+    )
+
+
+def _label(s: SeasonStanding | None) -> str:
+    if s is None:
+        return ""
+    return s.real_name or s.team_name or "—"
+
+
+def _count_clauses(raw: dict) -> int:
+    """Count real clausulazos in the transfer board.
+
+    Biwenger's ``board?type=transfer`` returns every transfer event (regular
+    market sales, clausulazos, etc.). A clausulazo is an item inside
+    ``entry.content`` whose ``type`` is ``"clause"`` — mirroring the filter
+    in ``packages/biwenger_tools/scraper_job/logic/processing.py``.
+    """
+    entries = raw.get("data", []) or []
+    if isinstance(entries, dict):
+        entries = list(entries.values())
+    return sum(
+        sum(1 for c in (entry.get("content") or []) if c.get("type") == "clause")
+        for entry in entries
+    )
+
+
+def _parse_abandoned(values: list[str]) -> list[tuple[str, str, str]]:
+    """Parse ``NAME=TEAM=REASON`` triples passed on the command line.
+
+    The team slot may be empty (``Alberto==abandono``) when no equivalent
+    Biwenger team name applies — the row then renders with ``"—"`` for
+    the team column.
+    """
+    parsed = []
+    for raw in values:
+        parts = raw.split("=", 2)
+        if len(parts) != 3:
+            print(
+                f"WARNING: --abandoned-user '{raw}' is malformed "
+                "(need NAME=TEAM=REASON, team may be empty); skipped.",
+                file=sys.stderr,
+            )
+            continue
+        name, team, reason = (p.strip() for p in parts)
+        parsed.append((name, team, reason))
+    return parsed
+
+
+def _write_to_firestore(palmares: Palmares, force: bool) -> bool:
+    """Write to ``palmares/<season>``.
+
+    Refuses to overwrite an existing doc unless ``force=True``. Returns True
+    on success, False on any error or on a skipped overwrite.
+    """
+    try:
+        from core.sdk.firestore import get_client
+    except Exception as exc:  # pragma: no cover
+        print(f"ERROR: cannot import firestore client: {exc}", file=sys.stderr)
+        return False
+    try:
+        doc_ref = get_client().collection("palmares").document(palmares.temporada)
+        if doc_ref.get().exists and not force:
+            print(
+                f"SKIP: palmares/{palmares.temporada} already exists in Firestore. "
+                "Pass --force to overwrite.",
+                file=sys.stderr,
+            )
+            return False
+        doc_ref.set(palmares.to_firestore())
+        return True
+    except Exception as exc:
+        print(f"ERROR: Firestore write failed: {exc}", file=sys.stderr)
+        return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("season", help="Season being closed, e.g. 25-26")
+    parser.add_argument(
+        "--abandoned-user",
+        action="append",
+        default=[],
+        metavar="NAME=TEAM=REASON",
+        help="Append a row for an account deleted mid-season; repeatable. "
+        "Example: --abandoned-user 'Alberto=#NOALOSCLAUSULAZOS=abandono'. "
+        "Leave the team slot empty if not known: 'Someone==abandono'.",
+    )
+    parser.add_argument(
+        "--write-firestore",
+        action="store_true",
+        help="Write the resulting doc to Firestore at palmares/<season>.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite palmares/<season> if it already exists. "
+        "Without this flag, an existing doc is left untouched.",
+    )
+    args = parser.parse_args()
+
     email = os.getenv("BIWENGER_EMAIL", "")
     password = os.getenv("BIWENGER_PASSWORD", "")
-    league_id = os.getenv("LEAGUE_ID", "")
-
+    league_id = os.getenv("LEAGUE_ID", DEFAULT_LEAGUE_ID)
     if not all([email, password, league_id]):
         print(
-            "ERROR: BIWENGER_EMAIL, BIWENGER_PASSWORD and LEAGUE_ID must be set.",
+            "ERROR: BIWENGER_EMAIL and BIWENGER_PASSWORD must be set "
+            "(LEAGUE_ID defaults to core.constants.LEAGUE_ID).",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -55,57 +328,66 @@ def main() -> None:
         )
     except Exception as exc:
         print(f"ERROR: Biwenger authentication failed: {exc}", file=sys.stderr)
-        print("You will need to fill in the palmares rows manually.", file=sys.stderr)
+        print("Fill in the palmares rows manually.", file=sys.stderr)
         sys.exit(1)
 
-    rows = []
-
-    # --- Standings (position, name, points) ---
+    # --- Fetch the three reports in sequence ---
     try:
         standings = client.get_standings_full(league_standings_url(league_id))
-        if standings:
-            # Sort by position ascending to be safe; API usually returns sorted.
-            standings_sorted = sorted(
-                standings, key=lambda u: u.get("position", 999)
-            )
-            if len(standings_sorted) >= 1:
-                rows.append(f'{season},campeon,{standings_sorted[0]["name"]}')
-                rows.append(
-                    f'{season},puntuacion,{standings_sorted[0].get("points", "?")}'
-                )
-            if len(standings_sorted) >= 2:
-                rows.append(f'{season},subcampeon,{standings_sorted[1]["name"]}')
-            if len(standings_sorted) >= 3:
-                rows.append(f'{season},tercero,{standings_sorted[2]["name"]}')
-            if len(standings_sorted) >= 1:
-                rows.append(f'{season},farolillo,{standings_sorted[-1]["name"]}')
-        else:
-            print("WARNING: standings returned empty.", file=sys.stderr)
     except Exception as exc:
-        print(f"WARNING: Could not fetch standings: {exc}", file=sys.stderr)
+        print(f"ERROR: standings fetch failed: {exc}", file=sys.stderr)
+        sys.exit(1)
 
-    # --- Clausulazos total ---
     try:
-        result = client.get_all_clausulazos(clausulazos_url(league_id))
-        total = len(result.get("data", []))
-        rows.append(f"{season},clausulazos_total,{total}")
+        rounds_rows = client.get_report_rows(league_round_report_url(league_id))
     except Exception as exc:
-        print(f"WARNING: Could not fetch clausulazos: {exc}", file=sys.stderr)
+        print(f"WARNING: rounds report failed: {exc}", file=sys.stderr)
+        rounds_rows = []
 
-    # --- Manual fields (output placeholders) ---
-    rows.append(f'{season},record_puntos,"RELLENAR — Jugador — X puntos (JY)"')
-    rows.append(f'{season},jornadas_ganadas,"RELLENAR — Jugador — N jornadas"')
-    rows.append(f"{season},multa,RELLENAR_O_BORRAR")
-    rows.append(f"{season},sancion,RELLENAR_O_BORRAR")
+    try:
+        points_rows = client.get_report_rows(league_round_points_report_url(league_id))
+    except Exception as exc:
+        print(f"WARNING: roundPoints report failed: {exc}", file=sys.stderr)
+        points_rows = []
 
-    print("\n--- Paste the following rows into palmares.csv in Google Drive ---\n")
-    for row in rows:
-        print(row)
-    print("\n--- End of rows ---")
-    print(
-        "\nNote: replace RELLENAR_O_BORRAR lines with real values, "
-        "or delete them if not applicable."
-    )
+    try:
+        clausulazos = client.get_all_clausulazos(clausulazos_url(league_id))
+        clausulazos_total = _count_clauses(clausulazos)
+    except Exception as exc:
+        print(f"WARNING: clausulazos fetch failed: {exc}", file=sys.stderr)
+        clausulazos_total = 0
+
+    # --- Combine + abandoned-user injection ---
+    table = _build_standings_table(standings, rounds_rows, points_rows)
+    _append_abandoned(table, _parse_abandoned(args.abandoned_user))
+
+    palmares = _build_palmares(args.season, table, clausulazos_total)
+
+    # --- Output ---
+    print("\n=== Firestore doc preview (palmares/{}) ===\n".format(args.season))
+    print(json.dumps(palmares.to_firestore(), indent=2, ensure_ascii=False))
+
+    print("\n=== Per-user table ===")
+    for s in palmares.standings_table:
+        note = f" [{s.note}]" if s.note else ""
+        print(
+            f"  {s.position}. {s.real_name or '—':10s} "
+            f"({s.team_name})  pts={s.points}  best={s.best_round} "
+            f"worst={s.worst_round}  wins={s.rounds_won} "
+            f"avg_pos={s.avg_position:.1f}{note}"
+        )
+
+    if args.write_firestore:
+        print("\nWriting to Firestore…")
+        if _write_to_firestore(palmares, force=args.force):
+            print(f"OK — palmares/{args.season} written.")
+        else:
+            sys.exit(1)
+    else:
+        print(
+            "\nNot writing to Firestore (no --write-firestore). "
+            "Rerun with the flag to push the doc."
+        )
 
 
 if __name__ == "__main__":

--- a/PENDING.md
+++ b/PENDING.md
@@ -17,6 +17,13 @@ Long-running follow-ups that don't yet warrant a plan or PR.
   drop the `biwenger-tools-sa-regional` secret or repoint it to a Sheets-only SA
   (Sheets API still authenticates through that mount for `ligas_especiales` /
   `trofeos`).
+- **Drop the in-code CSV layer** — once the Drive CSVs are gone (item above),
+  remove the legacy CSV serialization paths now that Firestore is the only source
+  of truth: `from_csv_rows` / `to_csv_row` / `CSV_FIELDS` across `core/domain/models.py`
+  (`Palmares`, `Participation`, `Clausulazo`, `JusticeEntry`, `LeagueMessage`), the
+  one-shot `scripts/backfill_firestore.py` recovery tool, and the related tests in
+  `core/tests/test_domain_models.py`. Update `docs/firestore.md` to drop the
+  "Backfill (one-shot)" row.
 
 ## my_photos
 

--- a/core/constants.py
+++ b/core/constants.py
@@ -15,6 +15,19 @@ MADRID_TZ = ZoneInfo("Europe/Madrid")
 # multiple leagues, this becomes per-config.
 LEAGUE_ID = "340703"
 
+# Stable user_id → real-name mapping for the Mochileros league. Biwenger
+# lets users rename their team at will, so the team `name` field drifts;
+# the numeric `id` is stable, so this is the source of truth when
+# attributing a row to a real person (palmares, post-rollover reports).
+LEAGUE_MEMBERS: dict[int, str] = {
+    7728610: "Fabio",  # Rayo Entrebirras
+    1376351: "Lucena",  # La Luceneta
+    12449616: "Pablo",  # Los caídos de la jornada
+    1372802: "Jorge",  # Farolillo Oracle United
+    7728598: "Javi",  # Kairat FC
+    7727371: "Ruben",  # Ferraz fc
+}
+
 # A dynamic Drive file is considered stale if it hasn't been touched in
 # this long. Surfaced as a red "is_stale" badge in the admin panel.
 DRIVE_STALE_THRESHOLD = timedelta(days=7)

--- a/core/domain/models.py
+++ b/core/domain/models.py
@@ -355,6 +355,63 @@ class JusticeEntry:
 
 
 @dataclass
+class SeasonStanding:
+    """End-of-season per-user row.
+
+    Captured at season close. ``team_name`` is the Biwenger team name at
+    capture time (it can drift later if the user renames). ``real_name``
+    is resolved via ``LEAGUE_MEMBERS`` from the stable numeric ``user_id``,
+    so it survives renames.
+
+    For accounts deleted mid-season the user_id is no longer resolvable
+    via Biwenger — emit ``user_id=0`` and fill ``real_name`` and ``note``
+    explicitly (e.g. ``note="abandono"``).
+    """
+
+    position: int
+    user_id: int
+    team_name: str
+    real_name: str
+    points: int = 0
+    best_round: int = 0
+    worst_round: int = 0
+    rounds_won: int = 0
+    avg_position: float = 0.0
+    note: str = ""
+
+    FIRESTORE_FIELDS: ClassVar[Tuple[str, ...]] = (
+        "position",
+        "user_id",
+        "team_name",
+        "real_name",
+        "points",
+        "best_round",
+        "worst_round",
+        "rounds_won",
+        "avg_position",
+        "note",
+    )
+
+    @classmethod
+    def from_firestore(cls, data: dict) -> "SeasonStanding":
+        return cls(
+            position=int(data.get("position", 0) or 0),
+            user_id=int(data.get("user_id", 0) or 0),
+            team_name=data.get("team_name", ""),
+            real_name=data.get("real_name", ""),
+            points=int(data.get("points", 0) or 0),
+            best_round=int(data.get("best_round", 0) or 0),
+            worst_round=int(data.get("worst_round", 0) or 0),
+            rounds_won=int(data.get("rounds_won", 0) or 0),
+            avg_position=float(data.get("avg_position", 0.0) or 0.0),
+            note=data.get("note", ""),
+        )
+
+    def to_firestore(self) -> dict:
+        return {f: getattr(self, f) for f in self.FIRESTORE_FIELDS}
+
+
+@dataclass
 class Palmares:
     """Historical honours for a single season.
 
@@ -362,34 +419,42 @@ class Palmares:
     per honour, so a season spans several rows; ``multa`` in particular
     appears more than once. This model collapses a season into one document
     — the shape Firestore stores under ``palmares/{temporada}``.
+
+    From 26-27 onwards we also capture ``standings_table`` — one
+    ``SeasonStanding`` per league member — so the palmarés page can show
+    a full per-user breakdown instead of the bare podium. Older seasons
+    leave it empty and the template falls back to the legacy podium view.
     """
 
     temporada: str
     campeon: str = ""
     subcampeon: str = ""
     tercero: str = ""
-    farolillo: str = ""
     multas: list = field(default_factory=list)
+    neutros: list = field(default_factory=list)
     puntuacion: str = ""
     record_puntos: str = ""
     jornadas_ganadas: str = ""
+    clausulazos_total: str = ""
+    standings_table: list = field(default_factory=list)
 
     FIRESTORE_FIELDS: ClassVar[Tuple[str, ...]] = (
         "campeon",
         "subcampeon",
         "tercero",
-        "farolillo",
         "puntuacion",
         "record_puntos",
         "jornadas_ganadas",
+        "clausulazos_total",
     )
 
     @classmethod
     def from_csv_rows(cls, rows: list) -> list["Palmares"]:
         """Collapse the flat ``temporada,categoria,valor`` CSV into one
-        ``Palmares`` per season. Unknown categories are ignored by the
-        caller's discretion — log them at the call site if needed."""
+        ``Palmares`` per season. Legacy ``farolillo`` rows are appended to
+        ``multas`` (the farolillo is now just the last entry of multas)."""
         by_season: dict[str, "Palmares"] = {}
+        legacy_farolillos: dict[str, str] = {}
         for row in rows:
             temporada = (row.get("temporada") or "").strip()
             categoria = (row.get("categoria") or "").strip()
@@ -399,20 +464,46 @@ class Palmares:
             entry = by_season.setdefault(temporada, cls(temporada=temporada))
             if categoria == "multa":
                 entry.multas.append(valor)
+            elif categoria == "farolillo":
+                legacy_farolillos[temporada] = valor
             elif categoria in cls.FIRESTORE_FIELDS:
                 setattr(entry, categoria, valor)
+        for temporada, farolillo in legacy_farolillos.items():
+            entry = by_season[temporada]
+            if farolillo and farolillo not in entry.multas:
+                entry.multas.append(farolillo)
         return list(by_season.values())
 
     @classmethod
     def from_firestore(cls, doc_id: str, data: dict) -> "Palmares":
-        """Build from a Firestore doc. The doc id is the `temporada`."""
-        entry = cls(temporada=doc_id, multas=list(data.get("multas", [])))
+        """Build from a Firestore doc. The doc id is the `temporada`.
+
+        Legacy 24-25 / 23-24 docs persist a separate ``farolillo`` string
+        field next to ``multas``. Reading merges it into ``multas`` (at the
+        end) so callers see a single ordered list — the last entry is the
+        farolillo, visually marked at render time. The legacy field stays
+        in Firestore until those docs are re-written.
+        """
+        entry = cls(
+            temporada=doc_id,
+            multas=list(data.get("multas", [])),
+            neutros=list(data.get("neutros", [])),
+        )
         for f in cls.FIRESTORE_FIELDS:
             setattr(entry, f, data.get(f, ""))
+        legacy_farolillo = (data.get("farolillo") or "").strip()
+        if legacy_farolillo and legacy_farolillo not in entry.multas:
+            entry.multas.append(legacy_farolillo)
+        entry.standings_table = [
+            SeasonStanding.from_firestore(row)
+            for row in (data.get("standings_table") or [])
+        ]
         return entry
 
     def to_firestore(self) -> dict:
         """Document fields. The `temporada` is the doc id, not a field."""
         doc = {f: getattr(self, f) for f in self.FIRESTORE_FIELDS}
         doc["multas"] = self.multas
+        doc["neutros"] = self.neutros
+        doc["standings_table"] = [s.to_firestore() for s in self.standings_table]
         return doc

--- a/core/sdk/biwenger.py
+++ b/core/sdk/biwenger.py
@@ -44,6 +44,18 @@ def manager_squad_url(manager_id: Union[str, int]) -> str:
     return f"{BIWENGER_API_BASE}/user/{manager_id}?fields=players(id,owner(*))"
 
 
+def league_round_report_url(league_id: Union[str, int], mode: str = "total") -> str:
+    """Per-user "Jornadas ganadas" + "Posición media"."""
+    return f"{league_url(league_id)}/report/rounds?mode={mode}"
+
+
+def league_round_points_report_url(
+    league_id: Union[str, int], mode: str = "total"
+) -> str:
+    """Per-user "Puntos" + "Mejor jornada" + "Peor jornada"."""
+    return f"{league_url(league_id)}/report/roundPoints?mode={mode}"
+
+
 class BiwengerClient:
     """
     Client for the Biwenger API.
@@ -181,6 +193,35 @@ class BiwengerClient:
         standings = response.json().get("data", {}).get("standings", [])
         logger.info("Standings fetched.", extra={"count": len(standings)})
         return standings
+
+    def get_report_rows(self, report_url: str) -> list[dict]:
+        """Fetch a Biwenger `report/*` endpoint and parse `columns + rows`
+        into a list of dicts keyed by column name.
+
+        Biwenger report responses share the shape:
+            {"data": {"columns": [{"name": ...}, ...],
+                       "rows": [[...], ...]}}
+
+        Row order matches column order. The first column ("Usuario") is
+        a user object (`{id, name, icon}`); the rest are scalars whose
+        types depend on the report. We keep the raw column names so the
+        caller can pull by the same label that the UI uses.
+        """
+        response = self.session.get(report_url)
+        response.raise_for_status()
+        payload = response.json().get("data", {}) or {}
+        columns = payload.get("columns", []) or []
+        rows = payload.get("rows", []) or []
+        col_names = [c.get("name", "") for c in columns]
+        parsed = [
+            {col_names[i]: row[i] for i in range(min(len(col_names), len(row)))}
+            for row in rows
+        ]
+        logger.info(
+            "Report rows fetched.",
+            extra={"url": report_url, "count": len(parsed)},
+        )
+        return parsed
 
     def get_board_messages(self, board_messages_url: str) -> dict:
         """Returns a single page of board messages."""

--- a/core/tests/test_biwenger_client.py
+++ b/core/tests/test_biwenger_client.py
@@ -361,3 +361,40 @@ def test_get_account_state_unknown_league_returns_zeros(
         m.get(TEST_ACCOUNT_URL, json=load_json_fixture("account_response.json"))
         state = client.get_account_state()
     assert state == {"cash": 0, "max_bid": 0}
+
+
+def test_get_report_rows_parses_columns_and_rows(biwenger_client_authenticated):
+    """report/* endpoints return {columns, rows}; the SDK zips them into dicts
+    keyed by column name so callers can pull values by the label the UI uses."""
+    url = "https://biwenger.as.com/api/v2/league/340703/report/rounds?mode=total"
+    payload = {
+        "status": 200,
+        "data": {
+            "columns": [
+                {"name": "Usuario", "type": "user"},
+                {"name": "Jornadas ganadas", "type": "number"},
+                {"name": "Posición media", "type": "ordinal"},
+            ],
+            "rows": [
+                [{"id": 7728610, "name": "Rayo Entrebirras"}, "11", 2.8],
+                [{"id": 1372802, "name": "Farolillo Oracle United"}, "3", 3.8],
+            ],
+        },
+    }
+    with requests_mock.Mocker() as m:
+        m.get(url, json=payload, status_code=200)
+        rows = biwenger_client_authenticated.get_report_rows(url)
+    assert len(rows) == 2
+    assert rows[0]["Usuario"]["id"] == 7728610
+    assert rows[0]["Jornadas ganadas"] == "11"
+    assert rows[0]["Posición media"] == 2.8
+    assert rows[1]["Usuario"]["name"] == "Farolillo Oracle United"
+
+
+def test_get_report_rows_empty_payload(biwenger_client_authenticated):
+    """Missing columns/rows → empty list, no exception."""
+    url = "https://biwenger.as.com/api/v2/league/340703/report/roundPoints?mode=total"
+    with requests_mock.Mocker() as m:
+        m.get(url, json={"status": 200, "data": {}}, status_code=200)
+        rows = biwenger_client_authenticated.get_report_rows(url)
+    assert rows == []

--- a/core/tests/test_domain_models.py
+++ b/core/tests/test_domain_models.py
@@ -9,6 +9,7 @@ from core.domain.models import (
     LeagueMessage,
     Palmares,
     Participation,
+    SeasonStanding,
     _parse_fecha,
 )
 
@@ -200,7 +201,8 @@ def test_justice_entry_firestore_roundtrip():
 
 def test_palmares_from_csv_rows_collapses_seasons():
     """The flat temporada/categoria/valor CSV collapses to one model per
-    season; `multa` appears twice and lands in the `multas` array."""
+    season. Legacy `farolillo` rows are appended to `multas` (the farolillo
+    is just the last entry — same shape used by new writes)."""
     rows = [
         {"temporada": "2024-2025", "categoria": "campeon", "valor": "Fabio"},
         {"temporada": "2024-2025", "categoria": "subcampeon", "valor": "Jorge"},
@@ -216,8 +218,7 @@ def test_palmares_from_csv_rows_collapses_seasons():
     assert p.temporada == "2024-2025"
     assert p.campeon == "Fabio"
     assert p.subcampeon == "Jorge"
-    assert p.farolillo == "Rubén"
-    assert p.multas == ["Alberto", "Lucen"]
+    assert p.multas == ["Alberto", "Lucen", "Rubén"]
     assert p.record_puntos == "112 @fabio"
 
 
@@ -227,14 +228,93 @@ def test_palmares_firestore_roundtrip():
         campeon="Jorge",
         subcampeon="Fabio",
         tercero="Albert",
-        farolillo="Javi",
-        multas=["Rubén", "Lucen"],
+        multas=["Rubén", "Lucen", "Javi"],
         puntuacion="sofascore",
         record_puntos="101 @fabio",
         jornadas_ganadas="18 @jorge",
     )
     doc = p.to_firestore()
     assert "temporada" not in doc
-    assert doc["multas"] == ["Rubén", "Lucen"]
+    assert "farolillo" not in doc
+    assert doc["multas"] == ["Rubén", "Lucen", "Javi"]
+    assert doc["standings_table"] == []
     parsed = Palmares.from_firestore("2023-2024", doc)
+    assert parsed == p
+
+
+def test_palmares_legacy_firestore_doc_merges_farolillo_into_multas():
+    """Pre-existing 24-25 / 23-24 Firestore docs persist `farolillo` as a
+    separate string field. On read it gets appended to `multas` so callers
+    see one ordered list — the legacy field is harmless until those docs
+    are re-written."""
+    legacy_doc = {
+        "campeon": "Fabio",
+        "subcampeon": "Jorge",
+        "tercero": "Albert",
+        "farolillo": "Rubén",
+        "multas": ["Alberto", "Lucen"],
+        "puntuacion": "sofascore",
+    }
+    p = Palmares.from_firestore("2024-2025", legacy_doc)
+    assert p.multas == ["Alberto", "Lucen", "Rubén"]
+
+
+def test_season_standing_firestore_roundtrip():
+    s = SeasonStanding(
+        position=1,
+        user_id=7728610,
+        team_name="Rayo Entrebirras",
+        real_name="Fabio",
+        points=2872,
+        best_round=120,
+        worst_round=44,
+        rounds_won=11,
+        avg_position=2.8,
+    )
+    doc = s.to_firestore()
+    assert SeasonStanding.from_firestore(doc) == s
+
+
+def test_palmares_with_standings_table_roundtrip():
+    """Palmares carries the per-user table for seasons captured from 26-27 on.
+    Legacy seasons leave it empty and the from/to roundtrip still works."""
+    p = Palmares(
+        temporada="2025-2026",
+        campeon="Fabio",
+        subcampeon="Lucena",
+        tercero="Pablo",
+        multas=["Javi", "Ruben", "Alberto"],
+        neutros=["Jorge"],
+        puntuacion="personalizada",
+        record_puntos="120 @fabio",
+        jornadas_ganadas="11 @fabio",
+        clausulazos_total="109",
+        standings_table=[
+            SeasonStanding(
+                position=1,
+                user_id=7728610,
+                team_name="Rayo Entrebirras",
+                real_name="Fabio",
+                points=2872,
+                best_round=120,
+                rounds_won=11,
+                avg_position=2.8,
+            ),
+            SeasonStanding(
+                position=7,
+                user_id=0,
+                team_name="—",
+                real_name="Alberto",
+                note="abandono",
+            ),
+        ],
+    )
+    doc = p.to_firestore()
+    assert doc["clausulazos_total"] == "109"
+    assert doc["multas"] == ["Javi", "Ruben", "Alberto"]
+    assert doc["neutros"] == ["Jorge"]
+    assert "farolillo" not in doc
+    assert len(doc["standings_table"]) == 2
+    assert doc["standings_table"][1]["note"] == "abandono"
+    parsed = Palmares.from_firestore("2025-2026", doc)
     assert parsed == p

--- a/packages/biwenger_tools/scraper_job/logic/processing.py
+++ b/packages/biwenger_tools/scraper_job/logic/processing.py
@@ -11,13 +11,22 @@ logger = get_logger(__name__)
 
 
 def categorize_title(title):
-    """Classify a board message by its title prefix."""
+    """Classify a board message by its title prefix.
+
+    The cronica rule is intentionally lenient: ``CRONICA`` alone,
+    ``CRONICAS`` (plural, with or without suffix), or ``CRONICA <anything>``
+    (``- X``, ``FINAL``, ``Jornada N``…) all count as cronica. The "space
+    after" requirement avoids accidentally matching words that just start
+    with the substring (``Cronicado…``).
+    """
     if not title:
         return "comunicado"
     normalized_title = unidecode.unidecode(title.strip().upper())
 
-    if normalized_title.startswith("CRONICA -") or normalized_title.startswith(
-        "CRONICAS"
+    if (
+        normalized_title == "CRONICA"
+        or normalized_title.startswith("CRONICA ")
+        or normalized_title.startswith("CRONICAS")
     ):
         return "cronica"
     if normalized_title.startswith("DATO -") or normalized_title.startswith("DATOS -"):

--- a/packages/biwenger_tools/scraper_job/tests/test_processing.py
+++ b/packages/biwenger_tools/scraper_job/tests/test_processing.py
@@ -30,6 +30,13 @@ def test_categorize_title():
     assert categorize_title("") == "comunicado"
     assert categorize_title("  noticia sin categoria ") == "comunicado"
     assert categorize_title("Crónica - con acento") == "cronica"
+    # Lenient cronica: bare "CRÓNICA" and "CRÓNICA <something>" without dash.
+    assert categorize_title("CRÓNICA") == "cronica"
+    assert categorize_title("CRÓNICA FINAL") == "cronica"
+    assert categorize_title("Crónica jornada 10") == "cronica"
+    assert categorize_title("CRÓNICAS Jornada 10") == "cronica"
+    # Should NOT match words that merely *start* with the substring.
+    assert categorize_title("Cronicado el partido") == "comunicado"
 
 
 def test_process_participation():

--- a/packages/biwenger_tools/web/routes/main.py
+++ b/packages/biwenger_tools/web/routes/main.py
@@ -12,6 +12,23 @@ logger = get_logger(__name__)
 bp = Blueprint("main", __name__)
 
 
+def _display_season(season: str) -> str:
+    """Expand ``25-26`` → ``2025-2026`` for the palmares heading.
+
+    Legacy docs already store the long form (``2024-2025``) — those pass
+    through untouched. Only the short ``YY-YY`` Firestore doc ids written
+    by the season-rollover skill get expanded.
+    """
+    if (
+        len(season) == 5
+        and season[2] == "-"
+        and season[:2].isdigit()
+        and season[3:].isdigit()
+    ):
+        return f"20{season[:2]}-20{season[3:]}"
+    return season
+
+
 @bp.route("/version")
 def version() -> Response:
     """Return the deployed git commit SHA."""
@@ -44,20 +61,58 @@ def palmares() -> str:
     sorted_seasons: list = []
     try:
         for p in repository.get_palmares():
-            otros = [{"tipo": "multa", "valor": m} for m in p.multas]
-            if p.farolillo:
-                otros.append({"tipo": "farolillo", "valor": p.farolillo})
+            n = len(p.standings_table)
+            winners_count = n // 2
+            neutros_count = n % 2
+            annotated_rows = []
+            for s in p.standings_table:
+                if s.note:
+                    tier = "loser"
+                elif s.position <= winners_count:
+                    tier = "winner"
+                elif s.position > winners_count + neutros_count:
+                    tier = "loser"
+                else:
+                    tier = "neutro"
+                annotated_rows.append(
+                    {
+                        "position": s.position,
+                        "real_name": s.real_name,
+                        "team_name": s.team_name,
+                        "points": s.points,
+                        "best_round": s.best_round,
+                        "worst_round": s.worst_round,
+                        "rounds_won": s.rounds_won,
+                        "avg_position": s.avg_position,
+                        "note": s.note,
+                        "tier": tier,
+                    }
+                )
+            farolillo_name = p.multas[-1] if p.multas else ""
+            farolillo_note = next(
+                (
+                    s.note
+                    for s in p.standings_table
+                    if s.real_name == farolillo_name and s.note
+                ),
+                "",
+            )
             sorted_seasons.append(
                 (
                     p.temporada,
                     {
+                        "display_season": _display_season(p.temporada),
                         "campeon": p.campeon,
                         "subcampeon": p.subcampeon,
                         "tercero": p.tercero,
                         "puntuacion": p.puntuacion,
                         "record_puntos": p.record_puntos,
                         "jornadas_ganadas": p.jornadas_ganadas,
-                        "otros": otros,
+                        "clausulazos_total": p.clausulazos_total,
+                        "standings_table": annotated_rows,
+                        "multas": p.multas,
+                        "farolillo_note": farolillo_note,
+                        "neutros": p.neutros,
                     },
                 )
             )

--- a/packages/biwenger_tools/web/templates/palmares.html
+++ b/packages/biwenger_tools/web/templates/palmares.html
@@ -9,7 +9,7 @@
     {% elif seasons %}
         {% for season, data in seasons %}
         <div class="card p-6 rounded-xl shadow-lg">
-            <h2 class="font-header text-3xl font-bold text-gray-900 mb-6 border-b border-gray-200 pb-3">{{ season }}</h2>
+            <h2 class="font-header text-3xl font-bold text-gray-900 mb-6 border-b border-gray-200 pb-3">{{ data.display_season or season }}</h2>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
                 <!-- Podio -->
                 <div class="space-y-4">
@@ -45,22 +45,87 @@
                     <p><strong class="font-medium text-gray-600">Clausulazos totales:</strong> {{ data.clausulazos_total }}</p>
                     {% endif %}
 
-                    <h3 class="font-header text-xl font-bold text-red-600 mt-6">Les toca pagar a:</h3>
+                    {% if data.multas %}
+                    <h3 class="font-header text-xl font-bold text-red-600 mt-6">Pierden:</h3>
                     <ul class="list-none space-y-2">
-                        {% for otro in data.otros %}
+                        {% for name in data.multas %}
                         <li class="flex items-center gap-2">
+                            <span>{% if loop.last %}🔴{% else %}💸{% endif %}</span>
                             <span>
-                                {% if otro.tipo == 'farolillo' %}🔴
-                                {% elif otro.tipo == 'multa' %}💸
-                                {% elif otro.tipo == 'sancion' %}📋
-                                {% else %}•{% endif %}
+                                {{ name }}
+                                {% if loop.last %}
+                                    <span class="text-xs text-red-600 font-semibold">— farolillo{% if data.farolillo_note %} ({{ data.farolillo_note }}){% endif %}</span>
+                                {% endif %}
                             </span>
-                            <span>{{ otro.valor }}</span>
                         </li>
                         {% endfor %}
                     </ul>
+                    {% endif %}
+
+                    {% if data.neutros %}
+                    <h3 class="font-header text-xl font-bold text-gray-600 mt-6">Neutros:</h3>
+                    <ul class="list-none space-y-2">
+                        {% for n in data.neutros %}
+                        <li class="flex items-center gap-2">
+                            <span>•</span>
+                            <span class="text-gray-700">{{ n }}</span>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                    {% endif %}
                 </div>
             </div>
+
+            {% if data.standings_table %}
+            <div class="mt-8 pt-6 border-t border-gray-200">
+                <h3 class="font-header text-xl font-bold text-gray-800 mb-4">Clasificación final</h3>
+                <div class="overflow-x-auto">
+                    <table class="min-w-full text-sm">
+                        <thead>
+                            <tr class="text-left text-gray-600 border-b border-gray-200">
+                                <th class="py-2 pr-3">#</th>
+                                <th class="py-2 pr-3">Manager</th>
+                                <th class="py-2 pr-3">Equipo</th>
+                                <th class="py-2 pr-3 text-right">Puntos</th>
+                                <th class="py-2 pr-3 text-right">Mejor J.</th>
+                                <th class="py-2 pr-3 text-right">Peor J.</th>
+                                <th class="py-2 pr-3 text-right">J. ganadas</th>
+                                <th class="py-2 pr-3 text-right">Pos. media</th>
+                                <th class="py-2 pr-3">Notas</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in data.standings_table %}
+                            <tr class="border-b last:border-b-0 border-gray-100
+                                {%- if row.note %} bg-red-50 hover:bg-red-100 text-gray-500 line-through decoration-red-400/60
+                                {%- elif row.tier == 'winner' %} bg-green-50 hover:bg-green-100
+                                {%- elif row.tier == 'loser' %} bg-red-50 hover:bg-red-100
+                                {%- else %} hover:bg-gray-50
+                                {%- endif %}">
+                                <td class="py-2 pr-3 font-semibold {% if row.note %}no-underline{% endif %}">
+                                    {% if row.note %}🚪
+                                    {% elif row.position == 1 %}🥇
+                                    {% elif row.position == 2 %}🥈
+                                    {% elif row.position == 3 %}🥉
+                                    {% else %}{{ row.position }}{% endif %}
+                                </td>
+                                <td class="py-2 pr-3 font-medium {% if not row.note %}text-gray-900{% endif %}">{{ row.real_name or '—' }}</td>
+                                <td class="py-2 pr-3 {% if not row.note %}text-gray-600{% endif %}">{{ row.team_name or '—' }}</td>
+                                <td class="py-2 pr-3 text-right">{{ row.points or '—' }}</td>
+                                <td class="py-2 pr-3 text-right">{{ row.best_round or '—' }}</td>
+                                <td class="py-2 pr-3 text-right">{{ row.worst_round or '—' }}</td>
+                                <td class="py-2 pr-3 text-right">{{ row.rounds_won or '—' }}</td>
+                                <td class="py-2 pr-3 text-right">{{ '%.1f'|format(row.avg_position) if row.avg_position else '—' }}</td>
+                                <td class="py-2 pr-3 no-underline {% if row.note %}text-red-700 font-semibold uppercase tracking-wide text-xs{% else %}text-gray-500 italic{% endif %}">
+                                    {% if row.note %}⚠️ {{ row.note }}{% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            {% endif %}
         </div>
         {% endfor %}
     {% else %}

--- a/packages/biwenger_tools/web/tests/test_web_app.py
+++ b/packages/biwenger_tools/web/tests/test_web_app.py
@@ -189,15 +189,15 @@ def test_participacion_renders_calculated_counts(mock_get, client):
 
 
 @patch("packages.biwenger_tools.web.routes.main.repository.get_palmares")
-def test_palmares_groups_otros_categories(mock_get, client):
-    """multa/farolillo become entries in the `otros` block; podium keys stay direct."""
+def test_palmares_renders_multas_with_farolillo_marker(mock_get, client):
+    """All losers (including the farolillo) live in `multas`; the template
+    marks the LAST entry as the farolillo. Podium keys stay direct."""
     mock_get.return_value = [
         Palmares(
             temporada="24-25",
             campeon="Jorge",
             subcampeon="",
             tercero="",
-            farolillo="",
             puntuacion="",
             record_puntos="",
             jornadas_ganadas="",
@@ -208,11 +208,10 @@ def test_palmares_groups_otros_categories(mock_get, client):
             campeon="Dani",
             subcampeon="",
             tercero="",
-            farolillo="Pepe",
             puntuacion="",
             record_puntos="",
             jornadas_ganadas="",
-            multas=["20"],
+            multas=["20", "Pepe"],
         ),
     ]
     response = client.get("/palmares")
@@ -221,9 +220,8 @@ def test_palmares_groups_otros_categories(mock_get, client):
 
     assert "Jorge" in body  # 24-25 campeon
     assert "Dani" in body  # 23-24 campeon
-    # `otros` block (multa + farolillo) for 23-24
     assert "20" in body
-    assert "Pepe" in body
+    assert "Pepe" in body  # last in multas → farolillo
 
 
 # --- API endpoint tests ---

--- a/scripts/biwenger_check_categorias.py
+++ b/scripts/biwenger_check_categorias.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Diagnostic: list categoria counts for a season and flag drift between
+``categorize_title(titulo)`` and the ``categoria`` Firestore actually stored.
+
+Usage::
+
+    python3 scripts/biwenger_check_categorias.py [season]
+
+``season`` defaults to ``25-26``. Read-only — touches nothing in Firestore.
+Pair with ``biwenger_recategorise.py`` to fix the drift it surfaces.
+"""
+
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.sdk.firestore import get_client  # noqa: E402
+from packages.biwenger_tools.scraper_job.logic.processing import (  # noqa: E402
+    categorize_title,
+)
+
+
+def main() -> None:
+    season = sys.argv[1] if len(sys.argv) > 1 else "25-26"
+    client = get_client()
+    coll = client.collection(f"comunicados/{season}/messages")
+
+    counts: dict[str, int] = defaultdict(int)
+    drift: list[tuple[str, str, str, str]] = []
+    for snap in coll.stream():
+        data = snap.to_dict() or {}
+        stored = data.get("categoria") or "(missing)"
+        counts[stored] += 1
+        expected = categorize_title(data.get("titulo", ""))
+        if expected != stored:
+            drift.append(
+                (
+                    str(data.get("fecha", ""))[:19],
+                    data.get("autor", ""),
+                    data.get("titulo", ""),
+                    f"{stored} → {expected}",
+                )
+            )
+
+    print(f"\n=== Counts for {season} ===")
+    for cat in sorted(counts):
+        print(f"  {cat:15s}  {counts[cat]}")
+
+    print(f"\n=== Drift ({len(drift)} docs whose stored categoria != expected) ===")
+    if not drift:
+        print("  (clean)")
+        return
+    for fecha, autor, titulo, change in sorted(drift):
+        print(f"  {fecha:20s}  {autor:30s}  {titulo!r:40s}  {change}")
+    print("\nRun scripts/biwenger_recategorise.py " f"{season} --apply  to fix these.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/biwenger_recategorise.py
+++ b/scripts/biwenger_recategorise.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Re-categorise messages and rebuild participacion for a season.
+
+For every message in ``comunicados/{season}/messages`` whose stored
+``categoria`` doesn't match ``categorize_title(titulo)``, this script
+updates the doc. After fixing categorías, it rebuilds
+``participacion/{season}/authors`` from scratch so the per-author totals
+reflect the corrected categorización.
+
+Use ``--autor-alias OLD=NEW`` (repeatable) to also rewrite the ``autor``
+field on every message where ``autor == OLD``. The synthetic case is
+when an account was deleted mid-season and the scraper fell back to
+``Autor Desconocido``; this lets you attribute those messages to the
+real team name.
+
+Default is dry-run; pass ``--apply`` to actually write Firestore.
+
+Usage::
+
+    # Inspect what would change for the current season
+    python3 scripts/biwenger_recategorise.py 25-26
+
+    # Apply, also reassigning a stale author fallback
+    python3 scripts/biwenger_recategorise.py 25-26 --apply \\
+        --autor-alias 'Autor Desconocido=#NOALOSCLAUSULAZOS'
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.domain.models import LeagueMessage  # noqa: E402
+from core.sdk.firestore import get_client  # noqa: E402
+from packages.biwenger_tools.scraper_job.logic.processing import (  # noqa: E402
+    categorize_title,
+    process_participation,
+)
+
+
+def _parse_aliases(values: list[str]) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for raw in values:
+        if "=" not in raw:
+            print(
+                f"WARNING: --autor-alias '{raw}' is malformed "
+                "(need OLD=NEW); skipped.",
+                file=sys.stderr,
+            )
+            continue
+        old, _, new = raw.partition("=")
+        aliases[old.strip()] = new.strip()
+    return aliases
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("season", help="Season key, e.g. 25-26")
+    parser.add_argument(
+        "--apply", action="store_true", help="Actually write to Firestore."
+    )
+    parser.add_argument(
+        "--autor-alias",
+        action="append",
+        default=[],
+        metavar="OLD=NEW",
+        help="Reassign autor on every message; repeatable.",
+    )
+    args = parser.parse_args()
+    aliases = _parse_aliases(args.autor_alias)
+    mode = "APPLY" if args.apply else "DRY-RUN"
+
+    print(f"[{mode}] Re-categorise messages for {args.season}")
+    if aliases:
+        print(f"Aliases: {aliases}")
+
+    client = get_client()
+    messages_coll = client.collection(f"comunicados/{args.season}/messages")
+
+    # --- Step 1: Walk messages, decide what to change ---
+    pending_updates = []
+    for snap in messages_coll.stream():
+        data = snap.to_dict() or {}
+        updates: dict = {}
+        expected = categorize_title(data.get("titulo", ""))
+        if expected != (data.get("categoria") or ""):
+            updates["categoria"] = expected
+        new_autor = aliases.get(data.get("autor"))
+        if new_autor:
+            updates["autor"] = new_autor
+        if updates:
+            pending_updates.append((snap, data, updates))
+
+    print(f"\n{len(pending_updates)} message docs need updates.")
+    for snap, data, updates in pending_updates:
+        print(
+            f"  {str(data.get('fecha', ''))[:19]:20s}  "
+            f"{data.get('autor', ''):30s}  "
+            f"{data.get('titulo', '')!r:30s}  {updates}"
+        )
+
+    if args.apply:
+        for snap, _, updates in pending_updates:
+            snap.reference.update(updates)
+        print(f"\nUpdated {len(pending_updates)} message docs.")
+    else:
+        print("\n(dry-run) skipping message updates.")
+
+    # --- Step 2: Rebuild participacion ---
+    # Re-read so the post-update state is used when --apply was passed.
+    all_messages = [
+        LeagueMessage.from_firestore(snap.id, snap.to_dict() or {})
+        for snap in messages_coll.stream()
+    ]
+    authors = sorted(
+        {m.autor for m in all_messages if m.autor and m.autor != "Autor Desconocido"}
+    )
+    synthetic_user_map = {i: name for i, name in enumerate(authors)}
+    participaciones = [
+        p
+        for p in process_participation(all_messages, synthetic_user_map)
+        if p.total > 0
+    ]
+
+    print(f"\nNew participacion totals ({len(participaciones)} authors):")
+    for p in sorted(participaciones, key=lambda p: -p.total):
+        print(
+            f"  {p.autor:30s}  total={p.total:3d}  "
+            f"comunicados={len(p.comunicados):3d}  datos={len(p.datos):3d}  "
+            f"cronicas={len(p.cronicas):3d}  cesiones={len(p.cesiones):3d}"
+        )
+
+    if args.apply:
+        existing = list(
+            client.collection(f"participacion/{args.season}/authors").stream()
+        )
+        for snap in existing:
+            snap.reference.delete()
+        for p in participaciones:
+            client.collection(f"participacion/{args.season}/authors").document(
+                p.autor
+            ).set(p.to_firestore())
+        print(
+            f"\nWiped {len(existing)} existing participacion docs; "
+            f"wrote {len(participaciones)} fresh ones."
+        )
+    else:
+        print("\n(dry-run) skipping participacion rebuild.")
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/biwenger_rename_team.py
+++ b/scripts/biwenger_rename_team.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Rename a team across clausulazos + rebuild tabla_justicia for a season.
+
+When an account is deleted mid-season Biwenger emits a placeholder like
+``Usuario`` in the transfer board, which the scraper persists verbatim
+into ``clausulazos/{season}/transfers``. This script rewrites every
+occurrence of ``--old`` to ``--new`` in both ``equipo_vendedor`` and
+``equipo_comprador`` and then recomputes ``tabla_justicia/{season}/teams``
+from the corrected clausulazos so the per-team aggregates stay consistent.
+
+Default is dry-run; pass ``--apply`` to actually write to Firestore.
+
+Usage::
+
+    python3 scripts/biwenger_rename_team.py 25-26 \\
+        --old Usuario --new '#NOALOSCLAUSULAZOS' [--apply]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.domain.models import Clausulazo  # noqa: E402
+from core.sdk.firestore import get_client  # noqa: E402
+from packages.biwenger_tools.scraper_job.logic.processing import (  # noqa: E402
+    build_tabla_justicia,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("season", help="Season key, e.g. 25-26")
+    parser.add_argument("--old", required=True, help="Name to replace.")
+    parser.add_argument("--new", required=True, help="Replacement name.")
+    parser.add_argument("--apply", action="store_true", help="Write Firestore.")
+    args = parser.parse_args()
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"[{mode}] Rename {args.old!r} → {args.new!r} for {args.season}\n")
+
+    client = get_client()
+    coll = client.collection(f"clausulazos/{args.season}/transfers")
+
+    # --- Step 1: rewrite affected clausulazos ---
+    pending = []
+    for snap in coll.stream():
+        data = snap.to_dict() or {}
+        updates: dict = {}
+        if data.get("equipo_vendedor") == args.old:
+            updates["equipo_vendedor"] = args.new
+        if data.get("equipo_comprador") == args.old:
+            updates["equipo_comprador"] = args.new
+        if updates:
+            pending.append((snap, data, updates))
+
+    print(f"{len(pending)} clausulazo docs to update.")
+    for snap, data, updates in pending:
+        print(
+            f"  {str(data.get('fecha', ''))[:19]:20s}  {snap.id[:12]}  "
+            f"{data.get('jugador'):20s}  {updates}"
+        )
+
+    if args.apply:
+        for snap, _, updates in pending:
+            snap.reference.update(updates)
+        print(f"\nUpdated {len(pending)} clausulazo docs.")
+    else:
+        print("\n(dry-run) skipping clausulazo updates.")
+
+    # --- Step 2: rebuild tabla_justicia from the corrected clausulazos ---
+    all_clausulazos = [
+        Clausulazo.from_firestore(snap.id, snap.to_dict() or {})
+        for snap in coll.stream()
+    ]
+    tabla = build_tabla_justicia(all_clausulazos)
+
+    print(f"\nNew tabla_justicia ({len(tabla)} teams):")
+    for entry in sorted(tabla, key=lambda e: -e.total_hechos):
+        print(
+            f"  {entry.equipo:30s}  hechos={entry.total_hechos:3d}  "
+            f"recibidos={entry.total_recibidos:3d}  "
+            f"mira={entry.punto_de_mira!r}  agresor={entry.mayor_agresor!r}"
+        )
+
+    if args.apply:
+        justice_coll = client.collection(f"tabla_justicia/{args.season}/teams")
+        existing = list(justice_coll.stream())
+        for snap in existing:
+            snap.reference.delete()
+        for entry in tabla:
+            justice_coll.document(entry.equipo).set(entry.to_firestore())
+        print(
+            f"\nWiped {len(existing)} existing tabla_justicia docs; "
+            f"wrote {len(tabla)} fresh ones."
+        )
+    else:
+        print("\n(dry-run) skipping tabla_justicia rebuild.")
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes the 25-26 season end-to-end: a much richer palmarés in Firestore, the
season-rollover skill able to write it automatically, a lenient cronica
classifier so end-of-season posts don't fall through the cracks, and three
small maintenance scripts to fix Firestore drift when an account dies mid-season.

## Commits (in landing order)

### 1. `feat(palmares): per-user standings + LEAGUE_MEMBERS + farolillo folded into multas`
End-of-season palmarés now carries a full per-user table (points, best/worst
round, jornadas ganadas, posición media). New `LEAGUE_MEMBERS` constant maps
stable user_ids → real names so team renames don't break attribution. SDK
gains `get_report_rows` for the generic `report/*` Biwenger endpoint. Web
route + template render a per-user "Clasificación final" table with
tier-based row colours (winner green / loser red / neutro blank) and a
distinct treatment for abandoned accounts. The standalone `farolillo` model
field is dropped — it's now just the last entry of `multas` (legacy docs
merge it in at read time, so 24-25 / 23-24 are untouched).

### 2. `feat(season-rollover): auto-build the palmarés Firestore doc`
`fetch_palmares.py` combines standings + `report/rounds` +
`report/roundPoints`, resolves real names by id, applies the league payout
rule (`N//2` winners + `N%2` neutros + `N//2` losers), and writes the
Firestore doc directly via ADC. `--abandoned-user "NAME=TEAM=REASON"`
injects rows for accounts deleted mid-season. `--write-firestore` is
write-once; pass `--force` to overwrite deliberately. SKILL.md updated
(Drive/CSV paste flow removed — Firestore is the only destination).

### 3. `fix(scraper): lenient cronica title detection`
`categorize_title` now accepts bare `CRÓNICA` and `CRÓNICA <anything>` in
addition to the existing `CRÓNICA - X` / `CRÓNICAS` prefixes. Three 25-26
messages had been silently filed as comunicado.

### 4. `chore(scripts): Firestore maintenance tools + queue CSV-layer removal`
Three reusable diagnostic / fix scripts under `scripts/biwenger_*`:
- `biwenger_check_categorias.py` — flag stored vs. expected categoría drift
- `biwenger_recategorise.py` — re-apply current `categorize_title` + rebuild
  participacion; supports `--autor-alias OLD=NEW` for deleted accounts
- `biwenger_rename_team.py` — rename a team across clausulazos + rebuild
  tabla_justicia

PENDING.md gains an entry to remove the legacy CSV serialization layer once
the Drive cleanup ships.

## Manual verification done before opening this PR

- Wrote `palmares/25-26` to Firestore via `fetch_palmares.py --write-firestore`.
- Backfilled three miscategorised crónicas + reassigned the deleted-author
  fallback for one of them; rebuilt `participacion/25-26/authors`.
- Renamed `Usuario` → `#NOALOSCLAUSULAZOS` in the one affected clausulazo;
  rebuilt `tabla_justicia/25-26/teams`.

## Test plan

- [x] `bazel test //...` — green
- [x] black + flake8 — clean
- [x] Local web checked at `/palmares` — heading, tiers, abandoned styling
  all render as expected
- [ ] After merge, Cloud Run deploy of web + scraper completes green
- [ ] Open `/palmares` in prod and confirm the new 25-26 card renders