### PR TITLE
chore: season rollover 25-26 → 26-27

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ env:
   REGION: europe-southwest1
   PROJECT_ID: biwenger-tools
   REGISTRY: europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker
-  TEMPORADA_ACTUAL: "25-26"
+  TEMPORADA_ACTUAL: "26-27"
 
 jobs:
   # -------------------------------------------------------

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -153,7 +153,7 @@ Commands for running each component.
           gcloud run jobs update biwenger-scraper-data \
               --image europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker/scraper_job \
               --region europe-southwest1 \
-              --update-env-vars TEMPORADA_ACTUAL=25-26
+              --update-env-vars TEMPORADA_ACTUAL=26-27
         ```
       * **Execute the Job manually:**
         ```bash

--- a/packages/biwenger_tools/scraper_job/config.py
+++ b/packages/biwenger_tools/scraper_job/config.py
@@ -15,7 +15,7 @@ load_dotenv()
 # --- CONFIGURACIÓN DE TEMPORADA ---
 # Para cambiar de temporada: actualizar TEMPORADA_ACTUAL en deploy.yml (env global)
 # o via: gcloud run jobs update ... --update-env-vars TEMPORADA_ACTUAL=26-27
-TEMPORADA_ACTUAL = os.getenv("TEMPORADA_ACTUAL", "25-26")
+TEMPORADA_ACTUAL = os.getenv("TEMPORADA_ACTUAL", "26-27")
 
 # --- BIWENGER CREDENTIALS ---
 # Prod: BIWENGER_CREDENTIALS_JSON in Secret Manager.

--- a/packages/biwenger_tools/web/config.py
+++ b/packages/biwenger_tools/web/config.py
@@ -16,9 +16,9 @@ SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
 # --- Season configuration ---
 # To roll over a season: bump TEMPORADA_ACTUAL in deploy.yml (global env)
 # or via: gcloud run services update ... --update-env-vars TEMPORADA_ACTUAL=26-27
-TEMPORADA_ACTUAL = os.getenv("TEMPORADA_ACTUAL", "25-26")
+TEMPORADA_ACTUAL = os.getenv("TEMPORADA_ACTUAL", "26-27")
 # Prepend the new season at the start of each year (see docs/operations.md).
-TEMPORADAS_DISPONIBLES = ["24-25", "25-26"]
+TEMPORADAS_DISPONIBLES = ["24-25", "25-26", "26-27"]
 
 # Per-season Sheet IDs for the Lloros Awards pages. Hand-edited in Sheets
 # by the user, never moved to Firestore.

--- a/packages/biwenger_tools/web/tests/test_web_app.py
+++ b/packages/biwenger_tools/web/tests/test_web_app.py
@@ -230,11 +230,13 @@ def test_palmares_renders_multas_with_farolillo_marker(mock_get, client):
 @patch("packages.biwenger_tools.web.routes.season.get_sheets_data")
 def test_api_lloros_ligas_returns_sheets_data(mock_get_sheets, client):
     """The endpoint forwards the sheets_data result for the active season."""
+    from packages.biwenger_tools.web import config
+
     payload = [{"nombre": "Liga A", "headers": ["Pos", "Equipo"], "rows": [["1", "X"]]}]
     mock_get_sheets.return_value = payload
     with patch(
         "packages.biwenger_tools.web.routes.season.config.LIGAS_ESPECIALES_SHEETS",
-        {"25-26": "sheet-id-test"},
+        {config.TEMPORADA_ACTUAL: "sheet-id-test"},
     ):
         response = client.get("/api/lloros-awards/ligas")
     assert response.status_code == 200
@@ -255,11 +257,13 @@ def test_api_lloros_ligas_returns_empty_when_no_sheet_configured(client):
 
 @patch("packages.biwenger_tools.web.routes.season.get_sheets_data")
 def test_api_lloros_trofeos_returns_sheets_data(mock_get_sheets, client):
+    from packages.biwenger_tools.web import config
+
     payload = [{"nombre": "Pichichi", "headers": ["Goleador"], "rows": [["X"]]}]
     mock_get_sheets.return_value = payload
     with patch(
         "packages.biwenger_tools.web.routes.season.config.TROFEOS_SHEETS",
-        {"25-26": "sheet-id-test"},
+        {config.TEMPORADA_ACTUAL: "sheet-id-test"},
     ):
         response = client.get("/api/lloros-awards/trofeos")
     assert response.status_code == 200


### PR DESCRIPTION
## Season rollover: 25-26 → 26-27

Automated changes prepared by the `season-rollover` skill.

### Files changed
- `.github/workflows/deploy.yml` — `TEMPORADA_ACTUAL` env updated
- `packages/biwenger_tools/web/config.py` — default updated, `26-27` appended to `TEMPORADAS_DISPONIBLES`
- `packages/biwenger_tools/scraper_job/config.py` — default updated
- `docs/operations.md` — manual gcloud example updated
- `packages/biwenger_tools/web/tests/test_web_app.py` — two Lloros sheets tests no longer hardcode the season; they read `config.TEMPORADA_ACTUAL` so the next rollover doesn't break them

### Not included (local only, gitignored)
- `web/.env` and `scraper_job/.env` — updated locally, not committed

### Palmares
`palmares/25-26` was written to Firestore in the previous PR (#119). No action needed here.

### Operational
- `biwenger-scraper-data-scheduler-trigger` Cloud Scheduler job paused before opening this PR (will be re-enabled once Biwenger resets its data for the new season).

### After merging
CI deploys both services automatically with `TEMPORADA_ACTUAL=26-27`.