### PR TITLE
feat(sdk): add place_clausulazo to the Biwenger client

### DIFF
--- a/core/sdk/biwenger.py
+++ b/core/sdk/biwenger.py
@@ -348,6 +348,62 @@ class BiwengerClient:
         )
         return data
 
+    def place_clausulazo(
+        self,
+        *,
+        player_id: int,
+        amount: int,
+        seller_user_id: int,
+        offers_url: str = OFFERS_URL,
+    ) -> dict:
+        """POST a clausulazo offer (release-clause buyout of another user's player).
+
+        Body shape (inferred from the response captured on 2026-05-26 and
+        the symmetric ``place_market_bid`` body — verify the first time
+        this is exercised against Biwenger by inspecting the DevTools
+        "Payload" tab):
+
+            {"to": <seller_user_id>, "type": "clause",
+             "amount": <eur>, "requestedPlayers": [<player_id>]}
+
+        ``to`` carries the current owner's user id (the seller); the
+        ``fromID`` in Biwenger's response is the authenticated buyer.
+        ``amount`` must be at least the player's current release clause
+        — Biwenger rejects lower amounts with 4xx.
+
+        Returns Biwenger's ``data`` dict (includes ``id``, ``status``,
+        ``created`` and the echoed ``fromID``/``toID``/``amount``/``type``).
+        """
+        payload = {
+            "to": int(seller_user_id),
+            "type": "clause",
+            "amount": int(amount),
+            "requestedPlayers": [int(player_id)],
+        }
+        logger.info(
+            "Placing clausulazo.",
+            extra={
+                "player_id": player_id,
+                "amount": amount,
+                "seller_user_id": seller_user_id,
+            },
+        )
+        response = retry_http_request(
+            lambda: self.session.post(offers_url, json=payload, timeout=30),
+            label="clausulazo POST",
+        )
+        data = response.json().get("data", {}) or {}
+        logger.info(
+            "Clausulazo accepted.",
+            extra={
+                "player_id": player_id,
+                "amount": amount,
+                "offer_id": data.get("id"),
+                "status": data.get("status"),
+            },
+        )
+        return data
+
     def get_clausulazos(self, clausulazos_url: str) -> dict:
         """Returns a single page of release-clause transfer entries."""
         response = self.session.get(clausulazos_url)

--- a/core/tests/test_biwenger_client.py
+++ b/core/tests/test_biwenger_client.py
@@ -306,6 +306,69 @@ def test_place_market_bid_posts_offer_with_expected_body(
     }
 
 
+def test_place_clausulazo_posts_offer_with_expected_body(
+    biwenger_client_authenticated,
+):
+    """Clausulazo body shape: same `/offers` endpoint as bids, but
+    `to=<seller_user_id>` (the current owner) and `type="clause"`.
+
+    Response shape mirrors `place_market_bid` (data block has `fromID`,
+    `toID`, `amount`, `type`, `status`, `id`).
+    """
+    client = biwenger_client_authenticated
+    captured_response = {
+        "status": 200,
+        "data": {
+            "fromID": 1372802,
+            "type": "clause",
+            "amount": 1_420_004,
+            "created": 1779822946,
+            "modified": 1779822946,
+            "status": "processed",
+            "toID": 12449616,
+            "id": 1505330715,
+        },
+    }
+    with requests_mock.Mocker() as m:
+        m.post(TEST_OFFERS_URL, json=captured_response, status_code=200)
+        data = client.place_clausulazo(
+            player_id=99999,
+            amount=1_420_004,
+            seller_user_id=12449616,
+            offers_url=TEST_OFFERS_URL,
+        )
+
+    assert data["id"] == 1505330715
+    assert data["status"] == "processed"
+    assert data["type"] == "clause"
+    assert m.last_request.json() == {
+        "to": 12449616,
+        "type": "clause",
+        "amount": 1_420_004,
+        "requestedPlayers": [99999],
+    }
+
+
+def test_place_clausulazo_coerces_numeric_args_to_int(biwenger_client_authenticated):
+    """Coerce any numeric input to plain int — Biwenger 400s on floats."""
+    client = biwenger_client_authenticated
+    with requests_mock.Mocker() as m:
+        m.post(TEST_OFFERS_URL, json={"data": {}}, status_code=200)
+        client.place_clausulazo(
+            player_id="99999",  # type: ignore[arg-type]
+            amount=1_420_004.0,  # type: ignore[arg-type]
+            seller_user_id="12449616",  # type: ignore[arg-type]
+            offers_url=TEST_OFFERS_URL,
+        )
+    body = m.last_request.json()
+    assert body == {
+        "to": 12449616,
+        "type": "clause",
+        "amount": 1_420_004,
+        "requestedPlayers": [99999],
+    }
+
+
 def test_place_market_bid_coerces_numeric_args_to_int(biwenger_client_authenticated):
     """Callers may pass numpy ints, floats from intermediate maths, etc.; the
     payload must always serialise as plain ints (Biwenger 400s on floats)."""


### PR DESCRIPTION
## Summary

Adds `BiwengerClient.place_clausulazo(player_id, amount, seller_user_id)` next to the existing `place_market_bid`. Targets the same `POST /api/v2/offers` endpoint with `type="clause"` and `to=<seller_user_id>`.

## Source of the body shape

The response was captured live on 2026-05-26 (real clausulazo of Aleñá, 1.420.004 € from Pablo → Jorge):

\`\`\`json
{"status": 200,
 "data": {"fromID": 1372802, "type": "clause", "amount": 1420004,
          "status": "processed", "toID": 12449616, "id": 1505330715, ...}}
\`\`\`

The request body wasn't captured — the implementation infers it from `place_market_bid` (same endpoint, same response shape) and labels the relevant fields. **The first caller that actually exercises this method should verify the body via DevTools "Payload" tab and adjust if Biwenger expects different field names.**

## What's NOT in this PR

No production caller. The SDK method exists; no api endpoint, no bot command, no auto-bid integration. Added because the user asked to have it ready for future automation.

## Test plan

- [x] `bazel test //core:core_tests` — both new tests green
- [x] `black` + `flake8` clean
- [ ] First live invocation: capture the actual request payload to confirm the inferred body shape