### PR TITLE
feat(api): distinguish no-cash skip in auto-bid summary

### DIFF
--- a/packages/biwenger_tools/api/logic/auto_bid.py
+++ b/packages/biwenger_tools/api/logic/auto_bid.py
@@ -227,6 +227,38 @@ def _log_bid(day: str, candidate: dict, bid_amount: int, offer: dict) -> None:
     )
 
 
+def _format_skip_line(entry: dict, esc) -> str:
+    """Render one skipped entry. Dispatches on `kind`:
+
+    - `no_cash`     → 💸 with SF + tier label so we can see what we missed.
+    - `already_bid` → 🔁 (idempotency replay).
+    - `biwenger_reject` → ⚠️ (Biwenger 4xx on the POST).
+    - `tier_low` (or missing kind) → ⏭️ + the bare reason string.
+
+    The `no_cash` branch is the user-visible payoff: it stops looking
+    like a generic "skip" so a SF 700 / T2 player blocked purely by
+    budget is visually distinct from a SF 280 / no-tier player.
+    """
+    kind = entry.get("kind")
+    name = esc(entry["name"])
+    if kind == "no_cash":
+        # The literal `>` between bid and cash must be pre-escaped as
+        # `&gt;` because Telegram's HTML parser reads a bare `>` after
+        # whitespace as the end of a tag and rejects the whole message.
+        return (
+            f"💸 Sin pasta para <b>{name}</b> · "
+            f"{esc(entry['tier_label'])} · "
+            f"puja {esc(_euros(entry['bid']))} &gt; "
+            f"cash {esc(_euros(entry['cash']))}"
+        )
+    if kind == "already_bid":
+        return f"🔁 Ya pujado <b>{name}</b>"
+    if kind == "biwenger_reject":
+        return f"⚠️ Biwenger rechazó <b>{name}</b>"
+    reason = esc(entry.get("reason") or "saltado")
+    return f"⏭️ Saltado <b>{name}</b> ({reason})"
+
+
 def _format_telegram_text(
     day: str,
     placed: list[dict],
@@ -253,11 +285,8 @@ def _format_telegram_text(
             f"<b>{esc(entry['name'])}</b> ({esc(entry['tier_label'])})"
         )
 
-    if skipped:
-        for entry in skipped:
-            lines.append(
-                f"⏭️ Saltado <b>{esc(entry['name'])}</b> ({esc(entry['reason'])})"
-            )
+    for entry in skipped:
+        lines.append(_format_skip_line(entry, esc))
 
     if not placed and not skipped:
         lines.append("Sin candidatos en el mercado diario.")
@@ -318,7 +347,7 @@ def run_auto_bid() -> dict:
                 {
                     "player_id": candidate["player_id"],
                     "name": candidate["name"],
-                    "reason": "ya pujado hoy",
+                    "kind": "already_bid",
                 }
             )
             continue
@@ -334,18 +363,25 @@ def run_auto_bid() -> dict:
                     {
                         "player_id": candidate["player_id"],
                         "name": candidate["name"],
+                        "kind": "tier_low",
+                        "sf": candidate["sf"],
                         "reason": label,
                     }
                 )
             continue
         if target_bid <= 0 or target_bid > remaining_cash:
+            # Out-of-budget skip carries the SF + tier label so the summary
+            # shows what a richer wallet would have grabbed (and so this skip
+            # is visually distinct from a tier_low "irrelevant" skip).
             skipped.append(
                 {
                     "player_id": candidate["player_id"],
                     "name": candidate["name"],
-                    "reason": (
-                        f"bid {_euros(target_bid)} > cash {_euros(remaining_cash)}"
-                    ),
+                    "kind": "no_cash",
+                    "sf": candidate["sf"],
+                    "tier_label": label,
+                    "bid": target_bid,
+                    "cash": remaining_cash,
                 }
             )
             continue
@@ -368,7 +404,7 @@ def run_auto_bid() -> dict:
                 {
                     "player_id": candidate["player_id"],
                     "name": candidate["name"],
-                    "reason": "Biwenger rechazó la puja",
+                    "kind": "biwenger_reject",
                 }
             )
             continue

--- a/packages/biwenger_tools/api/tests/test_auto_bid.py
+++ b/packages/biwenger_tools/api/tests/test_auto_bid.py
@@ -222,7 +222,14 @@ def test_format_telegram_text_renders_placed_skipped_and_totals():
         },
     ]
     skipped = [
-        {"name": "Bellingham", "reason": "bid 14.000.000 € > cash 3.000.000 €"},
+        {
+            "name": "Bellingham",
+            "kind": "no_cash",
+            "sf": 750,
+            "tier_label": "T2 (SF 750)",
+            "bid": 14_000_000,
+            "cash": 3_000_000,
+        },
     ]
     text = auto_bid._format_telegram_text(
         day="2026-05-23",
@@ -237,6 +244,55 @@ def test_format_telegram_text_renders_placed_skipped_and_totals():
     assert "Bellingham" in text
     assert "Total pujado: <b>43.000.000 €</b>" in text
     assert "Cash restante: <b>3.000.000 €</b>" in text
+
+
+def test_format_telegram_text_no_cash_skip_shows_sf_and_tier():
+    """The whole point of `kind=no_cash`: the user can tell what a richer
+    wallet would have grabbed. Tier label + SF live in the skip line,
+    and the icon is 💸 (not ⏭️) so it's visually distinct from a
+    tier_low skip in the same message."""
+    skipped = [
+        {
+            "name": "Bellingham",
+            "kind": "no_cash",
+            "sf": 750,
+            "tier_label": "T2 (SF 750)",
+            "bid": 14_000_000,
+            "cash": 3_000_000,
+        }
+    ]
+    text = auto_bid._format_telegram_text(
+        day="2026-05-23",
+        placed=[],
+        skipped=skipped,
+        total_bid=0,
+        remaining_cash=3_000_000,
+    )
+    assert "💸 Sin pasta para <b>Bellingham</b>" in text
+    assert "T2 (SF 750)" in text
+    # `>` gets HTML-escaped to `&gt;` so Telegram's HTML parser doesn't
+    # read it as a tag start (this is the 2026-05-24 regression).
+    assert "puja 14.000.000 € &gt; cash 3.000.000 €" in text
+
+
+def test_format_telegram_text_renders_each_skip_kind_with_own_icon():
+    """Every kind branch renders a distinct icon. tier_low keeps the
+    legacy ⏭️ + bare reason so a SF 280 skip still looks unchanged."""
+    skipped = [
+        {"name": "AlreadyBid", "kind": "already_bid"},
+        {"name": "Reject", "kind": "biwenger_reject"},
+        {"name": "LowTier", "kind": "tier_low", "sf": 280, "reason": "SF 280 < 300"},
+    ]
+    text = auto_bid._format_telegram_text(
+        day="2026-05-23",
+        placed=[],
+        skipped=skipped,
+        total_bid=0,
+        remaining_cash=1_000_000,
+    )
+    assert "🔁 Ya pujado <b>AlreadyBid</b>" in text
+    assert "⚠️ Biwenger rechazó <b>Reject</b>" in text
+    assert "⏭️ Saltado <b>LowTier</b> (SF 280 &lt; 300)" in text
 
 
 def test_format_telegram_text_html_escapes_user_content():
@@ -256,8 +312,13 @@ def test_format_telegram_text_html_escapes_user_content():
     skipped = [
         {
             "name": "Bellingham",
-            # The actual reason format from run_auto_bid — has literal `>`.
-            "reason": "bid 14.000.000 € > cash 3.000.000 €",
+            "kind": "no_cash",
+            "sf": 750,
+            # Tier label is rendered as-is; if it ever carries `<` or `&`
+            # the escape must catch it.
+            "tier_label": "T2 (SF 750)",
+            "bid": 14_000_000,
+            "cash": 3_000_000,
         }
     ]
     text = auto_bid._format_telegram_text(
@@ -270,13 +331,10 @@ def test_format_telegram_text_html_escapes_user_content():
     # Raw user-controlled `<`, `>`, `&` must NOT appear anywhere outside
     # of our intentional `<b>...</b>` wrappers.
     assert "&lt;Player &amp; Co&gt;" in text
-    assert "bid 14.000.000 € &gt; cash 3.000.000 €" in text
-    # The two literal `<` characters in our template must be exactly the
-    # ones we emitted (4 <b> open + 4 </b> close + 1 <b> in skipped + 1
-    # </b> in skipped + 2 in totals + 0 footer = 12 angle-bracket pairs).
+    # `>` inside the no_cash line is the literal "bid > cash" separator.
+    assert "puja 14.000.000 € &gt; cash 3.000.000 €" in text
     assert text.count("<b>") == text.count("</b>")  # balanced template tags
-    # No unescaped `>` in the skipped-line reason payload.
-    assert "> cash" not in text
+    assert "> cash" not in text  # no unescaped `>` left in the payload
 
 
 def test_format_telegram_text_handles_no_candidates():
@@ -406,6 +464,52 @@ def test_run_auto_bid_places_tiered_bids_and_stops_when_cash_runs_out(run_env):
     assert result["skipped_count"] == 2  # Lewa + Pedri don't fit
     assert result["sent"] == 1
     mock_send.assert_called_once()
+
+
+def test_run_auto_bid_first_too_expensive_does_not_block_cheaper_next(run_env):
+    """Edge case the user asked about: 3 candidates by SF desc, the
+    most expensive is unaffordable but the next one fits — the loop
+    must keep going and bid the second one. Without the `continue` on
+    `target_bid > remaining_cash`, the whole batch would be aborted.
+
+    Setup:
+    - cash = 5M.
+    - P1 (SF 750, price 8M) → T2 bid 13M → no_cash skip (13M > 5M cash).
+    - P2 (SF 720, price 2M) → T2 bid 3.4M → placed.
+    - P3 (SF 280) → tier_low skip (below SF 300 floor, but >200 so it
+      lands in the summary).
+    """
+    market = [_sale(1), _sale(2), _sale(3)]
+    biwenger_players = {
+        1: _bw(1, "Expensive", 8_000_000),
+        2: _bw(2, "Cheaper", 2_000_000),
+        3: _bw(3, "LowSf", 500_000),
+    }
+    jp_players = [
+        _jp_with_sf("Expensive", 750),
+        _jp_with_sf("Cheaper", 720),
+        _jp_with_sf("LowSf", 280),
+    ]
+    biwenger, mock_send = run_env(
+        market_players=market,
+        biwenger_players=biwenger_players,
+        jp_players=jp_players,
+        cash=5_000_000,
+    )
+    result = auto_bid.run_auto_bid()
+
+    # Only the cheaper player gets a bid. The expensive one is skipped
+    # by budget; the low-SF one is skipped by tier floor.
+    biwenger.place_market_bid.assert_called_once_with(player_id=2, amount=3_400_000)
+    assert result["bid_count"] == 1
+    assert result["skipped_count"] == 2
+
+    # Telegram message must visually distinguish the two skips: 💸 for
+    # the budget skip (with SF + tier), ⏭️ for the irrelevant skip.
+    text = mock_send.call_args.kwargs["text"]
+    assert "💸 Sin pasta para <b>Expensive</b>" in text
+    assert "T2 (SF 750)" in text
+    assert "⏭️ Saltado <b>LowSf</b>" in text
 
 
 def test_run_auto_bid_skips_already_bid_today(run_env):


### PR DESCRIPTION
## Summary
- Auto-bid skips now carry a `kind` (`no_cash`, `tier_low`, `already_bid`, `biwenger_reject`); the Telegram summary renders a distinct icon per case so a budget-blocked SF 750 player no longer looks like a SF 280 irrelevant skip.
- `no_cash` skip line shows the SF + tier label inline (e.g. `💸 Sin pasta para Bellingham · T2 (SF 750) · puja 14.000.000 € > cash 3.000.000 €`).
- Added e2e test pinning the "3 candidates, first too expensive, second affordable" path — the loop continues past a no-cash skip and bids the next candidate.

## Test plan
- [x] `bazel test //packages/biwenger_tools/api:api_tests` passes locally.
- [x] flake8 + black clean.
- [ ] After merge: observe tomorrow's 09:00 Madrid digest — when a candidate is skipped by budget, the summary uses 💸 with SF/tier instead of ⏭️ with a bare reason.