### PR TITLE
feat(bot): /emergencia clausulazo with inline confirmation

### DIFF
--- a/packages/biwenger_tools/api/app.py
+++ b/packages/biwenger_tools/api/app.py
@@ -16,6 +16,7 @@ from packages.biwenger_tools.api.logic import (
     actions,
     auto_bid,
     digests,
+    emergency,
     recommendations,
     scraper,
 )
@@ -146,6 +147,48 @@ def budget_recommendations():
 def scraper_trigger():
     """Queue an execution of the scraper Cloud Run Job — bot's /scrapper."""
     return _run_action("scraper.trigger", scraper.run_trigger_scraper)
+
+
+@app.route("/emergency/clausulazo/preview", methods=["POST"])
+def emergency_clausulazo_preview():
+    """Compute the emergency target + post confirmation message — bot's /emergencia.
+
+    Side effect: one Telegram message with an inline keyboard (Sí/No).
+    The bot does not read the JSON response — the confirmation flow
+    rides on the inline-keyboard callback the user taps.
+    """
+    return _run_action("emergency.preview", emergency.preview_clausulazo)
+
+
+@app.route("/emergency/clausulazo/execute", methods=["POST"])
+def emergency_clausulazo_execute():
+    """Fire the approved clausulazo.
+
+    Query params (passed by the bot from the inline-keyboard payload):
+      - `player_id` — Biwenger player id to clause.
+      - `owner_id` — current owner's user id (becomes `to` in the POST).
+      - `amount` — euros (must be ≥ clause_value or Biwenger 4xxes).
+    """
+    try:
+        player_id = int(request.args["player_id"])
+        owner_id = int(request.args["owner_id"])
+        amount = int(request.args["amount"])
+    except (KeyError, TypeError, ValueError):
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "error": "player_id, owner_id, amount required (int)",
+                }
+            ),
+            400,
+        )
+    return _run_action(
+        "emergency.execute",
+        lambda: emergency.execute_clausulazo(
+            player_id=player_id, owner_user_id=owner_id, amount=amount
+        ),
+    )
 
 
 # --- Scheduler-triggered endpoints -----------------------------------------

--- a/packages/biwenger_tools/api/config.py
+++ b/packages/biwenger_tools/api/config.py
@@ -35,6 +35,8 @@ LINEUP_URL = biwenger_sdk.LINEUP_URL
 ALL_PLAYERS_DATA_URL = biwenger_sdk.ALL_PLAYERS_DATA_URL
 LEAGUE_DATA_URL = biwenger_sdk.league_standings_url(LEAGUE_ID)
 USER_SQUAD_URL = biwenger_sdk.manager_squad_url("{manager_id}")
+CLAUSULAZOS_URL = biwenger_sdk.clausulazos_url(LEAGUE_ID)
+OFFERS_URL = biwenger_sdk.OFFERS_URL
 
 # --- JORNADA PERFECTA (private API) ---
 # Token sourced from BIWENGER_CREDENTIALS_JSON.jp_auth_token — it belongs to

--- a/packages/biwenger_tools/api/logic/clausulazo_candidates.py
+++ b/packages/biwenger_tools/api/logic/clausulazo_candidates.py
@@ -1,0 +1,90 @@
+"""Shared helpers to enumerate rival clausulazo candidates.
+
+Used by `recommendations.run_recommendations` (top-N per position, with
+margin) and `emergency.preview_clausulazo` (top-1 in a chosen position,
+with cash-justo / no margin). Kept here so both flows agree on:
+
+- which players are excluded (mine, clause-locked, no SF score, GK
+  with only 1 GK in the rival squad — the "don't break a rival" house rule);
+- which fields a candidate row carries (incl. `owner_user_id`, needed
+  by `place_clausulazo` for the `to=<seller>` payload field).
+"""
+
+import time
+
+from core.sdk.biwenger import BiwengerClient
+from core.sdk.jp import get_predict_rate
+from core.utils import get_logger
+from packages.biwenger_tools.api import config
+from packages.biwenger_tools.api.logic.rows import build_squad_rows
+from packages.biwenger_tools.api.player_formatting import SCORE_SF
+
+logger = get_logger(__name__)
+
+GK_POSITION_ID = 1
+
+
+def sf_of(row: dict) -> int:
+    jp = row.get("jp_player")
+    if not jp:
+        return 0
+    return get_predict_rate(jp, SCORE_SF) or 0
+
+
+def gather_rivals(
+    biwenger: BiwengerClient,
+    biwenger_players: dict,
+    jp_index: dict,
+) -> list[dict]:
+    """Build the rival_rows list, tagged with owner name + user id.
+
+    Skips the logged-in user's own squad. Each row carries:
+    - `owner` (manager name) — used by the recommendations message.
+    - `owner_user_id` (manager id) — used by emergency to fill
+      `place_clausulazo`'s `to=<seller_user_id>` payload field.
+    - `owner_gk_count` — used by `filter_affordable` to enforce the
+      "don't leave a rival with zero GKs" house rule.
+    """
+    managers = biwenger.get_league_users(config.LEAGUE_DATA_URL)
+    rivals: list[dict] = []
+    for manager_id, manager_name in managers.items():
+        if manager_id == biwenger.user_id:
+            continue
+        squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, manager_id)
+        rows = build_squad_rows(squad, biwenger_players, jp_index, include_clause=True)
+        gk_count = sum(1 for r in rows if r.get("position_id") == GK_POSITION_ID)
+        for r in rows:
+            r["owner"] = manager_name
+            r["owner_user_id"] = manager_id
+            r["owner_gk_count"] = gk_count
+            rivals.append(r)
+        time.sleep(0.3)
+    return rivals
+
+
+def filter_affordable(candidates: list[dict], my_ids: set, target: int) -> list[dict]:
+    """Keep candidates I can actually afford (clause ≤ target) and skip mine.
+
+    Also enforces the house rule that we never clauselazo a rival's only
+    goalkeeper — Biwenger would technically allow it but the league agreed
+    leaving someone with zero GKs is unsportsmanlike. The same rule does
+    not apply to outfield positions (rivals are expected to rebuild).
+    """
+    out: list[dict] = []
+    for row in candidates:
+        if row.get("bw_id") in my_ids:
+            continue
+        if not row.get("clausulable_now", False):
+            continue
+        clause = row.get("clause_value") or 0
+        if clause <= 0 or clause > target:
+            continue
+        if sf_of(row) <= 0:
+            continue
+        if (
+            row.get("position_id") == GK_POSITION_ID
+            and (row.get("owner_gk_count") or 0) <= 1
+        ):
+            continue
+        out.append(row)
+    return out

--- a/packages/biwenger_tools/api/logic/emergency.py
+++ b/packages/biwenger_tools/api/logic/emergency.py
@@ -1,0 +1,348 @@
+"""Emergency clausulazo — `POST /emergency/clausulazo/{preview,execute}`.
+
+Manual, on-demand operation triggered from the Telegram bot via
+`/emergencia`. Two phases:
+
+1. **Preview** — read my cash, decide which position needs reinforcing
+   (the line I just lost to a recent clausulazo, or the weakest outfield
+   line if none), pick the best affordable rival in that position, and
+   post a confirmation message with inline-keyboard buttons.
+2. **Execute** — fired by the bot when the user taps "Sí" on the inline
+   keyboard. Calls `place_clausulazo` against the exact `player_id` /
+   `owner_user_id` / `amount` the user approved, and notifies the
+   result.
+
+Hard rules:
+
+- Cash is **justo** — `target = cash` (no dynamic margin, unlike
+  `/recomendar`). The op must never push me into the red.
+- `amount = clause_value` exactly — minimum valid clausulazo, no inflation.
+- Multi-position players lost are NOT used to pick a target position
+  (their loss is ambiguous → fall back to the weakest-line rule).
+- Never clause a rival's only GK (shared `filter_affordable` house rule).
+"""
+
+import time
+from typing import Optional
+
+from core.sdk.biwenger import BiwengerClient
+from core.sdk.telegram import send_telegram_message_or_raise
+from core.utils import get_logger
+from packages.biwenger_tools.api import config
+from packages.biwenger_tools.api.logic.clausulazo_candidates import (
+    filter_affordable,
+    gather_rivals,
+    sf_of,
+)
+from packages.biwenger_tools.api.logic.orchestration import (
+    build_biwenger_session,
+    build_context,
+    require_telegram,
+)
+from packages.biwenger_tools.api.player_formatting import POSITION_SHORT
+
+logger = get_logger(__name__)
+
+RECENT_CLAUSULAZO_WINDOW_SECONDS = 24 * 60 * 60
+
+# Position-pick order when reinforcing the weakest line. GK is out of
+# scope (we don't clausulazo a GK on emergency). DEF goes first on
+# ties, then MID, then FWD — the lower-cost positions cover faster.
+_OUTFIELD_POSITION_IDS = (2, 3, 4)
+_POSITION_LABELS_ES = {1: "Portero", 2: "Defensa", 3: "Centrocampista", 4: "Delantero"}
+
+
+def _euros(n: int | None) -> str:
+    if n is None:
+        return "—"
+    s = f"{int(n):,}".replace(",", ".")
+    return f"{s} €"
+
+
+def _is_multi_position(bw_player: dict) -> bool:
+    """A multi-position player has at least one `altPositions` entry."""
+    return bool(bw_player.get("altPositions") or [])
+
+
+def _recent_lost_position(
+    biwenger: BiwengerClient,
+    biwenger_players: dict,
+    my_manager_name: str,
+    now_epoch: float,
+) -> tuple[Optional[int], Optional[str]]:
+    """Scan the transfer board for clausulazos against me in the last 24h.
+
+    Returns `(position_id, player_name)` of the most-recent lost player
+    if found AND the player is single-position, else `(None, None)`.
+    Multi-position losses are intentionally suppressed (ambiguous which
+    line to reinforce — fall back to weakest-line).
+
+    Detection compares `from.id == biwenger.user_id` first; some board
+    payload variants only expose `from.name`, so we fall back to a name
+    match. Either is sufficient — we own both sides of the lookup.
+    """
+    raw = biwenger.get_all_clausulazos(config.CLAUSULAZOS_URL)
+    entries = raw.get("data", []) or []
+    if isinstance(entries, dict):
+        entries = list(entries.values())
+
+    cutoff = now_epoch - RECENT_CLAUSULAZO_WINDOW_SECONDS
+    matches: list[tuple[float, dict]] = []
+    for entry in entries:
+        entry_date = entry.get("date", 0) or 0
+        if entry_date < cutoff:
+            continue
+        for item in entry.get("content") or []:
+            if item.get("type") != "clause":
+                continue
+            from_obj = item.get("from") or {}
+            from_id = from_obj.get("id")
+            from_name = from_obj.get("name")
+            is_me = (from_id is not None and int(from_id) == int(biwenger.user_id)) or (
+                from_name and my_manager_name and from_name == my_manager_name
+            )
+            if is_me:
+                matches.append((entry_date, item))
+
+    if not matches:
+        return None, None
+
+    matches.sort(key=lambda pair: pair[0], reverse=True)
+    item = matches[0][1]
+    player_ref = item.get("player")
+    player_id = player_ref.get("id") if isinstance(player_ref, dict) else player_ref
+    bw_player = biwenger_players.get(player_id)
+    if not bw_player:
+        return None, None
+    if _is_multi_position(bw_player):
+        return None, bw_player.get("name")
+    return bw_player.get("position"), bw_player.get("name")
+
+
+def _weakest_outfield_position(my_squad: list, biwenger_players: dict) -> int:
+    """Position id with the fewest players among DEF/MID/FWD.
+
+    Ties break in DEF > MID > FWD order — lower-tier positions get
+    filled first because affordable replacements are easier to find.
+    """
+    counts = {pos: 0 for pos in _OUTFIELD_POSITION_IDS}
+    for entry in my_squad:
+        bw_player = biwenger_players.get(entry.get("id"))
+        if not bw_player:
+            continue
+        pos = bw_player.get("position")
+        if pos in counts:
+            counts[pos] += 1
+    # Tie-break order: iterate _OUTFIELD_POSITION_IDS so DEF (2) wins
+    # over MID (3) over FWD (4) when counts are equal.
+    return min(_OUTFIELD_POSITION_IDS, key=lambda pos: (counts[pos], pos))
+
+
+def _pick_target(
+    candidates: list[dict], preferred_position: int
+) -> tuple[Optional[dict], str]:
+    """Top SF in `preferred_position`; fall back to top SF overall.
+
+    Returns `(candidate, fallback_note)`. `fallback_note` is empty if a
+    candidate in the preferred position was found, non-empty otherwise
+    so the message can say "no DEF afford(able), going for the best
+    SF instead".
+    """
+    in_position = [c for c in candidates if c.get("position_id") == preferred_position]
+    if in_position:
+        in_position.sort(key=sf_of, reverse=True)
+        return in_position[0], ""
+    if not candidates:
+        return None, ""
+    candidates_sorted = sorted(candidates, key=sf_of, reverse=True)
+    return candidates_sorted[0], (
+        f"sin candidatos en {_POSITION_LABELS_ES[preferred_position]}, "
+        "voy al mejor SF disponible"
+    )
+
+
+def _confirmation_keyboard(player_id: int, owner_id: int, amount: int) -> dict:
+    """Inline keyboard with Sí/No.
+
+    `callback_data` is capped at 64 bytes by Telegram. The packed
+    `e:c:<player>:<owner>:<amount>` payload is ~30 chars on real
+    numbers (player/owner ids are 6 digits, amount up to 9 digits).
+    """
+    return {
+        "inline_keyboard": [
+            [
+                {
+                    "text": "✅ Sí, clausular",
+                    "callback_data": f"e:c:{player_id}:{owner_id}:{amount}",
+                },
+                {"text": "❌ No, cancelar", "callback_data": "e:n"},
+            ]
+        ]
+    }
+
+
+def _format_preview_text(
+    target: dict,
+    reason: str,
+    fallback_note: str,
+    cash: int,
+) -> str:
+    pos_short = POSITION_SHORT.get(target["position_id"], "?")
+    extra = f" — {fallback_note}" if fallback_note else ""
+    return (
+        f"🚨 <b>Emergencia — confirma el clausulazo</b>\n"
+        f"\n"
+        f"Motivo: <i>{reason}{extra}</i>\n"
+        f"\n"
+        f"Objetivo: <b>{target['name']}</b> ({pos_short}) "
+        f"de <b>{target['owner']}</b>\n"
+        f"Cláusula: <b>{_euros(target['clause_value'])}</b> · "
+        f"SF {sf_of(target)}\n"
+        f"Tu cash: <b>{_euros(cash)}</b>\n"
+        f"\n"
+        f"<i>Esta operación es irreversible.</i>"
+    )
+
+
+def preview_clausulazo() -> dict:
+    """Compute the target + reason and post the confirmation message.
+
+    Side effect: one Telegram message with an inline keyboard. The
+    returned dict is what the route handler echoes to the bot as JSON
+    (used only for diagnostics — the user-visible artefact is the
+    Telegram message).
+    """
+    ctx = build_context()
+    biwenger = ctx.biwenger
+
+    my_squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, biwenger.user_id)
+    my_ids = {p.get("id") for p in my_squad if p.get("id") is not None}
+    cash = int(biwenger.get_account_state(my_squad, ctx.biwenger_players)["cash"])
+
+    league_users = biwenger.get_league_users(config.LEAGUE_DATA_URL)
+    my_manager_name = league_users.get(int(biwenger.user_id), "")
+
+    lost_position, lost_name = _recent_lost_position(
+        biwenger, ctx.biwenger_players, my_manager_name, now_epoch=time.time()
+    )
+
+    if lost_position is not None:
+        preferred_position = lost_position
+        reason = (
+            f"acaban de clausularte un {_POSITION_LABELS_ES[lost_position].lower()} "
+            f"({lost_name}) en las últimas 24h — refuerza esa línea"
+        )
+    else:
+        preferred_position = _weakest_outfield_position(my_squad, ctx.biwenger_players)
+        if lost_name:
+            reason = (
+                f"clausulazo reciente de un multiposición ({lost_name}) — "
+                "ambiguo, voy a la línea más mermada"
+            )
+        else:
+            reason = (
+                "sin clausulazos recientes contra ti — refuerza la línea más mermada"
+            )
+
+    rivals = gather_rivals(biwenger, ctx.biwenger_players, ctx.jp_index)
+    affordable = filter_affordable(rivals, my_ids, target=cash)
+    target, fallback_note = _pick_target(affordable, preferred_position)
+
+    payload = {
+        "cash": cash,
+        "preferred_position": preferred_position,
+        "lost_player_name": lost_name,
+        "lost_position": lost_position,
+    }
+
+    if target is None:
+        text = (
+            f"🚨 <b>Emergencia</b>\n"
+            f"\n"
+            f"Sin candidatos asequibles. Tu cash: <b>{_euros(cash)}</b>. "
+            f"Motivo: <i>{reason}</i>."
+        )
+        _send(text)
+        return {**payload, "target": None, "reason": reason}
+
+    text = _format_preview_text(target, reason, fallback_note, cash)
+    _send(
+        text,
+        reply_markup=_confirmation_keyboard(
+            player_id=int(target["bw_id"]),
+            owner_id=int(target["owner_user_id"]),
+            amount=int(target["clause_value"]),
+        ),
+    )
+    return {
+        **payload,
+        "reason": reason,
+        "target": {
+            "player_id": target["bw_id"],
+            "owner_user_id": target["owner_user_id"],
+            "owner": target["owner"],
+            "name": target["name"],
+            "position_id": target["position_id"],
+            "amount": target["clause_value"],
+            "sf": sf_of(target),
+        },
+    }
+
+
+def execute_clausulazo(player_id: int, owner_user_id: int, amount: int) -> dict:
+    """Place the approved clausulazo and notify Telegram with the result.
+
+    `player_id`, `owner_user_id` and `amount` come from the inline
+    keyboard payload the bot forwards — i.e. the exact values the user
+    saw and approved in the preview. We do NOT recompute candidates
+    here; if cash dropped between preview and confirm Biwenger will
+    reject and we surface the error.
+    """
+    biwenger = build_biwenger_session()
+    try:
+        offer = biwenger.place_clausulazo(
+            player_id=int(player_id),
+            amount=int(amount),
+            seller_user_id=int(owner_user_id),
+            offers_url=config.OFFERS_URL,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Emergency clausulazo failed.",
+            extra={"player_id": player_id, "amount": amount, "error": str(exc)},
+        )
+        _send(f"❌ <b>Clausulazo rechazado</b> — <code>{_escape(str(exc))}</code>")
+        raise
+
+    cash_after = int(biwenger.get_account_state().get("cash") or 0)
+    _send(
+        f"🚨 <b>Clausulazo ejecutado</b>\n"
+        f"\n"
+        f"Pagado <b>{_euros(amount)}</b> por jugador <code>{player_id}</code>.\n"
+        f"Cash restante: <b>{_euros(cash_after)}</b>"
+    )
+    return {
+        "player_id": int(player_id),
+        "amount": int(amount),
+        "offer_id": offer.get("id"),
+        "status": offer.get("status"),
+        "cash_after": cash_after,
+    }
+
+
+def _escape(text: str) -> str:
+    """HTML-escape for Telegram parse_mode=HTML."""
+    import html
+
+    return html.escape(text, quote=False)
+
+
+def _send(text: str, reply_markup: Optional[dict] = None) -> None:
+    telegram = require_telegram()
+    if telegram is None:
+        logger.warning("Telegram missing — emergency message dropped.")
+        return
+    token, chat_id = telegram
+    send_telegram_message_or_raise(
+        bot_token=token, chat_id=chat_id, text=text, reply_markup=reply_markup
+    )

--- a/packages/biwenger_tools/api/logic/recommendations.py
+++ b/packages/biwenger_tools/api/logic/recommendations.py
@@ -14,19 +14,20 @@ primary position — with a `multi` list of secondary positions. The bot
 formats that as a `[multi: MED]` badge.
 """
 
-import time
 from typing import Optional
 
-from core.sdk.biwenger import BiwengerClient
 from core.sdk.jp import get_predict_rate
 from core.sdk.telegram import send_telegram_message_or_raise
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
+from packages.biwenger_tools.api.logic.clausulazo_candidates import (
+    filter_affordable,
+    gather_rivals,
+)
 from packages.biwenger_tools.api.logic.orchestration import (
     build_context,
     require_telegram,
 )
-from packages.biwenger_tools.api.logic.rows import build_squad_rows
 from packages.biwenger_tools.api.player_formatting import POSITION_SHORT, SCORE_SF
 
 logger = get_logger(__name__)
@@ -162,67 +163,6 @@ def _format_telegram_text(payload: dict) -> str:
     return "\n".join(lines)
 
 
-GK_POSITION_ID = 1
-
-
-def _gather_rivals(
-    biwenger: BiwengerClient,
-    biwenger_players: dict,
-    jp_index: dict,
-) -> list[dict]:
-    """Build the rival_rows list, tagged with `owner = manager_name`.
-
-    Skips the logged-in user's own squad. My own squad is fetched separately
-    in `run_recommendations` so we can compute Biwenger's max_bid from it.
-
-    Each row also carries `owner_gk_count` — used by the house rule that
-    forbids taking a rival's only goalkeeper (see `_filter_affordable`).
-    """
-    managers = biwenger.get_league_users(config.LEAGUE_DATA_URL)
-    rivals: list[dict] = []
-    for manager_id, manager_name in managers.items():
-        if manager_id == biwenger.user_id:
-            continue
-        squad = biwenger.get_manager_squad(config.USER_SQUAD_URL, manager_id)
-        rows = build_squad_rows(squad, biwenger_players, jp_index, include_clause=True)
-        gk_count = sum(1 for r in rows if r.get("position_id") == GK_POSITION_ID)
-        for r in rows:
-            r["owner"] = manager_name
-            r["owner_gk_count"] = gk_count
-            rivals.append(r)
-        time.sleep(0.3)
-    return rivals
-
-
-def _filter_affordable(candidates: list[dict], my_ids: set, target: int) -> list[dict]:
-    """Keep candidates I can actually afford (clause ≤ target) and skip mine.
-
-    Also enforces the house rule that we never clauselazo a rival's only
-    goalkeeper — Biwenger would technically allow it but the league agreed
-    leaving someone with zero GKs is unsportsmanlike. The same rule does
-    not apply to outfield positions (rivals are expected to rebuild).
-    """
-    out: list[dict] = []
-    for row in candidates:
-        if row.get("bw_id") in my_ids:
-            continue
-        if not row.get("clausulable_now", False):
-            continue
-        clause = row.get("clause_value") or 0
-        if clause <= 0 or clause > target:
-            continue
-        if _sf_of(row) <= 0:
-            continue
-        if (
-            row.get("position_id") == GK_POSITION_ID
-            and (row.get("owner_gk_count") or 0) <= 1
-        ):
-            # Owner only has this GK — house rule forbids taking it.
-            continue
-        out.append(row)
-    return out
-
-
 def run_recommendations(
     top: int = DEFAULT_TOP_N,
     margin: Optional[int] = None,
@@ -257,8 +197,8 @@ def run_recommendations(
     margin = max(0, margin)
     target = cash + margin
 
-    rivals = _gather_rivals(ctx.biwenger, ctx.biwenger_players, ctx.jp_index)
-    affordable = _filter_affordable(rivals, my_ids, target)
+    rivals = gather_rivals(ctx.biwenger, ctx.biwenger_players, ctx.jp_index)
+    affordable = filter_affordable(rivals, my_ids, target)
     recommendations = _pick_top_per_position(affordable, top)
 
     payload = {

--- a/packages/biwenger_tools/api/tests/test_emergency.py
+++ b/packages/biwenger_tools/api/tests/test_emergency.py
@@ -1,0 +1,404 @@
+"""Unit tests for `api/logic/emergency.py`.
+
+Covers:
+- `_recent_lost_position` — board parsing, 24h window, multi-pos
+  suppression, id vs name fallback.
+- `_weakest_outfield_position` — counts + DEF > MID > FWD tie-break.
+- `_pick_target` — in-position first, fallback to top SF overall.
+- `preview_clausulazo` end-to-end with mocks (lost-line vs weakest-line
+  flows, no-candidate path, multi-pos fallback).
+- `execute_clausulazo` notifies on success and on Biwenger 4xx.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from packages.biwenger_tools.api.logic import emergency
+
+# --- _recent_lost_position -----------------------------------------------
+
+
+def _board_entry(date_epoch, from_id=None, from_name=None, player_id=42):
+    return {
+        "date": date_epoch,
+        "content": [
+            {
+                "type": "clause",
+                "from": {"id": from_id, "name": from_name},
+                "player": {"id": player_id},
+            }
+        ],
+    }
+
+
+def _bw_player(player_id, name, position, alt=None):
+    return {
+        "id": player_id,
+        "name": name,
+        "position": position,
+        "altPositions": alt or [],
+        "price": 0,
+    }
+
+
+def test_recent_lost_position_matches_by_user_id():
+    biwenger = MagicMock(user_id=99)
+    biwenger.get_all_clausulazos.return_value = {
+        "data": [_board_entry(1000, from_id=99, player_id=42)]
+    }
+    players = {42: _bw_player(42, "Ana", position=2)}
+    pos, name = emergency._recent_lost_position(
+        biwenger, players, my_manager_name="anyone", now_epoch=1500
+    )
+    assert pos == 2 and name == "Ana"
+
+
+def test_recent_lost_position_matches_by_name_when_id_missing():
+    """Board payload variants may omit `from.id` — fall back to name match."""
+    biwenger = MagicMock(user_id=99)
+    biwenger.get_all_clausulazos.return_value = {
+        "data": [_board_entry(1000, from_name="Lillo", player_id=42)]
+    }
+    players = {42: _bw_player(42, "Ana", position=2)}
+    pos, _ = emergency._recent_lost_position(
+        biwenger, players, my_manager_name="Lillo", now_epoch=1500
+    )
+    assert pos == 2
+
+
+def test_recent_lost_position_ignores_entries_older_than_24h():
+    biwenger = MagicMock(user_id=99)
+    biwenger.get_all_clausulazos.return_value = {
+        "data": [_board_entry(date_epoch=10, from_id=99, player_id=42)]
+    }
+    players = {42: _bw_player(42, "Ana", position=2)}
+    now = 10 + emergency.RECENT_CLAUSULAZO_WINDOW_SECONDS + 1
+    pos, name = emergency._recent_lost_position(
+        biwenger, players, my_manager_name="x", now_epoch=now
+    )
+    assert pos is None and name is None
+
+
+def test_recent_lost_position_suppresses_multi_position_player():
+    """Multi-position loss is ambiguous → return None for position but
+    keep the name so the message can mention the multi-pos fallback."""
+    biwenger = MagicMock(user_id=99)
+    biwenger.get_all_clausulazos.return_value = {
+        "data": [_board_entry(1000, from_id=99, player_id=42)]
+    }
+    players = {42: _bw_player(42, "MultiGuy", position=2, alt=[3])}
+    pos, name = emergency._recent_lost_position(
+        biwenger, players, my_manager_name="x", now_epoch=1500
+    )
+    assert pos is None and name == "MultiGuy"
+
+
+def test_recent_lost_position_takes_the_most_recent_match():
+    biwenger = MagicMock(user_id=99)
+    biwenger.get_all_clausulazos.return_value = {
+        "data": [
+            _board_entry(date_epoch=900, from_id=99, player_id=42),
+            _board_entry(date_epoch=1000, from_id=99, player_id=43),
+        ]
+    }
+    players = {
+        42: _bw_player(42, "Old", position=2),
+        43: _bw_player(43, "Recent", position=4),
+    }
+    pos, name = emergency._recent_lost_position(
+        biwenger, players, my_manager_name="x", now_epoch=1500
+    )
+    assert pos == 4 and name == "Recent"
+
+
+def test_recent_lost_position_ignores_other_managers_losses():
+    biwenger = MagicMock(user_id=99)
+    biwenger.get_all_clausulazos.return_value = {
+        "data": [_board_entry(1000, from_id=42, from_name="Otro", player_id=42)]
+    }
+    players = {42: _bw_player(42, "X", position=2)}
+    pos, _ = emergency._recent_lost_position(
+        biwenger, players, my_manager_name="Lillo", now_epoch=1500
+    )
+    assert pos is None
+
+
+# --- _weakest_outfield_position ------------------------------------------
+
+
+def _squad(*player_ids):
+    return [{"id": pid} for pid in player_ids]
+
+
+def test_weakest_outfield_position_picks_minimum_count():
+    players = {
+        10: _bw_player(10, "Gk", position=1),
+        11: _bw_player(11, "D1", position=2),
+        12: _bw_player(12, "D2", position=2),
+        13: _bw_player(13, "D3", position=2),
+        14: _bw_player(14, "M1", position=3),
+        15: _bw_player(15, "M2", position=3),
+        16: _bw_player(16, "F1", position=4),
+    }
+    # 3 DEF / 2 MID / 1 FWD → weakest is FWD.
+    assert (
+        emergency._weakest_outfield_position(
+            _squad(10, 11, 12, 13, 14, 15, 16), players
+        )
+        == 4
+    )
+
+
+def test_weakest_outfield_position_ties_prefer_def_then_mid():
+    players = {
+        11: _bw_player(11, "D1", position=2),
+        12: _bw_player(12, "M1", position=3),
+        13: _bw_player(13, "F1", position=4),
+    }
+    # 1 of each → DEF wins on tie-break.
+    assert emergency._weakest_outfield_position(_squad(11, 12, 13), players) == 2
+
+
+def test_weakest_outfield_position_full_squad_picks_def():
+    """Full squad (all positions equal at the maximum) — DEF still wins
+    because of the tie-break order; in practice this branch is rare."""
+    players = {i: _bw_player(i, f"P{i}", position=(2 + (i % 3))) for i in range(0, 12)}
+    assert emergency._weakest_outfield_position(_squad(*range(0, 12)), players) == 2
+
+
+# --- _pick_target --------------------------------------------------------
+
+
+def _cand(bw_id, position, sf, owner_user_id=7, owner="Pepe", clause=5_000_000):
+    return {
+        "bw_id": bw_id,
+        "name": f"P{bw_id}",
+        "position_id": position,
+        "owner": owner,
+        "owner_user_id": owner_user_id,
+        "clause_value": clause,
+        "jp_player": {"predict": [{"type": 2, "rate": sf}]},
+    }
+
+
+def test_pick_target_returns_top_sf_in_preferred_position():
+    candidates = [
+        _cand(1, position=2, sf=300),
+        _cand(2, position=2, sf=500),
+        _cand(3, position=4, sf=900),  # higher SF but wrong position
+    ]
+    target, note = emergency._pick_target(candidates, preferred_position=2)
+    assert target["bw_id"] == 2
+    assert note == ""
+
+
+def test_pick_target_falls_back_to_top_sf_when_position_empty():
+    candidates = [
+        _cand(1, position=3, sf=400),
+        _cand(2, position=4, sf=900),
+    ]
+    target, note = emergency._pick_target(candidates, preferred_position=2)
+    assert target["bw_id"] == 2
+    assert "Defensa" in note  # note mentions the position we couldn't fill
+
+
+def test_pick_target_returns_none_when_no_candidates():
+    target, note = emergency._pick_target([], preferred_position=2)
+    assert target is None
+    assert note == ""
+
+
+# --- preview_clausulazo (end-to-end with mocks) --------------------------
+
+
+def _patches(target):
+    return f"packages.biwenger_tools.api.logic.emergency.{target}"
+
+
+@pytest.fixture
+def preview_env():
+    """Wire `preview_clausulazo` collaborators: build_context, gather_rivals,
+    filter_affordable, _send. Returns the mocks the test wants to assert on."""
+    from contextlib import ExitStack
+
+    def _enter(
+        *,
+        cash,
+        my_squad,
+        biwenger_players,
+        rivals,
+        affordable,
+        lost_position=(None, None),
+    ):
+        stack = ExitStack()
+
+        biwenger = MagicMock(user_id=99)
+        biwenger.get_manager_squad.return_value = my_squad
+        biwenger.get_account_state.return_value = {"cash": cash, "max_bid": cash}
+        biwenger.get_league_users.return_value = {99: "Lillo"}
+
+        from packages.biwenger_tools.api.logic.orchestration import (
+            OrchestratorContext,
+        )
+
+        ctx = OrchestratorContext(
+            biwenger=biwenger, biwenger_players=biwenger_players, jp_index={}
+        )
+        stack.enter_context(patch(_patches("build_context"), return_value=ctx))
+        stack.enter_context(
+            patch(_patches("_recent_lost_position"), return_value=lost_position)
+        )
+        stack.enter_context(patch(_patches("gather_rivals"), return_value=rivals))
+        stack.enter_context(
+            patch(_patches("filter_affordable"), return_value=affordable)
+        )
+        mock_send = stack.enter_context(patch(_patches("_send")))
+        return biwenger, mock_send, stack
+
+    with ExitStack() as outer:
+
+        def factory(**kwargs):
+            biwenger, mock_send, stack = _enter(**kwargs)
+            outer.callback(stack.close)
+            return biwenger, mock_send
+
+        yield factory
+
+
+def test_preview_recent_clausulazo_targets_lost_line(preview_env):
+    """If a DEF was clausulated against me, the preview targets a DEF."""
+    biwenger_players = {
+        10: _bw_player(10, "Gk", position=1),
+        11: _bw_player(11, "D1", position=2),
+    }
+    rivals = [_cand(50, position=2, sf=500), _cand(51, position=4, sf=900)]
+    biwenger, mock_send = preview_env(
+        cash=10_000_000,
+        my_squad=_squad(10, 11),
+        biwenger_players=biwenger_players,
+        rivals=rivals,
+        affordable=rivals,
+        lost_position=(2, "AnaDef"),
+    )
+    result = emergency.preview_clausulazo()
+
+    assert result["target"]["player_id"] == 50  # DEF candidate wins, not the SF 900 FWD
+    assert result["target"]["position_id"] == 2
+    assert "AnaDef" in result["reason"]
+    # Telegram was called once with an inline keyboard carrying the 3 ids.
+    mock_send.assert_called_once()
+    kwargs = mock_send.call_args.kwargs
+    assert "AnaDef" in mock_send.call_args.args[0]
+    buttons = kwargs["reply_markup"]["inline_keyboard"][0]
+    assert buttons[0]["callback_data"] == "e:c:50:7:5000000"
+    assert buttons[1]["callback_data"] == "e:n"
+
+
+def test_preview_multi_pos_loss_falls_back_to_weakest_line(preview_env):
+    """`_recent_lost_position` returned `(None, "MultiGuy")` → use weakest line."""
+    biwenger_players = {
+        10: _bw_player(10, "Gk", position=1),
+        11: _bw_player(11, "D1", position=2),
+        12: _bw_player(12, "M1", position=3),
+        13: _bw_player(13, "M2", position=3),
+        14: _bw_player(14, "F1", position=4),
+        15: _bw_player(15, "F2", position=4),
+    }
+    # squad: 1 GK / 1 DEF / 2 MID / 2 FWD → weakest outfield = DEF (count 1).
+    rivals = [_cand(50, position=2, sf=400), _cand(51, position=3, sf=900)]
+    biwenger, mock_send = preview_env(
+        cash=20_000_000,
+        my_squad=_squad(10, 11, 12, 13, 14, 15),
+        biwenger_players=biwenger_players,
+        rivals=rivals,
+        affordable=rivals,
+        lost_position=(None, "MultiGuy"),
+    )
+    result = emergency.preview_clausulazo()
+
+    # DEF candidate is picked even though the MID has higher SF.
+    assert result["target"]["player_id"] == 50
+    assert "MultiGuy" in result["reason"]
+    assert "multiposición" in result["reason"]
+
+
+def test_preview_no_recent_clausulazo_uses_weakest_line(preview_env):
+    biwenger_players = {
+        10: _bw_player(10, "Gk", position=1),
+        11: _bw_player(11, "D1", position=2),
+        12: _bw_player(12, "D2", position=2),
+        13: _bw_player(13, "M1", position=3),
+        14: _bw_player(14, "F1", position=4),
+    }
+    # 2 DEF / 1 MID / 1 FWD → tie at 1 between MID and FWD → MID wins.
+    rivals = [_cand(50, position=3, sf=300), _cand(51, position=4, sf=600)]
+    biwenger, mock_send = preview_env(
+        cash=20_000_000,
+        my_squad=_squad(10, 11, 12, 13, 14),
+        biwenger_players=biwenger_players,
+        rivals=rivals,
+        affordable=rivals,
+        lost_position=(None, None),
+    )
+    result = emergency.preview_clausulazo()
+
+    assert result["target"]["player_id"] == 50  # the MID
+    assert "más mermada" in result["reason"]
+
+
+def test_preview_no_affordable_candidates_sends_no_target_message(preview_env):
+    biwenger_players = {10: _bw_player(10, "Gk", position=1)}
+    biwenger, mock_send = preview_env(
+        cash=100_000,
+        my_squad=_squad(10),
+        biwenger_players=biwenger_players,
+        rivals=[],
+        affordable=[],
+        lost_position=(None, None),
+    )
+    result = emergency.preview_clausulazo()
+
+    assert result["target"] is None
+    mock_send.assert_called_once()
+    # No inline keyboard when there's nothing to confirm.
+    assert mock_send.call_args.kwargs.get("reply_markup") is None
+    assert "Sin candidatos" in mock_send.call_args.args[0]
+
+
+# --- execute_clausulazo --------------------------------------------------
+
+
+def test_execute_clausulazo_calls_sdk_and_notifies():
+    biwenger = MagicMock()
+    biwenger.place_clausulazo.return_value = {"id": 777, "status": "processed"}
+    biwenger.get_account_state.return_value = {"cash": 1_000_000}
+    with patch(_patches("build_biwenger_session"), return_value=biwenger), patch(
+        _patches("_send")
+    ) as mock_send:
+        result = emergency.execute_clausulazo(
+            player_id=42, owner_user_id=7, amount=5_000_000
+        )
+
+    biwenger.place_clausulazo.assert_called_once_with(
+        player_id=42,
+        amount=5_000_000,
+        seller_user_id=7,
+        offers_url=emergency.config.OFFERS_URL,
+    )
+    assert result["offer_id"] == 777
+    assert result["cash_after"] == 1_000_000
+    text = mock_send.call_args.args[0]
+    assert "ejecutado" in text
+
+
+def test_execute_clausulazo_notifies_and_raises_on_failure():
+    biwenger = MagicMock()
+    biwenger.place_clausulazo.side_effect = RuntimeError("403 Clause locked")
+    with patch(_patches("build_biwenger_session"), return_value=biwenger), patch(
+        _patches("_send")
+    ) as mock_send, pytest.raises(RuntimeError):
+        emergency.execute_clausulazo(player_id=42, owner_user_id=7, amount=5_000_000)
+
+    mock_send.assert_called_once()
+    assert "rechazado" in mock_send.call_args.args[0]

--- a/packages/biwenger_tools/api/tests/test_recommendations.py
+++ b/packages/biwenger_tools/api/tests/test_recommendations.py
@@ -1,12 +1,14 @@
 """Unit tests for `api/logic/recommendations.py`.
 
-Covers `compute_dynamic_margin`, `_filter_affordable`, `_gather_rivals`
-(house GK rule), `_pick_top_per_position` and `_format_telegram_text`.
-The HTTP-level wiring is in `test_routes.py`.
+Covers `compute_dynamic_margin`, `_pick_top_per_position` and
+`_format_telegram_text`. The candidate-pool helpers (`gather_rivals`,
+`filter_affordable`) live in `clausulazo_candidates` and are tested
+in `test_clausulazo_candidates.py`. HTTP wiring is in `test_routes.py`.
 """
 
 from unittest.mock import MagicMock
 
+from packages.biwenger_tools.api.logic import clausulazo_candidates as cands
 from packages.biwenger_tools.api.logic import recommendations as recs
 
 
@@ -50,7 +52,7 @@ def test_compute_dynamic_margin_scales_with_cash():
     assert recs.compute_dynamic_margin(100_000_000) == 10_000_000  # cap
 
 
-# --- _filter_affordable ---
+# --- filter_affordable ---
 
 
 def test_filter_affordable_excludes_my_players_and_locked_and_too_expensive():
@@ -62,7 +64,7 @@ def test_filter_affordable_excludes_my_players_and_locked_and_too_expensive():
         _row(4, "Cheap", pos=2, clause=20_000_000),  # included
         _row(5, "NoSF", pos=2, sf=0, clause=15_000_000),  # excluded: SF 0
     ]
-    out = recs._filter_affordable(rows, my_ids, target=50_000_000)
+    out = cands.filter_affordable(rows, my_ids, target=50_000_000)
     assert [r["bw_id"] for r in out] == [4]
 
 
@@ -79,17 +81,18 @@ def test_filter_affordable_excludes_rival_only_gk_house_rule():
         # The rule must not bleed into outfield: sole striker stays included.
         _row(102, "SoleFwd", pos=4, owner_gk_count=1, clause=10_000_000, sf=400),
     ]
-    out = recs._filter_affordable(rows, my_ids=set(), target=50_000_000)
+    out = cands.filter_affordable(rows, my_ids=set(), target=50_000_000)
     assert [r["bw_id"] for r in out] == [101, 102]
 
 
-# --- _gather_rivals ---
+# --- gather_rivals ---
 
 
-def test_gather_rivals_annotates_owner_gk_count(monkeypatch):
-    """`_gather_rivals` must tag every rival row with the owner's GK count
-    so the affordability filter can apply the house rule. Two managers,
-    one with 1 GK, one with 2."""
+def test_gather_rivals_annotates_owner_gk_count_and_user_id(monkeypatch):
+    """`gather_rivals` must tag every rival row with the owner's GK count
+    (for the house rule) and the owner_user_id (needed by emergency to
+    fill `place_clausulazo`'s `to=<seller>` field). Two managers, one
+    with 1 GK, one with 2."""
     biwenger = MagicMock()
     biwenger.user_id = 0
     biwenger.get_league_users.return_value = {1: "Ana", 2: "Beto"}
@@ -134,14 +137,16 @@ def test_gather_rivals_annotates_owner_gk_count(monkeypatch):
             "altPositions": [],
         },
     }
-    monkeypatch.setattr(recs, "time", MagicMock())  # skip sleep
+    monkeypatch.setattr(cands, "time", MagicMock())  # skip sleep
 
-    rivals = recs._gather_rivals(
+    rivals = cands.gather_rivals(
         biwenger, biwenger_players, jp_index={"by_name": {}, "by_slug": {}}
     )
 
-    by_owner = {r["bw_id"]: r["owner_gk_count"] for r in rivals}
-    assert by_owner == {11: 1, 12: 1, 21: 2, 22: 2, 23: 2}
+    by_gk = {r["bw_id"]: r["owner_gk_count"] for r in rivals}
+    assert by_gk == {11: 1, 12: 1, 21: 2, 22: 2, 23: 2}
+    by_owner_id = {r["bw_id"]: r["owner_user_id"] for r in rivals}
+    assert by_owner_id == {11: 1, 12: 1, 21: 2, 22: 2, 23: 2}
 
 
 # --- _pick_top_per_position ---

--- a/packages/biwenger_tools/bot/app.py
+++ b/packages/biwenger_tools/bot/app.py
@@ -44,6 +44,7 @@ _HELP_TEXT = (
     "/preview — Previsualiza la alineación sin aplicarla\n"
     "/recomendar — Qué fichar si me clausulan (top 3 por posición)\n"
     "/pujar — Lanza el auto-bid del mercado diario por tiers\n"
+    "/emergencia — Clausulazo de emergencia con confirmación (irreversible)\n"
     "/scrapper — Lanza el scraper a demanda (te avisa al acabar)\n"
     "/version — Versión desplegada del bot y de la API\n"
     "/help — Muestra este mensaje"
@@ -60,6 +61,7 @@ _ACTION_ROUTES: dict[str, tuple[str, str, dict | None]] = {
     "recomendar": ("/budget/recommendations", "GET", None),
     "pujar": ("/market/auto-bid", "POST", None),
     "scrapper": ("/scraper/trigger", "POST", None),
+    "emergencia": ("/emergency/clausulazo/preview", "POST", None),
 }
 
 
@@ -204,12 +206,81 @@ def _run_analizar(manager_value: str, edit_into: tuple[str, int] | None) -> None
         )
 
 
+def _run_emergencia_confirm(payload: str, edit_into: tuple[str, int] | None) -> None:
+    """Tap on the "✅ Sí, clausular" button — fire `/emergency/execute`.
+
+    `payload` is `c:<player_id>:<owner_id>:<amount>` (the `e:` prefix
+    was already stripped). Validates the three ids parse to ints before
+    calling the api so a malformed callback can't trigger a 400-loop.
+    """
+    parts = payload.split(":")
+    if len(parts) != 4 or parts[0] != "c":
+        logger.info("Webhook: malformed emergencia payload", extra={"payload": payload})
+        return
+    try:
+        player_id, owner_id, amount = int(parts[1]), int(parts[2]), int(parts[3])
+    except ValueError:
+        logger.info(
+            "Webhook: non-int in emergencia payload", extra={"payload": payload}
+        )
+        return
+
+    status_text = "⏳ <b>Emergencia</b> — ejecutando clausulazo…"
+    if edit_into is not None:
+        chat_id, message_id = edit_into
+        edit_message_text(
+            bot_token=config.TELEGRAM_BOT_TOKEN,
+            chat_id=chat_id,
+            message_id=message_id,
+            text=status_text,
+        )
+
+    try:
+        api_client.call_api(
+            config.BIWENGER_API_URL,
+            "/emergency/clausulazo/execute",
+            method="POST",
+            params={
+                "player_id": str(player_id),
+                "owner_id": str(owner_id),
+                "amount": str(amount),
+            },
+        )
+    except Exception as exc:
+        logger.error(
+            "Webhook: emergency execute failed",
+            extra={"player_id": player_id, "error": str(exc)},
+        )
+        send_telegram_message(
+            bot_token=config.TELEGRAM_BOT_TOKEN,
+            chat_id=config.TELEGRAM_CHAT_ID,
+            text=(
+                f"❌ Error al ejecutar <b>Emergencia</b>: "
+                f"<code>{html.escape(str(exc))}</code>"
+            ),
+        )
+
+
+def _run_emergencia_cancel(edit_into: tuple[str, int] | None) -> None:
+    """Tap on the "❌ No, cancelar" button — edit the preview to cancelled."""
+    if edit_into is None:
+        return
+    chat_id, message_id = edit_into
+    edit_message_text(
+        bot_token=config.TELEGRAM_BOT_TOKEN,
+        chat_id=chat_id,
+        message_id=message_id,
+        text="🚫 <b>Emergencia cancelada.</b>",
+    )
+
+
 def _handle_callback(cb: dict) -> None:
     """Dispatch on the callback_data prefix.
 
-    Only `analizar:<id|all>` taps come through inline keyboards now;
-    the main menu is a persistent reply keyboard that posts plain text
-    handled by the message router instead.
+    Inline-keyboard taps in scope:
+    - `analizar:<id|all>` — manager picker for /analizar.
+    - `e:c:<player_id>:<owner_id>:<amount>` — confirm /emergencia.
+    - `e:n` — cancel /emergencia.
     """
     answer_callback_query(config.TELEGRAM_BOT_TOKEN, cb["id"])
     data = cb.get("data", "")
@@ -217,10 +288,17 @@ def _handle_callback(cb: dict) -> None:
         logger.info("Webhook: unknown callback_data", extra={"data": data})
         return
     prefix, value = data.split(":", 1)
+    edit_into = (cb["chat_id"], cb["message_id"]) if cb.get("message_id") else None
 
     if prefix == "analizar":
-        edit_into = (cb["chat_id"], cb["message_id"]) if cb.get("message_id") else None
         _run_analizar(value, edit_into)
+        return
+
+    if prefix == "e":
+        if value == "n":
+            _run_emergencia_cancel(edit_into)
+        else:
+            _run_emergencia_confirm(value, edit_into)
         return
 
     logger.info("Webhook: unhandled callback prefix", extra={"prefix": prefix})
@@ -301,6 +379,8 @@ def webhook():
         _dispatch_action("pujar", "💸 Pujar")
     elif cmd == "/scrapper":
         _dispatch_action("scrapper", "🧹 Scraper")
+    elif cmd == "/emergencia":
+        _dispatch_action("emergencia", "🚨 Emergencia")
     elif cmd == "/help":
         send_telegram_message(
             bot_token=config.TELEGRAM_BOT_TOKEN,

--- a/packages/biwenger_tools/bot/tests/test_bot.py
+++ b/packages/biwenger_tools/bot/tests/test_bot.py
@@ -96,6 +96,7 @@ def test_wrong_chat_callback_is_silently_ignored(client):
         ("/recomendar", "/budget/recommendations", "GET", None),
         ("/pujar", "/market/auto-bid", "POST", None),
         ("/scrapper", "/scraper/trigger", "POST", None),
+        ("/emergencia", "/emergency/clausulazo/preview", "POST", None),
     ],
 )
 def test_text_command_calls_api(client, command, path, method, params):
@@ -294,6 +295,49 @@ def test_analizar_all_callback_calls_teams_without_filter(client):
         resp = _post(client, _callback_update(_VALID_CHAT, "analizar:all"))
     assert resp.status_code == 200
     mock_call.assert_called_once_with(_API_URL, "/teams", method="GET", params=None)
+
+
+def test_emergencia_confirm_callback_calls_execute_with_query_params(client):
+    """`e:c:<player>:<owner>:<amount>` → POST /emergency/clausulazo/execute
+    with the same three ids the user saw and approved in the preview."""
+    with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
+        "packages.biwenger_tools.bot.app.edit_message_text"
+    ) as mock_edit, patch(
+        "packages.biwenger_tools.bot.app.api_client.call_api"
+    ) as mock_call:
+        resp = _post(client, _callback_update(_VALID_CHAT, "e:c:42:7:5000000"))
+    assert resp.status_code == 200
+    mock_edit.assert_called_once()  # picker → "ejecutando…"
+    mock_call.assert_called_once_with(
+        _API_URL,
+        "/emergency/clausulazo/execute",
+        method="POST",
+        params={"player_id": "42", "owner_id": "7", "amount": "5000000"},
+    )
+
+
+def test_emergencia_cancel_callback_edits_message_and_does_not_call_api(client):
+    with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
+        "packages.biwenger_tools.bot.app.edit_message_text"
+    ) as mock_edit, patch(
+        "packages.biwenger_tools.bot.app.api_client.call_api"
+    ) as mock_call:
+        resp = _post(client, _callback_update(_VALID_CHAT, "e:n"))
+    assert resp.status_code == 200
+    mock_call.assert_not_called()
+    text = mock_edit.call_args.kwargs.get("text", "")
+    assert "cancelada" in text.lower()
+
+
+def test_emergencia_confirm_with_malformed_payload_is_ignored(client):
+    """A malformed `e:c:not_a_number` callback must not POST to /execute
+    (Biwenger would 400 with no useful context). Drop on the floor."""
+    with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
+        "packages.biwenger_tools.bot.app.edit_message_text"
+    ), patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call:
+        resp = _post(client, _callback_update(_VALID_CHAT, "e:c:notanint:7:5000000"))
+    assert resp.status_code == 200
+    mock_call.assert_not_called()
 
 
 def test_unknown_callback_prefix_is_ignored(client):


### PR DESCRIPTION
## Summary
- New `/emergencia` bot command + two api routes (`/emergency/clausulazo/{preview,execute}`) that wrap `BiwengerClient.place_clausulazo` behind an inline Sí/No confirmation. Cash is **justo** (`target = cash`, no margin) and `amount = clause_value` exactly — irreversible op, never push into the red.
- **Target selection**: if a clausulazo against me happened in the last 24h and the lost player is single-position → reinforce that position; if multi-position or no recent loss → weakest outfield line (DEF/MID/FWD by count, DEF > MID > FWD on tie). Within the chosen position, top-SF affordable rival; fall back to top-SF across positions if empty.
- **Detection robustness**: board lookup tries `from.id == user_id` first and falls back to `from.name == my_manager_name` so the payload variants the scraper has seen don't break us.
- **Shared helpers**: `gather_rivals` + `filter_affordable` extracted from `recommendations.py` to `clausulazo_candidates.py` and now tag every row with `owner_user_id` (needed for `place_clausulazo`'s `to=<seller>` field).
- New inline callback shape `e:c:<player>:<owner>:<amount>` (Sí) / `e:n` (No); fits the 64-byte Telegram cap.

## Test plan
- [x] `bazel test //...` passes (api + bot + everything else).
- [x] flake8 + black clean.
- [ ] After merge: hit `/emergencia` in the chat → confirm the preview message renders with Sí/No buttons, the values look right against current cash, and the cancel path edits to "🚫 Emergencia cancelada".
- [ ] Live probe (one shot): confirm `from.id` is present on the real `/board?type=transfer` response — if not, the name-fallback already handles it.