### PR TITLE
chore(bot): register /emergencia in Telegram commands list

### DIFF
--- a/packages/biwenger_tools/bot/setup_commands.py
+++ b/packages/biwenger_tools/bot/setup_commands.py
@@ -38,6 +38,10 @@ COMMANDS = [
         "description": "Lanza el auto-bid del mercado diario por tiers",
     },
     {
+        "command": "emergencia",
+        "description": "Clausulazo de emergencia con confirmación (irreversible)",
+    },
+    {
         "command": "scrapper",
         "description": "Lanza el scraper a demanda (te avisa al acabar)",
     },


### PR DESCRIPTION
## Summary
- Adds `/emergencia` to `setup_commands.py`'s COMMANDS list. CI runs this script after every bot deploy to register slash-command autocomplete with Telegram; the new handler shipped in #125 worked but didn't show up in the in-chat command list because the registration list was out of sync.

## Test plan
- [ ] After merge: open Telegram, type `/`, confirm `/emergencia` appears in the autocomplete.