### PR TITLE
fix(api): show player name in emergency success message

### DIFF
--- a/packages/biwenger_tools/api/logic/emergency.py
+++ b/packages/biwenger_tools/api/logic/emergency.py
@@ -314,11 +314,19 @@ def execute_clausulazo(player_id: int, owner_user_id: int, amount: int) -> dict:
         _send(f"❌ <b>Clausulazo rechazado</b> — <code>{_escape(str(exc))}</code>")
         raise
 
+    # Resolve the player name for the success message. The execute
+    # endpoint only receives ids (callback_data is capped at 64 bytes),
+    # so the preview's player name doesn't survive the round-trip; we
+    # look it up against the cf-base players map.
+    players = biwenger.get_all_players_data_map(config.ALL_PLAYERS_DATA_URL)
+    player_name = (players.get(int(player_id)) or {}).get(
+        "name"
+    ) or f"jugador {player_id}"
     cash_after = int(biwenger.get_account_state().get("cash") or 0)
     _send(
         f"🚨 <b>Clausulazo ejecutado</b>\n"
         f"\n"
-        f"Pagado <b>{_euros(amount)}</b> por jugador <code>{player_id}</code>.\n"
+        f"Pagado <b>{_euros(amount)}</b> por <b>{_escape(player_name)}</b>.\n"
         f"Cash restante: <b>{_euros(cash_after)}</b>"
     )
     return {

--- a/packages/biwenger_tools/api/tests/test_emergency.py
+++ b/packages/biwenger_tools/api/tests/test_emergency.py
@@ -373,6 +373,9 @@ def test_execute_clausulazo_calls_sdk_and_notifies():
     biwenger = MagicMock()
     biwenger.place_clausulazo.return_value = {"id": 777, "status": "processed"}
     biwenger.get_account_state.return_value = {"cash": 1_000_000}
+    # The players map is consulted to resolve the name for the success
+    # message — the callback only carries the player id.
+    biwenger.get_all_players_data_map.return_value = {42: {"name": "Iago Aspas"}}
     with patch(_patches("build_biwenger_session"), return_value=biwenger), patch(
         _patches("_send")
     ) as mock_send:
@@ -390,6 +393,21 @@ def test_execute_clausulazo_calls_sdk_and_notifies():
     assert result["cash_after"] == 1_000_000
     text = mock_send.call_args.args[0]
     assert "ejecutado" in text
+    assert "Iago Aspas" in text
+
+
+def test_execute_clausulazo_falls_back_to_id_when_player_missing_from_map():
+    """Defensive: if the players map doesn't have the id (cache miss,
+    new player, etc.), the message still goes out — just with the id."""
+    biwenger = MagicMock()
+    biwenger.place_clausulazo.return_value = {"id": 777, "status": "processed"}
+    biwenger.get_account_state.return_value = {"cash": 1_000_000}
+    biwenger.get_all_players_data_map.return_value = {}
+    with patch(_patches("build_biwenger_session"), return_value=biwenger), patch(
+        _patches("_send")
+    ) as mock_send:
+        emergency.execute_clausulazo(player_id=42, owner_user_id=7, amount=5_000_000)
+    assert "jugador 42" in mock_send.call_args.args[0]
 
 
 def test_execute_clausulazo_notifies_and_raises_on_failure():


### PR DESCRIPTION
## Summary
- The execute endpoint only receives ids via the inline-keyboard callback (player/owner/amount, capped at 64 bytes by Telegram), so the player name from the preview was lost on the round-trip. Live result: "Pagado 6.492.500 € por jugador 1523." (it was Iago Aspas).
- Resolve the name against the cf-base players map after the offer is accepted. Falls back to "jugador <id>" if the lookup misses (defensive).

## Test plan
- [x] `bazel test //packages/biwenger_tools/api:api_tests` passes — new test pinning that the name is rendered, plus a fallback test for the id-only branch.
- [ ] After merge + deploy: fire `/emergencia` → confirm Sí → success message says the player name.