### PR TITLE
fix(bot): preserve emergency preview text when confirming

### DIFF
--- a/core/sdk/telegram.py
+++ b/core/sdk/telegram.py
@@ -12,6 +12,9 @@ TELEGRAM_SET_COMMANDS_URL = "https://api.telegram.org/bot{token}/setMyCommands"
 TELEGRAM_SET_MENU_BUTTON_URL = "https://api.telegram.org/bot{token}/setChatMenuButton"
 TELEGRAM_ANSWER_CALLBACK_URL = "https://api.telegram.org/bot{token}/answerCallbackQuery"
 TELEGRAM_EDIT_MESSAGE_URL = "https://api.telegram.org/bot{token}/editMessageText"
+TELEGRAM_EDIT_REPLY_MARKUP_URL = (
+    "https://api.telegram.org/bot{token}/editMessageReplyMarkup"
+)
 
 # Hard limit on Bot API sendMessage; anything longer is truncated server-side.
 TELEGRAM_MAX_MESSAGE_LENGTH = 4096
@@ -111,6 +114,30 @@ def edit_message_text(
         response.raise_for_status()
     except requests.RequestException as e:
         logger.error("Failed to edit Telegram message.", extra={"error": str(e)})
+
+
+def edit_message_reply_markup(
+    bot_token: str,
+    chat_id: str,
+    message_id: int,
+    reply_markup: Optional[dict] = None,
+) -> None:
+    """Replace ONLY the inline keyboard on an existing message.
+
+    Pass `reply_markup={"inline_keyboard": []}` (or `None`) to strip the
+    buttons while leaving the text untouched. Used after a confirmation
+    tap when we want the preview text to stay readable but the buttons
+    to no longer be clickable (preventing accidental re-confirms).
+    """
+    url = TELEGRAM_EDIT_REPLY_MARKUP_URL.format(token=bot_token)
+    payload: dict[str, Any] = {"chat_id": chat_id, "message_id": message_id}
+    if reply_markup is not None:
+        payload["reply_markup"] = reply_markup
+    try:
+        response = requests.post(url, json=payload, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        logger.error("Failed to edit Telegram reply markup.", extra={"error": str(e)})
 
 
 def send_telegram_photo(

--- a/packages/biwenger_tools/bot/app.py
+++ b/packages/biwenger_tools/bot/app.py
@@ -21,6 +21,7 @@ from flask import Flask, request
 
 from core.sdk.telegram import (
     answer_callback_query,
+    edit_message_reply_markup,
     edit_message_text,
     extract_webhook_callback,
     extract_webhook_update,
@@ -225,15 +226,23 @@ def _run_emergencia_confirm(payload: str, edit_into: tuple[str, int] | None) -> 
         )
         return
 
-    status_text = "⏳ <b>Emergencia</b> — ejecutando clausulazo…"
+    # Strip the buttons off the preview so it can't be re-confirmed,
+    # but keep the preview text intact for the chat history. The
+    # "ejecutando…" / success messages arrive as fresh sends so the
+    # original preview stays visible above them.
     if edit_into is not None:
         chat_id, message_id = edit_into
-        edit_message_text(
+        edit_message_reply_markup(
             bot_token=config.TELEGRAM_BOT_TOKEN,
             chat_id=chat_id,
             message_id=message_id,
-            text=status_text,
+            reply_markup={"inline_keyboard": []},
         )
+    send_telegram_message(
+        bot_token=config.TELEGRAM_BOT_TOKEN,
+        chat_id=config.TELEGRAM_CHAT_ID,
+        text="⏳ <b>Emergencia</b> — ejecutando clausulazo…",
+    )
 
     try:
         api_client.call_api(

--- a/packages/biwenger_tools/bot/tests/test_bot.py
+++ b/packages/biwenger_tools/bot/tests/test_bot.py
@@ -299,15 +299,24 @@ def test_analizar_all_callback_calls_teams_without_filter(client):
 
 def test_emergencia_confirm_callback_calls_execute_with_query_params(client):
     """`e:c:<player>:<owner>:<amount>` → POST /emergency/clausulazo/execute
-    with the same three ids the user saw and approved in the preview."""
+    with the same three ids the user saw and approved in the preview.
+    The preview text stays intact (only its inline keyboard is stripped)
+    and the "ejecutando…" status arrives as a fresh send."""
     with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
-        "packages.biwenger_tools.bot.app.edit_message_text"
-    ) as mock_edit, patch(
+        "packages.biwenger_tools.bot.app.edit_message_reply_markup"
+    ) as mock_strip, patch(
+        "packages.biwenger_tools.bot.app.send_telegram_message"
+    ) as mock_send, patch(
         "packages.biwenger_tools.bot.app.api_client.call_api"
     ) as mock_call:
         resp = _post(client, _callback_update(_VALID_CHAT, "e:c:42:7:5000000"))
     assert resp.status_code == 200
-    mock_edit.assert_called_once()  # picker → "ejecutando…"
+    # Preview keyboard removed (no text edit so the preview stays readable).
+    mock_strip.assert_called_once()
+    assert mock_strip.call_args.kwargs["reply_markup"] == {"inline_keyboard": []}
+    # New "ejecutando…" message goes as a fresh send.
+    mock_send.assert_called_once()
+    assert "ejecutando" in mock_send.call_args.kwargs["text"].lower()
     mock_call.assert_called_once_with(
         _API_URL,
         "/emergency/clausulazo/execute",


### PR DESCRIPTION
## Summary
- Tapping ✅ Sí on /emergencia used to edit the preview into a generic "⏳ ejecutando…" status, losing the context of what was approved (target name, owner, cláusula, motivo). Now the preview stays intact; only its inline keyboard is stripped so it can't be re-confirmed, and the "ejecutando…" / success messages arrive as fresh sends below.
- Adds `edit_message_reply_markup` helper to the Telegram SDK (uses Telegram's `editMessageReplyMarkup` endpoint).

## Test plan
- [x] `bazel test //packages/biwenger_tools/bot:bot_tests //core:core_tests` passes; updated callback test pins that the strip-keyboard call happens AND a new "ejecutando…" message is sent.
- [ ] After deploy: trigger `/emergencia` → tap Sí → confirm the preview stays readable in the chat with no buttons, "⏳ ejecutando…" appears as a new message below, then the success message below that.