### PR TITLE
feat(emergency): selector for multi-clausulazo and multi-pos losses

### DIFF
--- a/packages/biwenger_tools/api/app.py
+++ b/packages/biwenger_tools/api/app.py
@@ -153,11 +153,33 @@ def scraper_trigger():
 def emergency_clausulazo_preview():
     """Compute the emergency target + post confirmation message — bot's /emergencia.
 
-    Side effect: one Telegram message with an inline keyboard (Sí/No).
-    The bot does not read the JSON response — the confirmation flow
-    rides on the inline-keyboard callback the user taps.
+    Query params (set by the bot when the user taps a selector button
+    after a multi-clausulazo run):
+      - `force_position=<2|3|4>` — skip detection, lock target to that
+        outfield position.
+      - `force_weakest=1` — skip detection, target the weakest line.
+
+    Side effect: one Telegram message (selector OR confirmation). The
+    bot does not read the JSON response — the flow rides on the
+    inline-keyboard callbacks the user taps.
     """
-    return _run_action("emergency.preview", emergency.preview_clausulazo)
+    force_position_raw = (request.args.get("force_position") or "").strip()
+    force_weakest_raw = (request.args.get("force_weakest") or "").strip().lower()
+    force_weakest = force_weakest_raw in ("1", "true", "yes")
+    force_position: int | None
+    if force_position_raw:
+        try:
+            force_position = int(force_position_raw)
+        except ValueError:
+            force_position = None
+    else:
+        force_position = None
+    return _run_action(
+        "emergency.preview",
+        lambda: emergency.preview_clausulazo(
+            force_position=force_position, force_weakest=force_weakest
+        ),
+    )
 
 
 @app.route("/emergency/clausulazo/execute", methods=["POST"])

--- a/packages/biwenger_tools/api/logic/emergency.py
+++ b/packages/biwenger_tools/api/logic/emergency.py
@@ -64,18 +64,20 @@ def _is_multi_position(bw_player: dict) -> bool:
     return bool(bw_player.get("altPositions") or [])
 
 
-def _recent_lost_position(
+def _recent_lost_players(
     biwenger: BiwengerClient,
     biwenger_players: dict,
     my_manager_name: str,
     now_epoch: float,
-) -> tuple[Optional[int], Optional[str]]:
-    """Scan the transfer board for clausulazos against me in the last 24h.
+) -> list[dict]:
+    """Every clausulazo against me in the last 24h, resolved against the
+    cf-base players map.
 
-    Returns `(position_id, player_name)` of the most-recent lost player
-    if found AND the player is single-position, else `(None, None)`.
-    Multi-position losses are intentionally suppressed (ambiguous which
-    line to reinforce — fall back to weakest-line).
+    Returns a list of `{player_id, name, position_id, alt_positions, date}`
+    in board order (which Biwenger does NOT guarantee to be chronological:
+    multiple clausulazos that arrive in the same batch share the entry's
+    `date`, so we can't order them reliably by that field — the caller
+    is the one that decides what to do when there's more than one).
 
     Detection compares `from.id == biwenger.user_id` first; some board
     payload variants only expose `from.name`, so we fall back to a name
@@ -87,7 +89,7 @@ def _recent_lost_position(
         entries = list(entries.values())
 
     cutoff = now_epoch - RECENT_CLAUSULAZO_WINDOW_SECONDS
-    matches: list[tuple[float, dict]] = []
+    losses: list[dict] = []
     for entry in entries:
         entry_date = entry.get("date", 0) or 0
         if entry_date < cutoff:
@@ -101,22 +103,40 @@ def _recent_lost_position(
             is_me = (from_id is not None and int(from_id) == int(biwenger.user_id)) or (
                 from_name and my_manager_name and from_name == my_manager_name
             )
-            if is_me:
-                matches.append((entry_date, item))
+            if not is_me:
+                continue
+            player_ref = item.get("player")
+            player_id = (
+                player_ref.get("id") if isinstance(player_ref, dict) else player_ref
+            )
+            bw_player = biwenger_players.get(player_id)
+            if not bw_player:
+                continue
+            losses.append(
+                {
+                    "player_id": player_id,
+                    "name": bw_player.get("name"),
+                    "position_id": bw_player.get("position"),
+                    "alt_positions": bw_player.get("altPositions") or [],
+                    "date": entry_date,
+                }
+            )
+    return losses
 
-    if not matches:
-        return None, None
 
-    matches.sort(key=lambda pair: pair[0], reverse=True)
-    item = matches[0][1]
-    player_ref = item.get("player")
-    player_id = player_ref.get("id") if isinstance(player_ref, dict) else player_ref
-    bw_player = biwenger_players.get(player_id)
-    if not bw_player:
-        return None, None
-    if _is_multi_position(bw_player):
-        return None, bw_player.get("name")
-    return bw_player.get("position"), bw_player.get("name")
+def _unique_positions(losses: list[dict]) -> list[int]:
+    """Outfield positions a loss touches (primary + alts), DEF/MID/FWD order.
+
+    Used to build the selector buttons: one per distinct outfield
+    position the recent losses imply. GK is excluded — we never
+    clausulazo a GK on emergency.
+    """
+    found: set[int] = set()
+    for loss in losses:
+        for pos in (loss["position_id"], *loss["alt_positions"]):
+            if pos in _OUTFIELD_POSITION_IDS:
+                found.add(pos)
+    return [p for p in _OUTFIELD_POSITION_IDS if p in found]
 
 
 def _weakest_outfield_position(my_squad: list, biwenger_players: dict) -> int:
@@ -181,6 +201,51 @@ def _confirmation_keyboard(player_id: int, owner_id: int, amount: int) -> dict:
     }
 
 
+def _selector_keyboard(positions: list[int]) -> dict:
+    """One button per outfield position in `positions`, plus weakest-line.
+
+    `e:p:<pid>` taps trigger a refined preview locked to that position;
+    `e:m` triggers the weakest-line fallback (lets the user override the
+    auto-detected positions when they prefer to plug a different gap).
+    """
+    rows = [
+        [
+            {
+                "text": f"✅ Reforzar {_POSITION_LABELS_ES[pos]}",
+                "callback_data": f"e:p:{pos}",
+            }
+        ]
+        for pos in positions
+    ]
+    rows.append([{"text": "🌍 Línea más mermada", "callback_data": "e:m"}])
+    rows.append([{"text": "❌ Cancelar", "callback_data": "e:n"}])
+    return {"inline_keyboard": rows}
+
+
+def _format_selector_text(losses: list[dict], cash: int) -> str:
+    """Render the multi-loss selector message.
+
+    Lists every recent loss with its position(s) so the user can see
+    what happened, then asks which line to reinforce. Multi-position
+    players show both positions (e.g. `DEF/MED`).
+    """
+    lines = [
+        "🚨 <b>Emergencia — varias pérdidas recientes</b>",
+        "",
+        "Tu cash: <b>" + _euros(cash) + "</b>",
+        "",
+        "Te han clausulado (últimas 24h):",
+    ]
+    for loss in losses:
+        primary = POSITION_SHORT.get(loss["position_id"], "?")
+        alts = [POSITION_SHORT.get(p, "?") for p in loss["alt_positions"]]
+        pos_str = "/".join([primary, *alts]) if alts else primary
+        lines.append(f"  · <b>{_escape(loss['name'])}</b> ({pos_str})")
+    lines.append("")
+    lines.append("<i>¿Qué línea quieres reforzar?</i>")
+    return "\n".join(lines)
+
+
 def _format_preview_text(
     target: dict,
     reason: str,
@@ -204,13 +269,23 @@ def _format_preview_text(
     )
 
 
-def preview_clausulazo() -> dict:
+def preview_clausulazo(
+    force_position: Optional[int] = None, force_weakest: bool = False
+) -> dict:
     """Compute the target + reason and post the confirmation message.
 
-    Side effect: one Telegram message with an inline keyboard. The
-    returned dict is what the route handler echoes to the bot as JSON
-    (used only for diagnostics — the user-visible artefact is the
-    Telegram message).
+    Behaviour depends on the recent clausulazos against me:
+    - 0 losses → reinforce weakest outfield line.
+    - 1 single-position loss → target that position directly.
+    - Otherwise (>1 loss, or 1 multi-position loss) → post a selector
+      message with one button per outfield position involved + a
+      "weakest line" fallback. The user's tap re-enters this function
+      with `force_position` or `force_weakest`, which short-circuits
+      the detection and goes straight to the Sí/No preview.
+
+    Side effect: one Telegram message (selector OR confirmation). The
+    returned dict is for diagnostics only — the user-visible artefact
+    is the Telegram message.
     """
     ctx = build_context()
     biwenger = ctx.biwenger
@@ -222,28 +297,56 @@ def preview_clausulazo() -> dict:
     league_users = biwenger.get_league_users(config.LEAGUE_DATA_URL)
     my_manager_name = league_users.get(int(biwenger.user_id), "")
 
-    lost_position, lost_name = _recent_lost_position(
+    losses = _recent_lost_players(
         biwenger, ctx.biwenger_players, my_manager_name, now_epoch=time.time()
     )
 
-    if lost_position is not None:
-        preferred_position = lost_position
+    # --- Decide preferred_position + reason --------------------------------
+    if force_weakest:
+        preferred_position = _weakest_outfield_position(my_squad, ctx.biwenger_players)
+        reason = "refuerza la línea más mermada (elegido)"
+    elif force_position is not None:
+        preferred_position = force_position
         reason = (
-            f"acaban de clausularte un {_POSITION_LABELS_ES[lost_position].lower()} "
-            f"({lost_name}) en las últimas 24h — refuerza esa línea"
+            f"refuerza la línea de "
+            f"{_POSITION_LABELS_ES[force_position].lower()}s (elegido)"
         )
     else:
-        preferred_position = _weakest_outfield_position(my_squad, ctx.biwenger_players)
-        if lost_name:
+        # Auto-detect from recent losses. Two ambiguous cases trigger the
+        # selector: more than one loss, or a single loss that's
+        # multi-position. The selector lets the user disambiguate
+        # because the board batches transfers under a shared date and
+        # we can't reliably tell which is the most recent within the batch.
+        unique_positions = _unique_positions(losses)
+        needs_selector = len(losses) > 1 or (
+            len(losses) == 1 and len(losses[0]["alt_positions"]) > 0
+        )
+        if needs_selector and unique_positions:
+            text = _format_selector_text(losses, cash)
+            _send(text, reply_markup=_selector_keyboard(unique_positions))
+            return {
+                "cash": cash,
+                "losses": losses,
+                "selector": True,
+            }
+
+        if len(losses) == 1:
+            loss = losses[0]
+            preferred_position = loss["position_id"]
             reason = (
-                f"clausulazo reciente de un multiposición ({lost_name}) — "
-                "ambiguo, voy a la línea más mermada"
+                f"acaban de clausularte un "
+                f"{_POSITION_LABELS_ES[preferred_position].lower()} "
+                f"({loss['name']}) en las últimas 24h — refuerza esa línea"
             )
         else:
+            preferred_position = _weakest_outfield_position(
+                my_squad, ctx.biwenger_players
+            )
             reason = (
-                "sin clausulazos recientes contra ti — refuerza la línea más mermada"
+                "sin clausulazos recientes contra ti — " "refuerza la línea más mermada"
             )
 
+    # --- Pick target + send confirmation ----------------------------------
     rivals = gather_rivals(biwenger, ctx.biwenger_players, ctx.jp_index)
     affordable = filter_affordable(rivals, my_ids, target=cash)
     target, fallback_note = _pick_target(affordable, preferred_position)
@@ -251,8 +354,7 @@ def preview_clausulazo() -> dict:
     payload = {
         "cash": cash,
         "preferred_position": preferred_position,
-        "lost_player_name": lost_name,
-        "lost_position": lost_position,
+        "losses": losses,
     }
 
     if target is None:

--- a/packages/biwenger_tools/api/tests/test_emergency.py
+++ b/packages/biwenger_tools/api/tests/test_emergency.py
@@ -1,12 +1,12 @@
 """Unit tests for `api/logic/emergency.py`.
 
 Covers:
-- `_recent_lost_position` — board parsing, 24h window, multi-pos
-  suppression, id vs name fallback.
+- `_recent_lost_players` — board parsing, 24h window, id vs name match.
+- `_unique_positions` — outfield positions a loss list implies.
 - `_weakest_outfield_position` — counts + DEF > MID > FWD tie-break.
 - `_pick_target` — in-position first, fallback to top SF overall.
-- `preview_clausulazo` end-to-end with mocks (lost-line vs weakest-line
-  flows, no-candidate path, multi-pos fallback).
+- `preview_clausulazo` end-to-end (0/1/multi-loss + selector cases +
+  force_position / force_weakest entry points).
 - `execute_clausulazo` notifies on success and on Biwenger 4xx.
 """
 
@@ -16,7 +16,7 @@ import pytest
 
 from packages.biwenger_tools.api.logic import emergency
 
-# --- _recent_lost_position -----------------------------------------------
+# --- _recent_lost_players -----------------------------------------------
 
 
 def _board_entry(date_epoch, from_id=None, from_name=None, player_id=42):
@@ -42,86 +42,88 @@ def _bw_player(player_id, name, position, alt=None):
     }
 
 
-def test_recent_lost_position_matches_by_user_id():
+def test_recent_lost_players_matches_by_user_id():
     biwenger = MagicMock(user_id=99)
     biwenger.get_all_clausulazos.return_value = {
         "data": [_board_entry(1000, from_id=99, player_id=42)]
     }
     players = {42: _bw_player(42, "Ana", position=2)}
-    pos, name = emergency._recent_lost_position(
+    losses = emergency._recent_lost_players(
         biwenger, players, my_manager_name="anyone", now_epoch=1500
     )
-    assert pos == 2 and name == "Ana"
+    assert [(loss["name"], loss["position_id"]) for loss in losses] == [("Ana", 2)]
 
 
-def test_recent_lost_position_matches_by_name_when_id_missing():
+def test_recent_lost_players_matches_by_name_when_id_missing():
     """Board payload variants may omit `from.id` — fall back to name match."""
     biwenger = MagicMock(user_id=99)
     biwenger.get_all_clausulazos.return_value = {
         "data": [_board_entry(1000, from_name="Lillo", player_id=42)]
     }
     players = {42: _bw_player(42, "Ana", position=2)}
-    pos, _ = emergency._recent_lost_position(
+    losses = emergency._recent_lost_players(
         biwenger, players, my_manager_name="Lillo", now_epoch=1500
     )
-    assert pos == 2
+    assert len(losses) == 1 and losses[0]["position_id"] == 2
 
 
-def test_recent_lost_position_ignores_entries_older_than_24h():
+def test_recent_lost_players_ignores_entries_older_than_24h():
     biwenger = MagicMock(user_id=99)
     biwenger.get_all_clausulazos.return_value = {
         "data": [_board_entry(date_epoch=10, from_id=99, player_id=42)]
     }
     players = {42: _bw_player(42, "Ana", position=2)}
     now = 10 + emergency.RECENT_CLAUSULAZO_WINDOW_SECONDS + 1
-    pos, name = emergency._recent_lost_position(
+    losses = emergency._recent_lost_players(
         biwenger, players, my_manager_name="x", now_epoch=now
     )
-    assert pos is None and name is None
+    assert losses == []
 
 
-def test_recent_lost_position_suppresses_multi_position_player():
-    """Multi-position loss is ambiguous → return None for position but
-    keep the name so the message can mention the multi-pos fallback."""
-    biwenger = MagicMock(user_id=99)
-    biwenger.get_all_clausulazos.return_value = {
-        "data": [_board_entry(1000, from_id=99, player_id=42)]
-    }
-    players = {42: _bw_player(42, "MultiGuy", position=2, alt=[3])}
-    pos, name = emergency._recent_lost_position(
-        biwenger, players, my_manager_name="x", now_epoch=1500
-    )
-    assert pos is None and name == "MultiGuy"
-
-
-def test_recent_lost_position_takes_the_most_recent_match():
+def test_recent_lost_players_returns_all_matches_including_multi_pos():
+    """Multi-position losses are surfaced (so the selector can list
+    them); the suppression rule lives in `preview_clausulazo`, not here."""
     biwenger = MagicMock(user_id=99)
     biwenger.get_all_clausulazos.return_value = {
         "data": [
-            _board_entry(date_epoch=900, from_id=99, player_id=42),
-            _board_entry(date_epoch=1000, from_id=99, player_id=43),
+            {
+                "date": 1000,
+                "content": [
+                    {
+                        "type": "clause",
+                        "from": {"id": 99},
+                        "player": {"id": 42},
+                    },
+                    {
+                        "type": "clause",
+                        "from": {"id": 99},
+                        "player": {"id": 43},
+                    },
+                ],
+            }
         ]
     }
     players = {
-        42: _bw_player(42, "Old", position=2),
-        43: _bw_player(43, "Recent", position=4),
+        42: _bw_player(42, "MultiGuy", position=2, alt=[3]),
+        43: _bw_player(43, "SimpleGuy", position=4),
     }
-    pos, name = emergency._recent_lost_position(
+    losses = emergency._recent_lost_players(
         biwenger, players, my_manager_name="x", now_epoch=1500
     )
-    assert pos == 4 and name == "Recent"
+    assert [loss["name"] for loss in losses] == ["MultiGuy", "SimpleGuy"]
+    assert losses[0]["alt_positions"] == [3]
 
 
-def test_recent_lost_position_ignores_other_managers_losses():
+def test_recent_lost_players_ignores_other_managers_losses():
     biwenger = MagicMock(user_id=99)
     biwenger.get_all_clausulazos.return_value = {
         "data": [_board_entry(1000, from_id=42, from_name="Otro", player_id=42)]
     }
     players = {42: _bw_player(42, "X", position=2)}
-    pos, _ = emergency._recent_lost_position(
+    losses = emergency._recent_lost_players(
         biwenger, players, my_manager_name="Lillo", now_epoch=1500
     )
-    assert pos is None
+    assert losses == []
 
 
 # --- _weakest_outfield_position ------------------------------------------
@@ -229,7 +231,7 @@ def preview_env():
         biwenger_players,
         rivals,
         affordable,
-        lost_position=(None, None),
+        losses=None,
     ):
         stack = ExitStack()
 
@@ -247,7 +249,7 @@ def preview_env():
         )
         stack.enter_context(patch(_patches("build_context"), return_value=ctx))
         stack.enter_context(
-            patch(_patches("_recent_lost_position"), return_value=lost_position)
+            patch(_patches("_recent_lost_players"), return_value=losses or [])
         )
         stack.enter_context(patch(_patches("gather_rivals"), return_value=rivals))
         stack.enter_context(
@@ -266,8 +268,18 @@ def preview_env():
         yield factory
 
 
-def test_preview_recent_clausulazo_targets_lost_line(preview_env):
-    """If a DEF was clausulated against me, the preview targets a DEF."""
+def _loss(player_id, name, position, alt=None, date=1000):
+    return {
+        "player_id": player_id,
+        "name": name,
+        "position_id": position,
+        "alt_positions": alt or [],
+        "date": date,
+    }
+
+
+def test_preview_single_loss_targets_lost_line(preview_env):
+    """One DEF lost (single-position) → targets DEF without selector."""
     biwenger_players = {
         10: _bw_player(10, "Gk", position=1),
         11: _bw_player(11, "D1", position=2),
@@ -279,51 +291,95 @@ def test_preview_recent_clausulazo_targets_lost_line(preview_env):
         biwenger_players=biwenger_players,
         rivals=rivals,
         affordable=rivals,
-        lost_position=(2, "AnaDef"),
+        losses=[_loss(42, "AnaDef", position=2)],
     )
     result = emergency.preview_clausulazo()
 
     assert result["target"]["player_id"] == 50  # DEF candidate wins, not the SF 900 FWD
     assert result["target"]["position_id"] == 2
     assert "AnaDef" in result["reason"]
-    # Telegram was called once with an inline keyboard carrying the 3 ids.
     mock_send.assert_called_once()
-    kwargs = mock_send.call_args.kwargs
-    assert "AnaDef" in mock_send.call_args.args[0]
-    buttons = kwargs["reply_markup"]["inline_keyboard"][0]
+    buttons = mock_send.call_args.kwargs["reply_markup"]["inline_keyboard"][0]
     assert buttons[0]["callback_data"] == "e:c:50:7:5000000"
     assert buttons[1]["callback_data"] == "e:n"
 
 
-def test_preview_multi_pos_loss_falls_back_to_weakest_line(preview_env):
-    """`_recent_lost_position` returned `(None, "MultiGuy")` → use weakest line."""
-    biwenger_players = {
-        10: _bw_player(10, "Gk", position=1),
-        11: _bw_player(11, "D1", position=2),
-        12: _bw_player(12, "M1", position=3),
-        13: _bw_player(13, "M2", position=3),
-        14: _bw_player(14, "F1", position=4),
-        15: _bw_player(15, "F2", position=4),
-    }
-    # squad: 1 GK / 1 DEF / 2 MID / 2 FWD → weakest outfield = DEF (count 1).
-    rivals = [_cand(50, position=2, sf=400), _cand(51, position=3, sf=900)]
+def test_preview_multi_pos_single_loss_shows_selector(preview_env):
+    """One multi-pos loss → ambiguous → selector with both positions."""
+    biwenger_players = {10: _bw_player(10, "Gk", position=1)}
     biwenger, mock_send = preview_env(
         cash=20_000_000,
-        my_squad=_squad(10, 11, 12, 13, 14, 15),
+        my_squad=_squad(10),
         biwenger_players=biwenger_players,
-        rivals=rivals,
-        affordable=rivals,
-        lost_position=(None, "MultiGuy"),
+        rivals=[],
+        affordable=[],
+        losses=[_loss(42, "MultiGuy", position=2, alt=[3])],
     )
     result = emergency.preview_clausulazo()
 
-    # DEF candidate is picked even though the MID has higher SF.
-    assert result["target"]["player_id"] == 50
-    assert "MultiGuy" in result["reason"]
-    assert "multiposición" in result["reason"]
+    assert result.get("selector") is True
+    assert result.get("target") is None  # no target yet, user has to choose
+    text = mock_send.call_args.args[0]
+    assert "MultiGuy" in text
+    buttons_flat = [
+        btn
+        for row in mock_send.call_args.kwargs["reply_markup"]["inline_keyboard"]
+        for btn in row
+    ]
+    callback_data = {b["callback_data"] for b in buttons_flat}
+    assert "e:p:2" in callback_data  # DEF
+    assert "e:p:3" in callback_data  # MID (alt)
+    assert "e:m" in callback_data  # weakest fallback
+    assert "e:n" in callback_data  # cancel
 
 
-def test_preview_no_recent_clausulazo_uses_weakest_line(preview_env):
+def test_preview_multiple_losses_shows_selector(preview_env):
+    """Two single-position losses → can't tell which is more recent in
+    the batched-date board → selector lists both."""
+    biwenger, mock_send = preview_env(
+        cash=20_000_000,
+        my_squad=_squad(),
+        biwenger_players={},
+        rivals=[],
+        affordable=[],
+        losses=[
+            _loss(42, "DefenderOne", position=2),
+            _loss(43, "ForwardOne", position=4),
+        ],
+    )
+    result = emergency.preview_clausulazo()
+
+    assert result.get("selector") is True
+    text = mock_send.call_args.args[0]
+    assert "DefenderOne" in text and "ForwardOne" in text
+    callbacks = {
+        b["callback_data"]
+        for row in mock_send.call_args.kwargs["reply_markup"]["inline_keyboard"]
+        for b in row
+    }
+    assert {"e:p:2", "e:p:4", "e:m", "e:n"}.issubset(callbacks)
+
+
+def test_preview_force_position_skips_detection(preview_env):
+    """`force_position=3` jumps straight to picking a target in MID."""
+    biwenger_players = {10: _bw_player(10, "Gk", position=1)}
+    rivals = [_cand(50, position=3, sf=500), _cand(51, position=2, sf=900)]
+    biwenger, mock_send = preview_env(
+        cash=20_000_000,
+        my_squad=_squad(10),
+        biwenger_players=biwenger_players,
+        rivals=rivals,
+        affordable=rivals,
+        losses=[_loss(42, "MultiGuy", position=2, alt=[3])],  # detection ignored
+    )
+    result = emergency.preview_clausulazo(force_position=3)
+
+    assert result["target"]["player_id"] == 50  # MID candidate
+    assert "elegido" in result["reason"]
+
+
+def test_preview_force_weakest_skips_detection(preview_env):
+    """`force_weakest=True` runs the weakest-line flow regardless of losses."""
     biwenger_players = {
         10: _bw_player(10, "Gk", position=1),
         11: _bw_player(11, "D1", position=2),
@@ -331,7 +387,6 @@ def test_preview_no_recent_clausulazo_uses_weakest_line(preview_env):
         13: _bw_player(13, "M1", position=3),
         14: _bw_player(14, "F1", position=4),
     }
-    # 2 DEF / 1 MID / 1 FWD → tie at 1 between MID and FWD → MID wins.
     rivals = [_cand(50, position=3, sf=300), _cand(51, position=4, sf=600)]
     biwenger, mock_send = preview_env(
         cash=20_000_000,
@@ -339,7 +394,30 @@ def test_preview_no_recent_clausulazo_uses_weakest_line(preview_env):
         biwenger_players=biwenger_players,
         rivals=rivals,
         affordable=rivals,
-        lost_position=(None, None),
+        losses=[_loss(42, "X", position=2)],  # detection ignored
+    )
+    result = emergency.preview_clausulazo(force_weakest=True)
+
+    assert result["target"]["player_id"] == 50  # weakest = MID, no selector path
+    assert "elegido" in result["reason"]
+
+
+def test_preview_no_losses_uses_weakest_line(preview_env):
+    biwenger_players = {
+        10: _bw_player(10, "Gk", position=1),
+        11: _bw_player(11, "D1", position=2),
+        12: _bw_player(12, "D2", position=2),
+        13: _bw_player(13, "M1", position=3),
+        14: _bw_player(14, "F1", position=4),
+    }
+    rivals = [_cand(50, position=3, sf=300), _cand(51, position=4, sf=600)]
+    biwenger, mock_send = preview_env(
+        cash=20_000_000,
+        my_squad=_squad(10, 11, 12, 13, 14),
+        biwenger_players=biwenger_players,
+        rivals=rivals,
+        affordable=rivals,
+        losses=[],
     )
     result = emergency.preview_clausulazo()
 
@@ -355,13 +433,12 @@ def test_preview_no_affordable_candidates_sends_no_target_message(preview_env):
         biwenger_players=biwenger_players,
         rivals=[],
         affordable=[],
-        lost_position=(None, None),
+        losses=[],
     )
     result = emergency.preview_clausulazo()
 
     assert result["target"] is None
     mock_send.assert_called_once()
-    # No inline keyboard when there's nothing to confirm.
     assert mock_send.call_args.kwargs.get("reply_markup") is None
     assert "Sin candidatos" in mock_send.call_args.args[0]
 

--- a/packages/biwenger_tools/bot/app.py
+++ b/packages/biwenger_tools/bot/app.py
@@ -283,12 +283,57 @@ def _run_emergencia_cancel(edit_into: tuple[str, int] | None) -> None:
     )
 
 
+def _run_emergencia_refine(params: dict, edit_into: tuple[str, int] | None) -> None:
+    """Re-trigger /emergencia preview with a forced position/weakest flag.
+
+    Fired by the selector buttons in the multi-clausulazo case
+    (`e:p:<position>` and `e:m`). Strips the selector keyboard so it
+    can't be re-tapped, then calls the preview endpoint with the user's
+    choice — the api posts a fresh confirmation preview with Sí/No.
+    """
+    if edit_into is not None:
+        chat_id, message_id = edit_into
+        edit_message_reply_markup(
+            bot_token=config.TELEGRAM_BOT_TOKEN,
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup={"inline_keyboard": []},
+        )
+    send_telegram_message(
+        bot_token=config.TELEGRAM_BOT_TOKEN,
+        chat_id=config.TELEGRAM_CHAT_ID,
+        text="⏳ <b>Emergencia</b> — buscando objetivo…",
+    )
+    try:
+        api_client.call_api(
+            config.BIWENGER_API_URL,
+            "/emergency/clausulazo/preview",
+            method="POST",
+            params=params,
+        )
+    except Exception as exc:
+        logger.error(
+            "Webhook: emergency refine failed",
+            extra={"params": params, "error": str(exc)},
+        )
+        send_telegram_message(
+            bot_token=config.TELEGRAM_BOT_TOKEN,
+            chat_id=config.TELEGRAM_CHAT_ID,
+            text=(
+                f"❌ Error al ejecutar <b>Emergencia</b>: "
+                f"<code>{html.escape(str(exc))}</code>"
+            ),
+        )
+
+
 def _handle_callback(cb: dict) -> None:
     """Dispatch on the callback_data prefix.
 
     Inline-keyboard taps in scope:
     - `analizar:<id|all>` — manager picker for /analizar.
     - `e:c:<player_id>:<owner_id>:<amount>` — confirm /emergencia.
+    - `e:p:<position_id>` — selector "reinforce this position".
+    - `e:m` — selector "weakest line" fallback.
     - `e:n` — cancel /emergencia.
     """
     answer_callback_query(config.TELEGRAM_BOT_TOKEN, cb["id"])
@@ -306,6 +351,12 @@ def _handle_callback(cb: dict) -> None:
     if prefix == "e":
         if value == "n":
             _run_emergencia_cancel(edit_into)
+        elif value == "m":
+            _run_emergencia_refine({"force_weakest": "1"}, edit_into)
+        elif value.startswith("p:"):
+            _run_emergencia_refine(
+                {"force_position": value.split(":", 1)[1]}, edit_into
+            )
         else:
             _run_emergencia_confirm(value, edit_into)
         return

--- a/packages/biwenger_tools/bot/tests/test_bot.py
+++ b/packages/biwenger_tools/bot/tests/test_bot.py
@@ -325,6 +325,44 @@ def test_emergencia_confirm_callback_calls_execute_with_query_params(client):
     )
 
 
+def test_emergencia_selector_position_callback_refines_with_force_position(client):
+    """`e:p:<position>` → POST /preview?force_position=<position>.
+    Strips the selector keyboard so it can't be re-tapped."""
+    with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
+        "packages.biwenger_tools.bot.app.edit_message_reply_markup"
+    ) as mock_strip, patch(
+        "packages.biwenger_tools.bot.app.send_telegram_message"
+    ), patch(
+        "packages.biwenger_tools.bot.app.api_client.call_api"
+    ) as mock_call:
+        resp = _post(client, _callback_update(_VALID_CHAT, "e:p:3"))
+    assert resp.status_code == 200
+    mock_strip.assert_called_once()
+    mock_call.assert_called_once_with(
+        _API_URL,
+        "/emergency/clausulazo/preview",
+        method="POST",
+        params={"force_position": "3"},
+    )
+
+
+def test_emergencia_selector_weakest_callback_refines_with_force_weakest(client):
+    """`e:m` → POST /preview?force_weakest=1."""
+    with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
+        "packages.biwenger_tools.bot.app.edit_message_reply_markup"
+    ), patch("packages.biwenger_tools.bot.app.send_telegram_message"), patch(
+        "packages.biwenger_tools.bot.app.api_client.call_api"
+    ) as mock_call:
+        resp = _post(client, _callback_update(_VALID_CHAT, "e:m"))
+    assert resp.status_code == 200
+    mock_call.assert_called_once_with(
+        _API_URL,
+        "/emergency/clausulazo/preview",
+        method="POST",
+        params={"force_weakest": "1"},
+    )
+
+
 def test_emergencia_cancel_callback_edits_message_and_does_not_call_api(client):
     with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
         "packages.biwenger_tools.bot.app.edit_message_text"


### PR DESCRIPTION
## Background — the bug
Live probe of the Biwenger transfer board endpoint revealed it packs multiple clausulazos that happen close together into a single board "entry" with one shared \`date\`. With the previous logic (sort matches by \`entry.date\` desc, pick the first), this meant: when ≥2 clausulazos were against me in the same batch, the user always saw the SAME one — whichever happened to appear first in the content list — regardless of which was actually the most recent in real life. That's why /emergencia kept suggesting Affengruber when Juan Iglesias was the more recent loss.

## Fix
When there are >1 recent losses (or a single multi-position loss), the preview now posts a **selector** message listing every loss with its position(s) and offers a button per distinct outfield position the losses touch, plus a "🌍 Línea más mermada" override and "❌ Cancelar". The button tap fires \`/emergency/clausulazo/preview?force_position=N\` or \`?force_weakest=1\`, which re-enters with the position locked and posts the Sí/No confirmation.

For 0 or 1 single-position losses the flow is unchanged.

## Changes
- \`emergency.py\`: \`_recent_lost_position\` → \`_recent_lost_players\` (full list); new helpers \`_unique_positions\`, \`_selector_keyboard\`, \`_format_selector_text\`; \`preview_clausulazo\` takes \`force_position\`/\`force_weakest\`.
- \`api/app.py\`: \`/emergency/clausulazo/preview\` accepts the two new query params.
- \`bot/app.py\`: new callback prefixes \`e:p:<pos>\` and \`e:m\` (selector buttons) → forwards to refine endpoint.

## Test plan
- [x] \`bazel test //...\` passes (6/6 targets).
- [x] flake8 + black clean.
- [ ] After deploy: receive 2 clausulazos → /emergencia → confirm selector lists both with position buttons. Tap one → confirmation preview with Sí/No.