### PR TITLE
chore: split emergency module, dedupe euros/sf_of, lock master deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,17 @@ env:
   REGISTRY: europe-southwest1-docker.pkg.dev/biwenger-tools/biwenger-docker
   TEMPORADA_ACTUAL: "26-27"
 
+# Serialize master deploys. Without this, two PRs merged seconds apart
+# trigger two parallel runs that both `docker push` and `gcloud run
+# deploy` the same service — the slower image-build wins and the newer
+# code can be silently overwritten. Observed on the 2026-06-01
+# PR#124+#125 stack (api ended up at PR#124's commit even though #125
+# merged after). `cancel-in-progress: false` queues runs so no merge
+# loses its deploy.
+concurrency:
+  group: deploy-master
+  cancel-in-progress: false
+
 jobs:
   # -------------------------------------------------------
   # 0. Lint Python code (flake8 + black --check) via the Bazel toolchain

--- a/core/utils.py
+++ b/core/utils.py
@@ -46,3 +46,15 @@ def load_json_secret(env_var: str) -> dict:
         return json.loads(raw)
     except json.JSONDecodeError:
         return {}
+
+
+def format_euros(n: int | None) -> str:
+    """Spanish-style euro formatting: `12.345.678 €`.
+
+    `None` returns `"—"` so callers can tell "Biwenger returned 0" apart
+    from "field not present" without an extra branch at every call site.
+    """
+    if n is None:
+        return "—"
+    s = f"{int(n):,}".replace(",", ".")
+    return f"{s} €"

--- a/packages/biwenger_tools/api/logic/auto_bid.py
+++ b/packages/biwenger_tools/api/logic/auto_bid.py
@@ -47,7 +47,7 @@ from core.constants import MADRID_TZ
 from core.sdk import firestore
 from core.sdk.jp import get_predict_rate
 from core.sdk.telegram import send_telegram_message_or_raise
-from core.utils import get_logger
+from core.utils import format_euros, get_logger
 from packages.biwenger_tools.api import config
 from packages.biwenger_tools.api.logic.orchestration import build_context
 from packages.biwenger_tools.api.logic.player_matching import find_player_match
@@ -99,14 +99,6 @@ def _today_madrid() -> str:
 def _log_collection_path(day: str) -> str:
     """`auto_bid_log/{day}/bids` — odd-segment subcollection for Firestore."""
     return f"{AUTO_BID_LOG_PATH}/{day}/bids"
-
-
-def _euros(n: int | None) -> str:
-    """Spanish-style thousands separator: 12.345.678 €."""
-    if n is None:
-        return "—"
-    s = f"{int(n):,}".replace(",", ".")
-    return f"{s} €"
 
 
 def _jitter() -> int:
@@ -248,8 +240,8 @@ def _format_skip_line(entry: dict, esc) -> str:
         return (
             f"💸 Sin pasta para <b>{name}</b> · "
             f"{esc(entry['tier_label'])} · "
-            f"puja {esc(_euros(entry['bid']))} &gt; "
-            f"cash {esc(_euros(entry['cash']))}"
+            f"puja {esc(format_euros(entry['bid']))} &gt; "
+            f"cash {esc(format_euros(entry['cash']))}"
         )
     if kind == "already_bid":
         return f"🔁 Ya pujado <b>{name}</b>"
@@ -281,7 +273,7 @@ def _format_telegram_text(
 
     for entry in placed:
         lines.append(
-            f"✅ Pujado <b>{esc(_euros(entry['bid']))}</b> por "
+            f"✅ Pujado <b>{esc(format_euros(entry['bid']))}</b> por "
             f"<b>{esc(entry['name'])}</b> ({esc(entry['tier_label'])})"
         )
 
@@ -293,8 +285,8 @@ def _format_telegram_text(
 
     lines.append("")
     lines.append(
-        f"Total pujado: <b>{esc(_euros(total_bid))}</b> · "
-        f"Cash restante: <b>{esc(_euros(remaining_cash))}</b>"
+        f"Total pujado: <b>{esc(format_euros(total_bid))}</b> · "
+        f"Cash restante: <b>{esc(format_euros(remaining_cash))}</b>"
     )
     if not placed:
         lines.append(f"<i>Log: auto_bid_log/{esc(day)}</i>")

--- a/packages/biwenger_tools/api/logic/clausulazo_candidates.py
+++ b/packages/biwenger_tools/api/logic/clausulazo_candidates.py
@@ -88,3 +88,24 @@ def filter_affordable(candidates: list[dict], my_ids: set, target: int) -> list[
             continue
         out.append(row)
     return out
+
+
+def pick_top_in_position(
+    candidates: list[dict], preferred_position: int
+) -> tuple[dict | None, bool]:
+    """Top SF in `preferred_position`; fall back to top SF overall.
+
+    Returns `(candidate, in_preferred_position)`. When `in_preferred_position`
+    is False the candidate is the best-SF rival overall — used by callers
+    that want to surface "no DEF afford(able), going for the best SF
+    instead" without owning the in-position filtering logic themselves.
+    `(None, False)` when there are no candidates at all.
+    """
+    in_position = [c for c in candidates if c.get("position_id") == preferred_position]
+    if in_position:
+        in_position.sort(key=sf_of, reverse=True)
+        return in_position[0], True
+    if not candidates:
+        return None, False
+    candidates_sorted = sorted(candidates, key=sf_of, reverse=True)
+    return candidates_sorted[0], False

--- a/packages/biwenger_tools/api/logic/clausulazo_detection.py
+++ b/packages/biwenger_tools/api/logic/clausulazo_detection.py
@@ -1,0 +1,130 @@
+"""Read-side helpers for `/emergencia`: who got clausulated and which
+position the squad needs reinforcing.
+
+Sibling of `clausulazo_candidates.py` (which builds the rival pool to
+clausulazo *to*). The split keeps "what's happening" (this file)
+separate from "who I can go after" (candidates).
+
+Public surface:
+
+- `recent_lost_players(...)` — every clausulazo against me in the
+  configured window, resolved against the cf-base players map. Returns
+  a list because Biwenger batches transfers under a single shared
+  `date` and we can't reliably tell which is the most recent within a
+  batch — that's a caller decision.
+- `weakest_outfield_position(...)` — DEF/MID/FWD with the fewest
+  players in my squad, with DEF > MID > FWD tie-break.
+- `unique_outfield_positions(losses)` — DEF/MID/FWD positions a loss
+  list touches (primary + alts).
+- `is_multi_position(bw_player)` — `altPositions` non-empty.
+"""
+
+from core.sdk.biwenger import BiwengerClient
+from core.utils import get_logger
+from packages.biwenger_tools.api import config
+
+logger = get_logger(__name__)
+
+RECENT_CLAUSULAZO_WINDOW_SECONDS = 24 * 60 * 60
+
+# Outfield positions, in DEF > MID > FWD priority order. GK is out of
+# scope: we never clausulazo a GK on emergency and we never reinforce
+# the GK line via /emergencia either.
+OUTFIELD_POSITION_IDS = (2, 3, 4)
+
+
+def is_multi_position(bw_player: dict) -> bool:
+    """A multi-position player has at least one `altPositions` entry."""
+    return bool(bw_player.get("altPositions") or [])
+
+
+def recent_lost_players(
+    biwenger: BiwengerClient,
+    biwenger_players: dict,
+    my_manager_name: str,
+    now_epoch: float,
+) -> list[dict]:
+    """Every clausulazo against me in the last
+    `RECENT_CLAUSULAZO_WINDOW_SECONDS`, resolved against `biwenger_players`.
+
+    Returns `[{player_id, name, position_id, alt_positions, date}, ...]`
+    in board order. Biwenger packs multiple transfers into a single
+    entry with one shared `date`, so the order here is NOT chronological
+    — when there's more than one match the caller is the one that
+    decides what to do (typically: show a selector so the user picks).
+
+    Detection compares `from.id == biwenger.user_id` first; some board
+    payload variants only expose `from.name`, so we fall back to a
+    name match. Either suffices — we own both sides of the lookup.
+    """
+    raw = biwenger.get_all_clausulazos(config.CLAUSULAZOS_URL)
+    entries = raw.get("data", []) or []
+    if isinstance(entries, dict):
+        entries = list(entries.values())
+
+    cutoff = now_epoch - RECENT_CLAUSULAZO_WINDOW_SECONDS
+    losses: list[dict] = []
+    for entry in entries:
+        entry_date = entry.get("date", 0) or 0
+        if entry_date < cutoff:
+            continue
+        for item in entry.get("content") or []:
+            if item.get("type") != "clause":
+                continue
+            from_obj = item.get("from") or {}
+            from_id = from_obj.get("id")
+            from_name = from_obj.get("name")
+            is_me = (from_id is not None and int(from_id) == int(biwenger.user_id)) or (
+                from_name and my_manager_name and from_name == my_manager_name
+            )
+            if not is_me:
+                continue
+            player_ref = item.get("player")
+            player_id = (
+                player_ref.get("id") if isinstance(player_ref, dict) else player_ref
+            )
+            bw_player = biwenger_players.get(player_id)
+            if not bw_player:
+                continue
+            losses.append(
+                {
+                    "player_id": player_id,
+                    "name": bw_player.get("name"),
+                    "position_id": bw_player.get("position"),
+                    "alt_positions": bw_player.get("altPositions") or [],
+                    "date": entry_date,
+                }
+            )
+    return losses
+
+
+def unique_outfield_positions(losses: list[dict]) -> list[int]:
+    """Outfield positions a loss list touches (primary + alts), DEF/MID/FWD order.
+
+    Used to build the selector buttons when there's more than one
+    recent loss against me: one button per distinct position the
+    losses imply. GK is excluded (see module docstring).
+    """
+    found: set[int] = set()
+    for loss in losses:
+        for pos in (loss["position_id"], *loss["alt_positions"]):
+            if pos in OUTFIELD_POSITION_IDS:
+                found.add(pos)
+    return [p for p in OUTFIELD_POSITION_IDS if p in found]
+
+
+def weakest_outfield_position(my_squad: list, biwenger_players: dict) -> int:
+    """Position id with the fewest players among DEF/MID/FWD.
+
+    Ties break in DEF > MID > FWD order — lower-tier positions get
+    filled first because affordable replacements are easier to find.
+    """
+    counts = {pos: 0 for pos in OUTFIELD_POSITION_IDS}
+    for entry in my_squad:
+        bw_player = biwenger_players.get(entry.get("id"))
+        if not bw_player:
+            continue
+        pos = bw_player.get("position")
+        if pos in counts:
+            counts[pos] += 1
+    return min(OUTFIELD_POSITION_IDS, key=lambda pos: (counts[pos], pos))

--- a/packages/biwenger_tools/api/logic/emergency.py
+++ b/packages/biwenger_tools/api/logic/emergency.py
@@ -1,38 +1,48 @@
 """Emergency clausulazo — `POST /emergency/clausulazo/{preview,execute}`.
 
-Manual, on-demand operation triggered from the Telegram bot via
-`/emergencia`. Two phases:
+Two-phase flow:
 
-1. **Preview** — read my cash, decide which position needs reinforcing
-   (the line I just lost to a recent clausulazo, or the weakest outfield
-   line if none), pick the best affordable rival in that position, and
-   post a confirmation message with inline-keyboard buttons.
-2. **Execute** — fired by the bot when the user taps "Sí" on the inline
-   keyboard. Calls `place_clausulazo` against the exact `player_id` /
-   `owner_user_id` / `amount` the user approved, and notifies the
-   result.
+1. **Preview** — read recent losses + cash, decide which position to
+   reinforce, and post a confirmation message. When the losses don't
+   uniquely identify a position (>1 loss in the last 24h, or 1
+   multi-position loss), the preview posts a *selector* message and
+   the user picks a position; the bot's tap re-enters this function
+   via `force_position` / `force_weakest`, which goes straight to the
+   confirmation message.
+
+2. **Execute** — fired by the bot when the user taps "Sí". POSTs the
+   clausulazo with the exact `player_id`/`owner_user_id`/`amount` the
+   user approved and notifies the result.
 
 Hard rules:
 
 - Cash is **justo** — `target = cash` (no dynamic margin, unlike
-  `/recomendar`). The op must never push me into the red.
-- `amount = clause_value` exactly — minimum valid clausulazo, no inflation.
-- Multi-position players lost are NOT used to pick a target position
-  (their loss is ambiguous → fall back to the weakest-line rule).
-- Never clause a rival's only GK (shared `filter_affordable` house rule).
+  `/recomendar`). The op must never push the user into the red.
+- `amount = clause_value` exactly — minimum valid clausulazo, no
+  inflation.
+- Detection lives in `clausulazo_detection.py`; rival candidate
+  selection in `clausulazo_candidates.py`. This module is just the
+  flow + UX.
 """
 
+import html
 import time
 from typing import Optional
 
-from core.sdk.biwenger import BiwengerClient
 from core.sdk.telegram import send_telegram_message_or_raise
-from core.utils import get_logger
+from core.utils import format_euros, get_logger
 from packages.biwenger_tools.api import config
 from packages.biwenger_tools.api.logic.clausulazo_candidates import (
     filter_affordable,
     gather_rivals,
+    pick_top_in_position,
     sf_of,
+)
+from packages.biwenger_tools.api.logic.clausulazo_detection import (
+    OUTFIELD_POSITION_IDS,
+    recent_lost_players,
+    unique_outfield_positions,
+    weakest_outfield_position,
 )
 from packages.biwenger_tools.api.logic.orchestration import (
     build_biwenger_session,
@@ -43,142 +53,10 @@ from packages.biwenger_tools.api.player_formatting import POSITION_SHORT
 
 logger = get_logger(__name__)
 
-RECENT_CLAUSULAZO_WINDOW_SECONDS = 24 * 60 * 60
-
-# Position-pick order when reinforcing the weakest line. GK is out of
-# scope (we don't clausulazo a GK on emergency). DEF goes first on
-# ties, then MID, then FWD — the lower-cost positions cover faster.
-_OUTFIELD_POSITION_IDS = (2, 3, 4)
 _POSITION_LABELS_ES = {1: "Portero", 2: "Defensa", 3: "Centrocampista", 4: "Delantero"}
 
 
-def _euros(n: int | None) -> str:
-    if n is None:
-        return "—"
-    s = f"{int(n):,}".replace(",", ".")
-    return f"{s} €"
-
-
-def _is_multi_position(bw_player: dict) -> bool:
-    """A multi-position player has at least one `altPositions` entry."""
-    return bool(bw_player.get("altPositions") or [])
-
-
-def _recent_lost_players(
-    biwenger: BiwengerClient,
-    biwenger_players: dict,
-    my_manager_name: str,
-    now_epoch: float,
-) -> list[dict]:
-    """Every clausulazo against me in the last 24h, resolved against the
-    cf-base players map.
-
-    Returns a list of `{player_id, name, position_id, alt_positions, date}`
-    in board order (which Biwenger does NOT guarantee to be chronological:
-    multiple clausulazos that arrive in the same batch share the entry's
-    `date`, so we can't order them reliably by that field — the caller
-    is the one that decides what to do when there's more than one).
-
-    Detection compares `from.id == biwenger.user_id` first; some board
-    payload variants only expose `from.name`, so we fall back to a name
-    match. Either is sufficient — we own both sides of the lookup.
-    """
-    raw = biwenger.get_all_clausulazos(config.CLAUSULAZOS_URL)
-    entries = raw.get("data", []) or []
-    if isinstance(entries, dict):
-        entries = list(entries.values())
-
-    cutoff = now_epoch - RECENT_CLAUSULAZO_WINDOW_SECONDS
-    losses: list[dict] = []
-    for entry in entries:
-        entry_date = entry.get("date", 0) or 0
-        if entry_date < cutoff:
-            continue
-        for item in entry.get("content") or []:
-            if item.get("type") != "clause":
-                continue
-            from_obj = item.get("from") or {}
-            from_id = from_obj.get("id")
-            from_name = from_obj.get("name")
-            is_me = (from_id is not None and int(from_id) == int(biwenger.user_id)) or (
-                from_name and my_manager_name and from_name == my_manager_name
-            )
-            if not is_me:
-                continue
-            player_ref = item.get("player")
-            player_id = (
-                player_ref.get("id") if isinstance(player_ref, dict) else player_ref
-            )
-            bw_player = biwenger_players.get(player_id)
-            if not bw_player:
-                continue
-            losses.append(
-                {
-                    "player_id": player_id,
-                    "name": bw_player.get("name"),
-                    "position_id": bw_player.get("position"),
-                    "alt_positions": bw_player.get("altPositions") or [],
-                    "date": entry_date,
-                }
-            )
-    return losses
-
-
-def _unique_positions(losses: list[dict]) -> list[int]:
-    """Outfield positions a loss touches (primary + alts), DEF/MID/FWD order.
-
-    Used to build the selector buttons: one per distinct outfield
-    position the recent losses imply. GK is excluded — we never
-    clausulazo a GK on emergency.
-    """
-    found: set[int] = set()
-    for loss in losses:
-        for pos in (loss["position_id"], *loss["alt_positions"]):
-            if pos in _OUTFIELD_POSITION_IDS:
-                found.add(pos)
-    return [p for p in _OUTFIELD_POSITION_IDS if p in found]
-
-
-def _weakest_outfield_position(my_squad: list, biwenger_players: dict) -> int:
-    """Position id with the fewest players among DEF/MID/FWD.
-
-    Ties break in DEF > MID > FWD order — lower-tier positions get
-    filled first because affordable replacements are easier to find.
-    """
-    counts = {pos: 0 for pos in _OUTFIELD_POSITION_IDS}
-    for entry in my_squad:
-        bw_player = biwenger_players.get(entry.get("id"))
-        if not bw_player:
-            continue
-        pos = bw_player.get("position")
-        if pos in counts:
-            counts[pos] += 1
-    # Tie-break order: iterate _OUTFIELD_POSITION_IDS so DEF (2) wins
-    # over MID (3) over FWD (4) when counts are equal.
-    return min(_OUTFIELD_POSITION_IDS, key=lambda pos: (counts[pos], pos))
-
-
-def _pick_target(
-    candidates: list[dict], preferred_position: int
-) -> tuple[Optional[dict], str]:
-    """Top SF in `preferred_position`; fall back to top SF overall.
-
-    Returns `(candidate, fallback_note)`. `fallback_note` is empty if a
-    candidate in the preferred position was found, non-empty otherwise
-    so the message can say "no DEF afford(able), going for the best
-    SF instead".
-    """
-    in_position = [c for c in candidates if c.get("position_id") == preferred_position]
-    if in_position:
-        in_position.sort(key=sf_of, reverse=True)
-        return in_position[0], ""
-    if not candidates:
-        return None, ""
-    candidates_sorted = sorted(candidates, key=sf_of, reverse=True)
-    return candidates_sorted[0], (
-        f"sin candidatos en {_POSITION_LABELS_ES[preferred_position]}, "
-        "voy al mejor SF disponible"
-    )
+# --- Keyboards -----------------------------------------------------------
 
 
 def _confirmation_keyboard(player_id: int, owner_id: int, amount: int) -> dict:
@@ -205,8 +83,9 @@ def _selector_keyboard(positions: list[int]) -> dict:
     """One button per outfield position in `positions`, plus weakest-line.
 
     `e:p:<pid>` taps trigger a refined preview locked to that position;
-    `e:m` triggers the weakest-line fallback (lets the user override the
-    auto-detected positions when they prefer to plug a different gap).
+    `e:m` triggers the weakest-line fallback (so the user can override
+    the auto-detected positions when they prefer to plug a different
+    gap). `e:n` cancels the flow.
     """
     rows = [
         [
@@ -222,6 +101,9 @@ def _selector_keyboard(positions: list[int]) -> dict:
     return {"inline_keyboard": rows}
 
 
+# --- Message formatters --------------------------------------------------
+
+
 def _format_selector_text(losses: list[dict], cash: int) -> str:
     """Render the multi-loss selector message.
 
@@ -232,7 +114,7 @@ def _format_selector_text(losses: list[dict], cash: int) -> str:
     lines = [
         "🚨 <b>Emergencia — varias pérdidas recientes</b>",
         "",
-        "Tu cash: <b>" + _euros(cash) + "</b>",
+        f"Tu cash: <b>{format_euros(cash)}</b>",
         "",
         "Te han clausulado (últimas 24h):",
     ]
@@ -261,31 +143,85 @@ def _format_preview_text(
         f"\n"
         f"Objetivo: <b>{target['name']}</b> ({pos_short}) "
         f"de <b>{target['owner']}</b>\n"
-        f"Cláusula: <b>{_euros(target['clause_value'])}</b> · "
+        f"Cláusula: <b>{format_euros(target['clause_value'])}</b> · "
         f"SF {sf_of(target)}\n"
-        f"Tu cash: <b>{_euros(cash)}</b>\n"
+        f"Tu cash: <b>{format_euros(cash)}</b>\n"
         f"\n"
         f"<i>Esta operación es irreversible.</i>"
     )
 
 
+def _format_no_target_text(reason: str, cash: int) -> str:
+    return (
+        f"🚨 <b>Emergencia</b>\n"
+        f"\n"
+        f"Sin candidatos asequibles. Tu cash: <b>{format_euros(cash)}</b>. "
+        f"Motivo: <i>{reason}</i>."
+    )
+
+
+def _format_executed_text(amount: int, player_name: str, cash_after: int) -> str:
+    return (
+        f"🚨 <b>Clausulazo ejecutado</b>\n"
+        f"\n"
+        f"Pagado <b>{format_euros(amount)}</b> por "
+        f"<b>{_escape(player_name)}</b>.\n"
+        f"Cash restante: <b>{format_euros(cash_after)}</b>"
+    )
+
+
+# --- Reason strings ------------------------------------------------------
+
+
+def _reason_force_weakest() -> str:
+    return "refuerza la línea más mermada (elegido)"
+
+
+def _reason_force_position(position_id: int) -> str:
+    return (
+        f"refuerza la línea de "
+        f"{_POSITION_LABELS_ES[position_id].lower()}s (elegido)"
+    )
+
+
+def _reason_single_loss(loss: dict) -> str:
+    return (
+        f"acaban de clausularte un "
+        f"{_POSITION_LABELS_ES[loss['position_id']].lower()} "
+        f"({loss['name']}) en las últimas 24h — refuerza esa línea"
+    )
+
+
+def _reason_no_losses() -> str:
+    return "sin clausulazos recientes contra ti — refuerza la línea más mermada"
+
+
+def _fallback_note(preferred_position: int, in_preferred: bool) -> str:
+    if in_preferred:
+        return ""
+    return (
+        f"sin candidatos en {_POSITION_LABELS_ES[preferred_position]}, "
+        "voy al mejor SF disponible"
+    )
+
+
+# --- Flow ----------------------------------------------------------------
+
+
 def preview_clausulazo(
     force_position: Optional[int] = None, force_weakest: bool = False
 ) -> dict:
-    """Compute the target + reason and post the confirmation message.
+    """Compute the target + reason and post the corresponding message.
 
-    Behaviour depends on the recent clausulazos against me:
-    - 0 losses → reinforce weakest outfield line.
-    - 1 single-position loss → target that position directly.
-    - Otherwise (>1 loss, or 1 multi-position loss) → post a selector
-      message with one button per outfield position involved + a
-      "weakest line" fallback. The user's tap re-enters this function
-      with `force_position` or `force_weakest`, which short-circuits
-      the detection and goes straight to the Sí/No preview.
+    Cases:
+    - 0 losses (and no force) → reinforce weakest outfield line.
+    - 1 single-position loss (and no force) → target that position.
+    - Otherwise (multi-loss, multi-pos loss) → post a selector with one
+      button per affected outfield position + weakest-line fallback.
+      The user's tap re-enters with `force_position` / `force_weakest`.
 
-    Side effect: one Telegram message (selector OR confirmation). The
-    returned dict is for diagnostics only — the user-visible artefact
-    is the Telegram message.
+    Returns a diagnostics dict; the user-visible artefact is the
+    Telegram message.
     """
     ctx = build_context()
     biwenger = ctx.biwenger
@@ -297,59 +233,24 @@ def preview_clausulazo(
     league_users = biwenger.get_league_users(config.LEAGUE_DATA_URL)
     my_manager_name = league_users.get(int(biwenger.user_id), "")
 
-    losses = _recent_lost_players(
+    losses = recent_lost_players(
         biwenger, ctx.biwenger_players, my_manager_name, now_epoch=time.time()
     )
 
-    # --- Decide preferred_position + reason --------------------------------
-    if force_weakest:
-        preferred_position = _weakest_outfield_position(my_squad, ctx.biwenger_players)
-        reason = "refuerza la línea más mermada (elegido)"
-    elif force_position is not None:
-        preferred_position = force_position
-        reason = (
-            f"refuerza la línea de "
-            f"{_POSITION_LABELS_ES[force_position].lower()}s (elegido)"
-        )
-    else:
-        # Auto-detect from recent losses. Two ambiguous cases trigger the
-        # selector: more than one loss, or a single loss that's
-        # multi-position. The selector lets the user disambiguate
-        # because the board batches transfers under a shared date and
-        # we can't reliably tell which is the most recent within the batch.
-        unique_positions = _unique_positions(losses)
-        needs_selector = len(losses) > 1 or (
-            len(losses) == 1 and len(losses[0]["alt_positions"]) > 0
-        )
-        if needs_selector and unique_positions:
-            text = _format_selector_text(losses, cash)
-            _send(text, reply_markup=_selector_keyboard(unique_positions))
-            return {
-                "cash": cash,
-                "losses": losses,
-                "selector": True,
-            }
+    preferred_position, reason, selector_payload = _resolve_intent(
+        losses=losses,
+        my_squad=my_squad,
+        biwenger_players=ctx.biwenger_players,
+        cash=cash,
+        force_position=force_position,
+        force_weakest=force_weakest,
+    )
+    if selector_payload is not None:
+        return selector_payload
 
-        if len(losses) == 1:
-            loss = losses[0]
-            preferred_position = loss["position_id"]
-            reason = (
-                f"acaban de clausularte un "
-                f"{_POSITION_LABELS_ES[preferred_position].lower()} "
-                f"({loss['name']}) en las últimas 24h — refuerza esa línea"
-            )
-        else:
-            preferred_position = _weakest_outfield_position(
-                my_squad, ctx.biwenger_players
-            )
-            reason = (
-                "sin clausulazos recientes contra ti — " "refuerza la línea más mermada"
-            )
-
-    # --- Pick target + send confirmation ----------------------------------
     rivals = gather_rivals(biwenger, ctx.biwenger_players, ctx.jp_index)
     affordable = filter_affordable(rivals, my_ids, target=cash)
-    target, fallback_note = _pick_target(affordable, preferred_position)
+    target, in_preferred = pick_top_in_position(affordable, preferred_position)
 
     payload = {
         "cash": cash,
@@ -358,16 +259,12 @@ def preview_clausulazo(
     }
 
     if target is None:
-        text = (
-            f"🚨 <b>Emergencia</b>\n"
-            f"\n"
-            f"Sin candidatos asequibles. Tu cash: <b>{_euros(cash)}</b>. "
-            f"Motivo: <i>{reason}</i>."
-        )
-        _send(text)
+        _send(_format_no_target_text(reason, cash))
         return {**payload, "target": None, "reason": reason}
 
-    text = _format_preview_text(target, reason, fallback_note, cash)
+    text = _format_preview_text(
+        target, reason, _fallback_note(preferred_position, in_preferred), cash
+    )
     _send(
         text,
         reply_markup=_confirmation_keyboard(
@@ -391,14 +288,59 @@ def preview_clausulazo(
     }
 
 
+def _resolve_intent(
+    *,
+    losses: list[dict],
+    my_squad: list,
+    biwenger_players: dict,
+    cash: int,
+    force_position: Optional[int],
+    force_weakest: bool,
+) -> tuple[int, str, Optional[dict]]:
+    """Decide `(preferred_position, reason, selector_payload)`.
+
+    When `selector_payload` is not None, the caller should post the
+    selector and return that payload as-is — there is no target yet,
+    the user has to pick. Otherwise the caller proceeds to candidate
+    selection with the returned `preferred_position` and `reason`.
+    """
+    if force_weakest:
+        return (
+            weakest_outfield_position(my_squad, biwenger_players),
+            _reason_force_weakest(),
+            None,
+        )
+    if force_position is not None:
+        return force_position, _reason_force_position(force_position), None
+
+    needs_selector = len(losses) > 1 or (
+        len(losses) == 1 and len(losses[0]["alt_positions"]) > 0
+    )
+    if needs_selector:
+        positions = unique_outfield_positions(losses)
+        if positions:
+            _send(
+                _format_selector_text(losses, cash),
+                reply_markup=_selector_keyboard(positions),
+            )
+            return 0, "", {"cash": cash, "losses": losses, "selector": True}
+
+    if len(losses) == 1:
+        return losses[0]["position_id"], _reason_single_loss(losses[0]), None
+    return (
+        weakest_outfield_position(my_squad, biwenger_players),
+        _reason_no_losses(),
+        None,
+    )
+
+
 def execute_clausulazo(player_id: int, owner_user_id: int, amount: int) -> dict:
     """Place the approved clausulazo and notify Telegram with the result.
 
-    `player_id`, `owner_user_id` and `amount` come from the inline
-    keyboard payload the bot forwards — i.e. the exact values the user
-    saw and approved in the preview. We do NOT recompute candidates
-    here; if cash dropped between preview and confirm Biwenger will
-    reject and we surface the error.
+    `player_id`/`owner_user_id`/`amount` are the values the user saw and
+    approved in the preview. We do NOT recompute candidates here; if
+    cash dropped between preview and confirm Biwenger rejects and we
+    surface the error.
     """
     biwenger = build_biwenger_session()
     try:
@@ -416,21 +358,15 @@ def execute_clausulazo(player_id: int, owner_user_id: int, amount: int) -> dict:
         _send(f"❌ <b>Clausulazo rechazado</b> — <code>{_escape(str(exc))}</code>")
         raise
 
-    # Resolve the player name for the success message. The execute
-    # endpoint only receives ids (callback_data is capped at 64 bytes),
-    # so the preview's player name doesn't survive the round-trip; we
-    # look it up against the cf-base players map.
+    # Resolve the player name for the success message — the callback
+    # only carries the id and we want the chat to read "Pagado X € por
+    # Iago Aspas" not "por jugador 1523".
     players = biwenger.get_all_players_data_map(config.ALL_PLAYERS_DATA_URL)
     player_name = (players.get(int(player_id)) or {}).get(
         "name"
     ) or f"jugador {player_id}"
     cash_after = int(biwenger.get_account_state().get("cash") or 0)
-    _send(
-        f"🚨 <b>Clausulazo ejecutado</b>\n"
-        f"\n"
-        f"Pagado <b>{_euros(amount)}</b> por <b>{_escape(player_name)}</b>.\n"
-        f"Cash restante: <b>{_euros(cash_after)}</b>"
-    )
+    _send(_format_executed_text(int(amount), player_name, cash_after))
     return {
         "player_id": int(player_id),
         "amount": int(amount),
@@ -440,10 +376,11 @@ def execute_clausulazo(player_id: int, owner_user_id: int, amount: int) -> dict:
     }
 
 
+# --- Side-effect helpers -------------------------------------------------
+
+
 def _escape(text: str) -> str:
     """HTML-escape for Telegram parse_mode=HTML."""
-    import html
-
     return html.escape(text, quote=False)
 
 
@@ -456,3 +393,13 @@ def _send(text: str, reply_markup: Optional[dict] = None) -> None:
     send_telegram_message_or_raise(
         bot_token=token, chat_id=chat_id, text=text, reply_markup=reply_markup
     )
+
+
+# Re-export the outfield set so callers that need the canonical tuple
+# (e.g. the recommendations message) don't have to know which module
+# owns it. Keeps the dependency arrow pointing into `clausulazo_detection`.
+__all__ = [
+    "preview_clausulazo",
+    "execute_clausulazo",
+    "OUTFIELD_POSITION_IDS",
+]

--- a/packages/biwenger_tools/api/logic/recommendations.py
+++ b/packages/biwenger_tools/api/logic/recommendations.py
@@ -16,19 +16,19 @@ formats that as a `[multi: MED]` badge.
 
 from typing import Optional
 
-from core.sdk.jp import get_predict_rate
 from core.sdk.telegram import send_telegram_message_or_raise
-from core.utils import get_logger
+from core.utils import format_euros, get_logger
 from packages.biwenger_tools.api import config
 from packages.biwenger_tools.api.logic.clausulazo_candidates import (
     filter_affordable,
     gather_rivals,
+    sf_of,
 )
 from packages.biwenger_tools.api.logic.orchestration import (
     build_context,
     require_telegram,
 )
-from packages.biwenger_tools.api.player_formatting import POSITION_SHORT, SCORE_SF
+from packages.biwenger_tools.api.player_formatting import POSITION_SHORT
 
 logger = get_logger(__name__)
 
@@ -70,25 +70,6 @@ _POSITION_LABELS_ES = {
 }
 
 
-def _euros(n: int | None) -> str:
-    """Format an integer as Spanish-style euros: 12.972.212 €.
-
-    `None` and 0 are surfaced explicitly so the user can tell the difference
-    between "Biwenger returned 0" and "Biwenger didn't return this field".
-    """
-    if n is None:
-        return "—"
-    s = f"{int(n):,}".replace(",", ".")
-    return f"{s} €"
-
-
-def _sf_of(row: dict) -> int:
-    jp = row.get("jp_player")
-    if not jp:
-        return 0
-    return get_predict_rate(jp, SCORE_SF) or 0
-
-
 def _short_position_es(position_id: int) -> str:
     """Spanish short label (POR/DEF/MED/DEL) for multi-pos badge."""
     return POSITION_SHORT.get(position_id, "?")
@@ -103,7 +84,7 @@ def _serialise_row(row: dict) -> dict:
         "name": row.get("name"),
         "owner": row.get("owner", ""),
         "clause": row.get("clause_value", 0),
-        "sf": _sf_of(row),
+        "sf": sf_of(row),
         "multi": [_short_position_es(a) for a in alts],
     }
 
@@ -123,7 +104,7 @@ def _pick_top_per_position(candidates: list[dict], top: int) -> dict[str, list[d
         grouped[key].append(row)
 
     for key in grouped:
-        grouped[key].sort(key=_sf_of, reverse=True)
+        grouped[key].sort(key=sf_of, reverse=True)
         grouped[key] = [_serialise_row(r) for r in grouped[key][:top]]
 
     return grouped
@@ -132,11 +113,11 @@ def _pick_top_per_position(candidates: list[dict], top: int) -> dict[str, list[d
 def _format_telegram_text(payload: dict) -> str:
     """Render the JSON payload as the Telegram message the bot would send."""
     budget = payload["budget"]
-    cash = _euros(budget["cash"])
-    target = _euros(budget["target"])
+    cash = format_euros(budget["cash"])
+    target = format_euros(budget["target"])
     max_bid_value = budget.get("max_bid")
-    max_bid_str = _euros(max_bid_value) if max_bid_value else "—"
-    margin = _euros(budget["margin"])
+    max_bid_str = format_euros(max_bid_value) if max_bid_value else "—"
+    margin = format_euros(budget["margin"])
     margin_source = budget.get("margin_source", "auto")
     margin_label = "auto" if margin_source == "auto" else "fijo"
 
@@ -158,7 +139,7 @@ def _format_telegram_text(payload: dict) -> str:
             badge = f"  <i>[multi: {'/'.join(r['multi'])}]</i>" if r["multi"] else ""
             lines.append(
                 f"  · {r['name']} ({r['owner']}) — "
-                f"cláusula {_euros(r['clause'])} · SF {r['sf']}{badge}"
+                f"cláusula {format_euros(r['clause'])} · SF {r['sf']}{badge}"
             )
     return "\n".join(lines)
 

--- a/packages/biwenger_tools/api/tests/test_emergency.py
+++ b/packages/biwenger_tools/api/tests/test_emergency.py
@@ -1,20 +1,29 @@
 """Unit tests for `api/logic/emergency.py`.
 
 Covers:
-- `_recent_lost_players` — board parsing, 24h window, id vs name match.
-- `_unique_positions` — outfield positions a loss list implies.
-- `_weakest_outfield_position` — counts + DEF > MID > FWD tie-break.
-- `_pick_target` — in-position first, fallback to top SF overall.
+- `recent_lost_players` — board parsing, 24h window, id vs name match.
+- `unique_outfield_positions` — outfield positions a loss list implies.
+- `weakest_outfield_position` — counts + DEF > MID > FWD tie-break.
+- `pick_top_in_position` — in-position first, fallback to top SF overall.
 - `preview_clausulazo` end-to-end (0/1/multi-loss + selector cases +
   force_position / force_weakest entry points).
 - `execute_clausulazo` notifies on success and on Biwenger 4xx.
+
+Detection helpers live in `clausulazo_detection`; candidate scoring in
+`clausulazo_candidates`. We import from the canonical home and patch the
+re-imported names *inside* `emergency` when stubbing `preview_clausulazo`'s
+collaborators, since that's where the lookup happens at runtime.
 """
 
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from packages.biwenger_tools.api.logic import emergency
+from packages.biwenger_tools.api.logic import (
+    clausulazo_candidates,
+    clausulazo_detection,
+    emergency,
+)
 
 # --- _recent_lost_players -----------------------------------------------
 
@@ -48,7 +57,7 @@ def test_recent_lost_players_matches_by_user_id():
         "data": [_board_entry(1000, from_id=99, player_id=42)]
     }
     players = {42: _bw_player(42, "Ana", position=2)}
-    losses = emergency._recent_lost_players(
+    losses = clausulazo_detection.recent_lost_players(
         biwenger, players, my_manager_name="anyone", now_epoch=1500
     )
     assert [(loss["name"], loss["position_id"]) for loss in losses] == [("Ana", 2)]
@@ -61,7 +70,7 @@ def test_recent_lost_players_matches_by_name_when_id_missing():
         "data": [_board_entry(1000, from_name="Lillo", player_id=42)]
     }
     players = {42: _bw_player(42, "Ana", position=2)}
-    losses = emergency._recent_lost_players(
+    losses = clausulazo_detection.recent_lost_players(
         biwenger, players, my_manager_name="Lillo", now_epoch=1500
     )
     assert len(losses) == 1 and losses[0]["position_id"] == 2
@@ -73,8 +82,8 @@ def test_recent_lost_players_ignores_entries_older_than_24h():
         "data": [_board_entry(date_epoch=10, from_id=99, player_id=42)]
     }
     players = {42: _bw_player(42, "Ana", position=2)}
-    now = 10 + emergency.RECENT_CLAUSULAZO_WINDOW_SECONDS + 1
-    losses = emergency._recent_lost_players(
+    now = 10 + clausulazo_detection.RECENT_CLAUSULAZO_WINDOW_SECONDS + 1
+    losses = clausulazo_detection.recent_lost_players(
         biwenger, players, my_manager_name="x", now_epoch=now
     )
     assert losses == []
@@ -107,7 +116,7 @@ def test_recent_lost_players_returns_all_matches_including_multi_pos():
         42: _bw_player(42, "MultiGuy", position=2, alt=[3]),
         43: _bw_player(43, "SimpleGuy", position=4),
     }
-    losses = emergency._recent_lost_players(
+    losses = clausulazo_detection.recent_lost_players(
         biwenger, players, my_manager_name="x", now_epoch=1500
     )
     assert [loss["name"] for loss in losses] == ["MultiGuy", "SimpleGuy"]
@@ -120,7 +129,7 @@ def test_recent_lost_players_ignores_other_managers_losses():
         "data": [_board_entry(1000, from_id=42, from_name="Otro", player_id=42)]
     }
     players = {42: _bw_player(42, "X", position=2)}
-    losses = emergency._recent_lost_players(
+    losses = clausulazo_detection.recent_lost_players(
         biwenger, players, my_manager_name="Lillo", now_epoch=1500
     )
     assert losses == []
@@ -145,7 +154,7 @@ def test_weakest_outfield_position_picks_minimum_count():
     }
     # 3 DEF / 2 MID / 1 FWD → weakest is FWD.
     assert (
-        emergency._weakest_outfield_position(
+        clausulazo_detection.weakest_outfield_position(
             _squad(10, 11, 12, 13, 14, 15, 16), players
         )
         == 4
@@ -159,14 +168,19 @@ def test_weakest_outfield_position_ties_prefer_def_then_mid():
         13: _bw_player(13, "F1", position=4),
     }
     # 1 of each → DEF wins on tie-break.
-    assert emergency._weakest_outfield_position(_squad(11, 12, 13), players) == 2
+    assert (
+        clausulazo_detection.weakest_outfield_position(_squad(11, 12, 13), players) == 2
+    )
 
 
 def test_weakest_outfield_position_full_squad_picks_def():
     """Full squad (all positions equal at the maximum) — DEF still wins
     because of the tie-break order; in practice this branch is rare."""
     players = {i: _bw_player(i, f"P{i}", position=(2 + (i % 3))) for i in range(0, 12)}
-    assert emergency._weakest_outfield_position(_squad(*range(0, 12)), players) == 2
+    assert (
+        clausulazo_detection.weakest_outfield_position(_squad(*range(0, 12)), players)
+        == 2
+    )
 
 
 # --- _pick_target --------------------------------------------------------
@@ -190,9 +204,11 @@ def test_pick_target_returns_top_sf_in_preferred_position():
         _cand(2, position=2, sf=500),
         _cand(3, position=4, sf=900),  # higher SF but wrong position
     ]
-    target, note = emergency._pick_target(candidates, preferred_position=2)
+    target, in_preferred = clausulazo_candidates.pick_top_in_position(
+        candidates, preferred_position=2
+    )
     assert target["bw_id"] == 2
-    assert note == ""
+    assert in_preferred is True
 
 
 def test_pick_target_falls_back_to_top_sf_when_position_empty():
@@ -200,15 +216,19 @@ def test_pick_target_falls_back_to_top_sf_when_position_empty():
         _cand(1, position=3, sf=400),
         _cand(2, position=4, sf=900),
     ]
-    target, note = emergency._pick_target(candidates, preferred_position=2)
+    target, in_preferred = clausulazo_candidates.pick_top_in_position(
+        candidates, preferred_position=2
+    )
     assert target["bw_id"] == 2
-    assert "Defensa" in note  # note mentions the position we couldn't fill
+    assert in_preferred is False  # caller will build the "no DEF afford" note
 
 
 def test_pick_target_returns_none_when_no_candidates():
-    target, note = emergency._pick_target([], preferred_position=2)
+    target, in_preferred = clausulazo_candidates.pick_top_in_position(
+        [], preferred_position=2
+    )
     assert target is None
-    assert note == ""
+    assert in_preferred is False
 
 
 # --- preview_clausulazo (end-to-end with mocks) --------------------------
@@ -248,8 +268,12 @@ def preview_env():
             biwenger=biwenger, biwenger_players=biwenger_players, jp_index={}
         )
         stack.enter_context(patch(_patches("build_context"), return_value=ctx))
+        # The emergency module imports these names by short name from
+        # their canonical homes (clausulazo_detection / candidates), so
+        # patching the re-imported attribute on `emergency` is what
+        # affects the lookup `preview_clausulazo` actually performs.
         stack.enter_context(
-            patch(_patches("_recent_lost_players"), return_value=losses or [])
+            patch(_patches("recent_lost_players"), return_value=losses or [])
         )
         stack.enter_context(patch(_patches("gather_rivals"), return_value=rivals))
         stack.enter_context(


### PR DESCRIPTION
## Summary
Three improvements bundled because they all came out of the same audit:

**1. CI: serialize master deploys.**
PRs #124 and #125 merged 10s apart triggered two parallel runs that each pushed a fresh api image. The slower build won and PR #125's code got silently overwritten by PR #124's — we only noticed when \`/emergency/*\` 404'd. A workflow-level \`concurrency: { group: deploy-master, cancel-in-progress: false }\` queues runs.

**2. Dedupe shared helpers via \`core/\`.**
- \`format_euros\` lives in \`core/utils.py\` and replaces three identical private copies in \`auto_bid\`, \`recommendations\`, \`emergency\`.
- \`_sf_of\` in \`recommendations\` is replaced by the canonical \`sf_of\` from \`clausulazo_candidates\`.

No behaviour change.

**3. Split \`emergency.py\` along responsibilities.**
- NEW \`clausulazo_detection.py\`: \`recent_lost_players\`, \`weakest_outfield_position\`, \`unique_outfield_positions\`, \`is_multi_position\`.
- \`clausulazo_candidates.py\`: also owns \`pick_top_in_position\` (renamed from emergency's \`_pick_target\`); returns \`(target, in_preferred_position: bool)\` so callers build the "no DEF afford(able)" message in their own voice.
- \`emergency.py\`: only flow + UX (keyboards, message formatters, route entry points). Cut from ~450 lines to ~350 with clearer sections.

## Test plan
- [x] \`bazel test //...\` — 6/6 targets pass.
- [x] flake8 + black clean.
- [ ] After deploy: confirm /emergencia and /pujar both still work end-to-end (no behaviour change expected).