### PR TITLE
chore(scripts): firestore-surgery tool for scraper recovery

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -19,13 +19,15 @@ LEAGUE_ID = "340703"
 # lets users rename their team at will, so the team `name` field drifts;
 # the numeric `id` is stable, so this is the source of truth when
 # attributing a row to a real person (palmares, post-rollover reports).
+# Per-season team names live in `palmares/{season}/standings_table` — don't
+# duplicate them as comments here, they drift on every rollover.
 LEAGUE_MEMBERS: dict[int, str] = {
-    7728610: "Fabio",  # Rayo Entrebirras
-    1376351: "Lucena",  # La Luceneta
-    12449616: "Pablo",  # Los caídos de la jornada
-    1372802: "Jorge",  # Farolillo Oracle United
-    7728598: "Javi",  # Kairat FC
-    7727371: "Ruben",  # Ferraz fc
+    7728610: "Fabio",
+    1376351: "Lucena",
+    12449616: "Pablo",
+    1372802: "Jorge",
+    7728598: "Javi",
+    7727371: "Ruben",
 }
 
 # A dynamic Drive file is considered stale if it hasn't been touched in

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -507,6 +507,22 @@ El cambio de temporada es **manual e intencional** — ocurre cuando se resetea 
 
 ---
 
+## 🛠️ Firestore maintenance scripts
+
+One-off surgical edits live under `scripts/`. All default to dry-run; pass `--apply` to write. They use ADC (`gcloud auth application-default login` once) and respect `FIRESTORE_PROJECT` / `GOOGLE_CLOUD_PROJECT`.
+
+- **`biwenger_firestore_surgery.py`** — recovery toolkit for scraper mishaps (e.g. a `/scrapper` run against the wrong season). Three subcommands:
+  - `list-messages <SEASON> [--author X] [--limit N]` — inspect `comunicados/{SEASON}/messages` and find a `doc-id`.
+  - `move-message <FROM> <TO> --doc-id <ID> [--rename-author <NAME>]` — copy one message across seasons (same id_hash), optionally rewriting `autor`, and rebuild `participacion/{TO}/authors/{autor}` accordingly.
+  - `wipe-season <SEASON>` — delete every doc under `comunicados`, `participacion`, `clausulazos`, `tabla_justicia` for that season.
+- **`biwenger_rename_team.py`** — rename a team across `clausulazos/{season}/transfers` and rebuild `tabla_justicia/{season}/teams` from the corrected data.
+- **`biwenger_recategorise.py`** — recompute `categoria` for every message and rebuild `participacion/{season}/authors`; supports `--autor-alias OLD=NEW`.
+- **`biwenger_check_categorias.py`** — read-only audit of `categoria` mismatches.
+
+Usage pattern is the same everywhere: run without `--apply` first, review, then re-run with `--apply`.
+
+---
+
 ## ⚠️ Important Notes
 
   * **Do not commit** the credentials file `biwenger-tools-sa.json`.

--- a/scripts/biwenger_firestore_surgery.py
+++ b/scripts/biwenger_firestore_surgery.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Surgical Firestore edits for scraper recovery scenarios.
+
+Three subcommands, all dry-run by default; pass ``--apply`` to write:
+
+``list-messages <SEASON> [--author X] [--limit N]``
+    Print message docs in ``comunicados/{SEASON}/messages`` for inspection
+    (id, fecha, autor, titulo). Use it to find the ``doc-id`` for a
+    subsequent ``move-message``.
+
+``move-message <FROM> <TO> --doc-id <ID> [--rename-author <NAME>]``
+    Copy a single message from ``comunicados/{FROM}`` to
+    ``comunicados/{TO}`` (same doc id — the id_hash is content-derived,
+    so renaming the author does not change it). Then add the doc id to
+    the destination ``participacion/{TO}/authors/{autor}`` bucket that
+    matches the message ``categoria``. Idempotent.
+
+``wipe-season <SEASON>``
+    Delete every document under the four scraper-produced subcollections
+    for the season:
+        comunicados/{SEASON}/messages
+        participacion/{SEASON}/authors
+        clausulazos/{SEASON}/transfers
+        tabla_justicia/{SEASON}/teams
+    Use when a scrape ran against the wrong season.
+
+Examples::
+
+    # Find the message id by scanning the bad-season collection
+    python3 scripts/biwenger_firestore_surgery.py list-messages 26-27 --limit 5
+
+    # Move it to the right season, renaming the author to the season-1 team name
+    python3 scripts/biwenger_firestore_surgery.py move-message 26-27 25-26 \\
+        --doc-id <hash> --rename-author 'Los caídos de la jornada' --apply
+
+    # Wipe everything the scraper wrote under the wrong season
+    python3 scripts/biwenger_firestore_surgery.py wipe-season 26-27 --apply
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.domain.models import Participation  # noqa: E402
+from core.sdk.firestore import get_client  # noqa: E402
+
+_CATEGORY_BUCKET = {
+    "comunicado": "comunicados",
+    "dato": "datos",
+    "cesion": "cesiones",
+    "cronica": "cronicas",
+}
+
+_SCRAPER_SUBCOLLECTIONS = (
+    "comunicados/{s}/messages",
+    "participacion/{s}/authors",
+    "clausulazos/{s}/transfers",
+    "tabla_justicia/{s}/teams",
+)
+
+
+def _cmd_list_messages(args) -> None:
+    client = get_client()
+    coll = client.collection(f"comunicados/{args.season}/messages")
+    rows = []
+    for snap in coll.stream():
+        data = snap.to_dict() or {}
+        if args.author and data.get("autor") != args.author:
+            continue
+        rows.append((snap.id, data))
+    rows.sort(key=lambda r: str(r[1].get("fecha", "")), reverse=True)
+    if args.limit:
+        rows = rows[: args.limit]
+
+    print(f"{len(rows)} message(s) in comunicados/{args.season}/messages:\n")
+    for doc_id, data in rows:
+        print(f"  id     : {doc_id}")
+        print(f"  fecha  : {data.get('fecha', '')}")
+        print(f"  autor  : {data.get('autor', '')}")
+        print(f"  titulo : {data.get('titulo', '')}")
+        print(f"  cat    : {data.get('categoria', '')}")
+        print()
+
+
+def _cmd_move_message(args) -> None:
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(
+        f"[{mode}] Move {args.doc_id[:12]}… "
+        f"comunicados/{args.from_season} → comunicados/{args.to_season}"
+    )
+
+    client = get_client()
+    src_ref = (
+        client.collection(f"comunicados/{args.from_season}/messages")
+        .document(args.doc_id)
+    )
+    src_snap = src_ref.get()
+    if not src_snap.exists:
+        print(
+            f"ERROR: source doc not found at "
+            f"comunicados/{args.from_season}/messages/{args.doc_id}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    src_data = src_snap.to_dict() or {}
+    original_autor = src_data.get("autor", "")
+    new_autor = args.rename_author or original_autor
+    target_data = dict(src_data)
+    if args.rename_author:
+        target_data["autor"] = args.rename_author
+
+    print("\nSource doc:")
+    for k in ("fecha", "autor", "titulo", "categoria"):
+        print(f"  {k:8s}: {src_data.get(k, '')}")
+    if args.rename_author:
+        print(f"\nRename autor: {original_autor!r} → {new_autor!r}")
+
+    # --- Participation update planning ---
+    bucket_name = _CATEGORY_BUCKET.get(target_data.get("categoria", ""))
+    if not bucket_name:
+        print(
+            f"\nWARNING: unknown categoria {target_data.get('categoria')!r}; "
+            "participation will NOT be updated. Move continues.",
+            file=sys.stderr,
+        )
+    else:
+        part_ref = (
+            client.collection(f"participacion/{args.to_season}/authors")
+            .document(new_autor)
+        )
+        part_snap = part_ref.get()
+        if part_snap.exists:
+            part_data = part_snap.to_dict() or {}
+            part = Participation.from_firestore(new_autor, part_data)
+        else:
+            part = Participation(autor=new_autor)
+        bucket = getattr(part, bucket_name)
+        already_in_bucket = args.doc_id in bucket
+        if not already_in_bucket:
+            bucket.append(args.doc_id)
+        print(
+            f"\nParticipation target: "
+            f"participacion/{args.to_season}/authors/{new_autor} "
+            f"(bucket={bucket_name})"
+        )
+        print(
+            f"  before: total={part.total - (0 if already_in_bucket else 1)}  "
+            f"{bucket_name}={len(bucket) - (0 if already_in_bucket else 1)}"
+        )
+        print(
+            f"  after : total={part.total}  {bucket_name}={len(bucket)}  "
+            f"(no-op: {already_in_bucket})"
+        )
+
+    if not args.apply:
+        print("\n(dry-run) skipping writes.")
+        return
+
+    target_ref = (
+        client.collection(f"comunicados/{args.to_season}/messages")
+        .document(args.doc_id)
+    )
+    target_ref.set(target_data)
+    print(f"\nWrote comunicados/{args.to_season}/messages/{args.doc_id}.")
+
+    if bucket_name:
+        part_ref.set(part.to_firestore())
+        print(
+            f"Updated participacion/{args.to_season}/authors/{new_autor} "
+            f"({bucket_name} bucket)."
+        )
+
+    print("\nNote: source doc in {0} was NOT deleted. Use `wipe-season {0}` "
+          "or delete it manually if needed.".format(args.from_season))
+
+
+def _cmd_wipe_season(args) -> None:
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"[{mode}] Wipe scraper data under season {args.season}\n")
+
+    client = get_client()
+    plan: list[tuple[str, list]] = []
+    for template in _SCRAPER_SUBCOLLECTIONS:
+        path = template.format(s=args.season)
+        snaps = list(client.collection(path).stream())
+        plan.append((path, snaps))
+        print(f"  {path:40s}  {len(snaps)} doc(s)")
+
+    total = sum(len(s) for _, s in plan)
+    print(f"\nTotal: {total} doc(s) to delete.")
+
+    if not args.apply:
+        print("\n(dry-run) skipping deletes.")
+        return
+
+    deleted = 0
+    for path, snaps in plan:
+        for snap in snaps:
+            snap.reference.delete()
+        deleted += len(snaps)
+        print(f"Deleted {len(snaps)} from {path}.")
+    print(f"\nDone. Deleted {deleted} doc(s) total.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_list = sub.add_parser("list-messages", help="List comunicados for a season.")
+    p_list.add_argument("season", help="Season key, e.g. 25-26")
+    p_list.add_argument("--author", help="Filter by autor exact match.")
+    p_list.add_argument("--limit", type=int, help="Max rows to print.")
+    p_list.set_defaults(func=_cmd_list_messages)
+
+    p_move = sub.add_parser("move-message", help="Copy a message to another season.")
+    p_move.add_argument("from_season", metavar="FROM", help="Source season, e.g. 26-27")
+    p_move.add_argument("to_season", metavar="TO", help="Destination season, e.g. 25-26")
+    p_move.add_argument("--doc-id", required=True, help="id_hash of the message.")
+    p_move.add_argument(
+        "--rename-author",
+        help="Rewrite autor on the destination doc (id_hash is unaffected).",
+    )
+    p_move.add_argument("--apply", action="store_true", help="Actually write.")
+    p_move.set_defaults(func=_cmd_move_message)
+
+    p_wipe = sub.add_parser(
+        "wipe-season", help="Delete all scraper data for a season."
+    )
+    p_wipe.add_argument("season", help="Season key, e.g. 26-27")
+    p_wipe.add_argument("--apply", action="store_true", help="Actually delete.")
+    p_wipe.set_defaults(func=_cmd_wipe_season)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `scripts/biwenger_firestore_surgery.py` — recovery toolkit for scraper mishaps, with `list-messages`, `move-message`, `wipe-season` subcommands (dry-run by default, `--apply` to write).
- Document it under a new "Firestore maintenance scripts" section in `docs/operations.md`, also listing the pre-existing surgery scripts (`biwenger_rename_team`, `biwenger_recategorise`, `biwenger_check_categorias`).
- Drop the per-row team-name comments in `LEAGUE_MEMBERS` (they drift on every rollover; the authoritative per-season name lives in `palmares/{season}/standings_table`).

## Context

A `/scrapper` run against the wrong season (`TEMPORADA_ACTUAL=26-27` while 25-26 was still active) dumped the full Biwenger board into `26-27`: 137 messages, 7 participacion authors, 121 clausulazos, 7 tabla_justicia teams. We:

1. Moved the single new June 7 comunicado (`📢 EL ADVENIMIENTO DEL NUEVO ORDEN`) from `26-27` → `25-26`, rewriting `autor` from `El Tercer Reich` → `Los caídos de la jornada` (the canonical 25-26 team name for `user_id=12449616`).
2. Wiped all 272 docs under the four `26-27` subcollections.

Post-apply state verified: `25-26` is intact (138 messages, 109 clausulazos, 7 authors, 7 teams), `26-27` is empty across the four subcollections, and Pablo's participation in `25-26` bumped to `total=20, comunicados=19` with the moved id_hash present.

## Test plan

- [x] `list-messages 26-27` returned the offending entries (137 docs).
- [x] `move-message 26-27 25-26 --doc-id … --rename-author 'Los caídos de la jornada' --apply` ran cleanly; participation totals updated as expected.
- [x] `wipe-season 26-27 --apply` deleted 272 docs across the four subcollections.
- [x] Verified `26905eb9…` is in `participacion/25-26/authors/Los caídos de la jornada` `comunicados` list.