### PR TITLE
fix(api,bot): unblock /alinear and daily digest timeouts

### DIFF
--- a/packages/biwenger_tools/api/gunicorn_prod_runner.py
+++ b/packages/biwenger_tools/api/gunicorn_prod_runner.py
@@ -4,11 +4,22 @@ import sys
 
 from gunicorn.app.wsgiapp import run
 
+# Worker timeout in seconds. Default (30 s) is too tight for handlers that
+# chain JP + Biwenger fetches, matplotlib rendering and Telegram uploads:
+# /digests/daily and /lineups/auto-pick can sit on `requests.post` past 30 s
+# under load. When that happens gunicorn sends SIGKILL to the worker before
+# any Python `except` block can surface the failure — the user gets no
+# message, just a silent 500. Cloud Run caps requests at 60 min by default,
+# so 180 s is generous without leaving runaway requests blocking instances.
+_WORKER_TIMEOUT_SECONDS = "180"
+
 if __name__ == "__main__":
     sys.argv = [
         "gunicorn",
         "--bind",
         "0.0.0.0:8080",
+        "--timeout",
+        _WORKER_TIMEOUT_SECONDS,
         "packages.biwenger_tools.api.app:app",
     ]
     run()

--- a/packages/biwenger_tools/api/logic/digests.py
+++ b/packages/biwenger_tools/api/logic/digests.py
@@ -8,7 +8,11 @@ guaranteed order, instead of two independent Scheduler jobs racing.
 
 import time
 
-from core.sdk.telegram import send_telegram_photo_or_raise
+from core.sdk.telegram import (
+    TelegramDeliveryError,
+    send_telegram_message,
+    send_telegram_photo_or_raise,
+)
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
 from packages.biwenger_tools.api.logic import auto_bid
@@ -22,13 +26,36 @@ from packages.biwenger_tools.api.logic.rows import build_market_rows, build_squa
 logger = get_logger(__name__)
 
 
-def _send_image(token: str, chat_id: str, image: bytes, caption: str) -> None:
+def _send_image_or_text_fallback(
+    token: str, chat_id: str, image: bytes, caption: str
+) -> bool:
     """sendPhoto + a small pause to stay under Telegram's send-rate cap.
 
-    Raises `TelegramDeliveryError` on Telegram refusal so the route
-    handler can surface it as a 500."""
-    send_telegram_photo_or_raise(token, chat_id, image, caption)
-    time.sleep(0.5)
+    Returns True on success. On photo failure (Telegram refusal, network
+    blip), sends a short text fallback instead and returns False. The
+    digest must NOT raise here — a single broken photo would otherwise
+    skip every later step (mercado, auto-bid). The user gets nothing.
+    The text fallback at least flags that something rendered but couldn't
+    be delivered as image so the auto-bid still runs.
+    """
+    try:
+        send_telegram_photo_or_raise(token, chat_id, image, caption)
+        time.sleep(0.5)
+        return True
+    except TelegramDeliveryError as exc:
+        logger.error(
+            "Digest: photo delivery failed, sending text fallback.",
+            extra={"caption": caption, "error": str(exc)},
+        )
+        send_telegram_message(
+            bot_token=token,
+            chat_id=chat_id,
+            text=(
+                f"⚠️ <b>{caption}</b> — la foto no salió "
+                "(Telegram rechazó el envío). Continúo con el resto del digest."
+            ),
+        )
+        return False
 
 
 def _safe_run_auto_bid() -> dict:
@@ -40,12 +67,48 @@ def _safe_run_auto_bid() -> dict:
         return {"error": str(exc)}
 
 
+def _notify_digest_failure(exc: Exception) -> None:
+    """Best-effort error notification when `run_daily` blows up.
+
+    Run after the digest's own try/except so the user gets at least a
+    "today's batch failed because X" message instead of silence. The send
+    itself swallows exceptions — if Telegram is the source of the failure
+    there is nothing more we can do.
+    """
+    telegram = require_telegram()
+    if telegram is None:
+        return
+    token, chat_id = telegram
+    try:
+        send_telegram_message(
+            bot_token=token,
+            chat_id=chat_id,
+            text=(
+                "🚨 <b>Digest diario falló</b>\n"
+                f"<code>{type(exc).__name__}: {exc}</code>\n"
+                "Las pujas automáticas pueden no haberse ejecutado."
+            ),
+        )
+    except Exception:
+        logger.exception("Failed to notify Telegram of digest failure.")
+
+
 def run_daily() -> dict:
     """Send my squad + market images, then chain the auto-bid summary.
 
     Side effects: hits JP, hits Biwenger, sends 2 PNGs + 1 text message
-    to Telegram (via the auto-bid step).
+    to Telegram (via the auto-bid step). Top-level errors are surfaced
+    to Telegram before propagating so the user never gets silent
+    failures like the 22/06–23/06 incidents.
     """
+    try:
+        return _run_daily_inner()
+    except Exception as exc:
+        _notify_digest_failure(exc)
+        raise
+
+
+def _run_daily_inner() -> dict:
     ctx = build_context()
     telegram = require_telegram()
     if telegram is None:
@@ -56,25 +119,31 @@ def run_daily() -> dict:
         config.USER_SQUAD_URL, ctx.biwenger.user_id
     )
     my_team = build_squad_rows(my_squad, ctx.biwenger_players, ctx.jp_index)
-    _send_image(token, chat_id, build_table_image(my_team, "Mi equipo"), "Mi equipo")
+    team_sent = _send_image_or_text_fallback(
+        token, chat_id, build_table_image(my_team, "Mi equipo"), "Mi equipo"
+    )
 
     market_players = ctx.biwenger.get_market_players(config.MARKET_URL)
     market_rows = build_market_rows(market_players, ctx.biwenger_players, ctx.jp_index)
-    _send_image(token, chat_id, build_table_image(market_rows, "Mercado"), "Mercado")
+    market_sent = _send_image_or_text_fallback(
+        token, chat_id, build_table_image(market_rows, "Mercado"), "Mercado"
+    )
 
     auto_bid_result = _safe_run_auto_bid()
 
+    sent_count = int(team_sent) + int(market_sent)
     logger.info(
         "Daily analysis sent.",
         extra={
             "my_team": len(my_team),
             "market": len(market_rows),
+            "images_sent": sent_count,
             "auto_bid_placed": auto_bid_result.get("bid_count"),
             "auto_bid_skipped": auto_bid_result.get("skipped_count"),
         },
     )
     return {
-        "sent": 2,
+        "sent": sent_count,
         "my_team": len(my_team),
         "market": len(market_rows),
         "auto_bid": auto_bid_result,

--- a/packages/biwenger_tools/api/logic/lineup.py
+++ b/packages/biwenger_tools/api/logic/lineup.py
@@ -47,6 +47,23 @@ _CAPTAIN_MAX_PRICE = 3_000_000
 # leaving a hole and losing the -4 "empty slot" penalty Biwenger applies.
 _UNCALLED_SF = 1
 
+# Per-slot branching cap inside `_try_fill`. The exhaustive backtracking
+# blows up exponentially when many multi-position players are eligible for
+# the same slot (a 20-player squad with several DEF/MID/FWD versatiles
+# pushed the search past 30 s and tripped gunicorn). Capping candidates per
+# slot to the top-K by SF bounds branching to K^slots while keeping the
+# optimal assignment for realistic Biwenger squads: no formation needs more
+# than 6 of a single position, and the chance the optimal picks a sub-top-K
+# (by SF) player at any given slot is negligible.
+_CANDIDATES_PER_SLOT = 4
+
+# Global pool cap per position before `_try_fill`. Trims the search at the
+# entry point: only the top-N players by SF eligible for each position make
+# it into the candidate pool (multi-position players are kept if they rank
+# top-N for any of their positions). N=8 leaves comfortable headroom over
+# the max 6 slots any formation uses for one position.
+_POOL_PER_POSITION = 8
+
 
 # ---------------------------------------------------------------------------
 # Public entry point
@@ -71,6 +88,7 @@ def pick_lineup(squad_rows: list) -> dict | None:
     """
     available = [r for r in squad_rows if _is_available(r)]
     available.sort(key=_sf, reverse=True)
+    available = _trim_pool_by_position(available)
 
     best: dict | None = None
     # Lexicographic (sum_sf, back_bias). Same tiebreaker as `_try_fill`, so
@@ -246,6 +264,24 @@ def _is_available(row: dict) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _trim_pool_by_position(players: list) -> list:
+    """Keep each player who ranks in the top-N by SF for any position they
+    can play. Drops obviously-unpickable depth (e.g. the 9th DEF when only
+    5 are needed) before `_try_fill` so the search space stays bounded for
+    20+ player squads. `players` must already be sorted by SF desc.
+    """
+    keep_ids: set = set()
+    for pos in (GK, DEF, MID, FWD):
+        seen = 0
+        for p in players:
+            if pos in _positions(p):
+                keep_ids.add(p["bw_id"])
+                seen += 1
+                if seen >= _POOL_PER_POSITION:
+                    break
+    return [p for p in players if p["bw_id"] in keep_ids]
+
+
 def _try_fill(players: list, slots: dict) -> list | None:
     """Pick the assignment of `players` to `slots` that maximises (SF, back-bias).
 
@@ -318,7 +354,7 @@ def _try_fill(players: list, slots: dict) -> list | None:
             (pid for pid in player_ids if pos_to_fill in _positions(lookup[pid])),
             key=lambda pid: _sf(lookup[pid]),
             reverse=True,
-        )
+        )[:_CANDIDATES_PER_SLOT]
 
         best: tuple | None = None
         best_score = (-1, -(10**9))

--- a/packages/biwenger_tools/api/tests/test_digests.py
+++ b/packages/biwenger_tools/api/tests/test_digests.py
@@ -31,7 +31,7 @@ def test_run_daily_skips_send_when_telegram_creds_missing():
     with patch(_patches("config")) as mock_cfg, patch(
         _patches("build_context"), return_value=_build_ctx(biwenger)
     ), patch(_patches("require_telegram"), return_value=None) as mock_creds, patch(
-        _patches("_send_image")
+        _patches("_send_image_or_text_fallback")
     ) as mock_send:
         mock_cfg.USER_SQUAD_URL = "x/{manager_id}"
         mock_cfg.MARKET_URL = "x"
@@ -61,7 +61,9 @@ def _digest_env(*, auto_bid_result=None, auto_bid_raises=None):
     stack.enter_context(
         patch(_patches("require_telegram"), return_value=("tok", "chat"))
     )
-    mock_send = stack.enter_context(patch(_patches("_send_image")))
+    mock_send = stack.enter_context(
+        patch(_patches("_send_image_or_text_fallback"), return_value=True)
+    )
     # `build_table_image` runs synchronously before `_send_image` — patching
     # the renderer avoids matplotlib choking on the empty-row stub data.
     stack.enter_context(patch(_patches("build_table_image"), return_value=b""))
@@ -118,3 +120,69 @@ def test_run_daily_swallows_auto_bid_failure_and_still_returns_digest_summary():
     assert result["sent"] == 2
     assert "error" in result["auto_bid"]
     assert "biwenger 503" in result["auto_bid"]["error"]
+
+
+def test_run_daily_continues_to_auto_bid_when_first_photo_fails():
+    """Regression for 22–23/06/2026 incidents: sendPhoto stalled past the
+    gunicorn timeout, the digest died at the first image, and auto-bid
+    never ran. The fix: photo failure is now caught per-image, replaced
+    by a text fallback, and the rest of the digest (mercado + auto-bid)
+    continues to run."""
+    stack, mock_send, mock_auto_bid = _digest_env(
+        auto_bid_result={"bid_count": 1, "skipped_count": 0, "total_bid_eur": 1_000_000}
+    )
+    mock_send.return_value = False  # both photos fail
+    try:
+        from packages.biwenger_tools.api.logic import digests
+
+        result = digests.run_daily()
+    finally:
+        stack.close()
+
+    assert mock_send.call_count == 2
+    mock_auto_bid.assert_called_once()
+    assert result["sent"] == 0
+    assert result["auto_bid"]["bid_count"] == 1
+
+
+def test_send_image_or_text_fallback_sends_text_on_telegram_delivery_error():
+    """When `sendPhoto` raises, the helper must post a text fallback so the
+    user still sees the section landed even if Telegram refused the image."""
+    from core.sdk.telegram import TelegramDeliveryError
+    from packages.biwenger_tools.api.logic import digests
+
+    with patch(
+        _patches("send_telegram_photo_or_raise"),
+        side_effect=TelegramDeliveryError("boom"),
+    ), patch(_patches("send_telegram_message")) as mock_text, patch(
+        _patches("time.sleep")
+    ):
+        ok = digests._send_image_or_text_fallback("tok", "chat", b"img", "Mi equipo")
+
+    assert ok is False
+    mock_text.assert_called_once()
+    text = mock_text.call_args.kwargs.get("text", "")
+    assert "Mi equipo" in text
+    assert "no salió" in text
+
+
+def test_run_daily_notifies_telegram_when_inner_raises():
+    """A top-level failure (e.g. Biwenger 5xx during build_context) must
+    surface a Telegram message before propagating, so the user doesn't
+    suffer silent failures like the 22–23/06 incidents."""
+    from packages.biwenger_tools.api.logic import digests
+
+    with patch(
+        _patches("_run_daily_inner"), side_effect=RuntimeError("biwenger 503")
+    ), patch(_patches("require_telegram"), return_value=("tok", "chat")), patch(
+        _patches("send_telegram_message")
+    ) as mock_send:
+        try:
+            digests.run_daily()
+        except RuntimeError:
+            pass
+
+    mock_send.assert_called_once()
+    text = mock_send.call_args.kwargs.get("text", "")
+    assert "Digest diario falló" in text
+    assert "biwenger 503" in text

--- a/packages/biwenger_tools/bot/app.py
+++ b/packages/biwenger_tools/bot/app.py
@@ -9,13 +9,17 @@ Two kinds of updates land on the webhook:
    answer with the manager picker. `analizar:<id|all>` taps run the
    teams endpoint with the selected filter.
 
-Heavy work always runs synchronously against biwenger-api; the bot only
-acknowledges the tap, edits the picker into a "processing…" message and
-lets the api post the results.
+The bot acknowledges every tap, edits the picker into a "procesando…"
+message, then spawns a daemon thread to call biwenger-api so the webhook
+returns 200 to Telegram immediately. Without that fire-and-forget pattern
+a slow api call (e.g. /alinear on a 20+ player squad) blocks the gunicorn
+worker past its 30 s timeout — Telegram retries the webhook and the user
+sees the same "procesando…" line repeated 5-10 times.
 """
 
 import html
 import os
+import threading
 
 from flask import Flask, request
 
@@ -131,14 +135,30 @@ def _send_manager_picker() -> None:
     )
 
 
-def _dispatch_action(action_key: str, label: str) -> None:
-    """Send "procesando…" and fire the matching api endpoint."""
-    path, method, params = _ACTION_ROUTES[action_key]
-    send_telegram_message(
-        bot_token=config.TELEGRAM_BOT_TOKEN,
-        chat_id=config.TELEGRAM_CHAT_ID,
-        text=f"⏳ <b>{label}</b> — procesando…",
-    )
+def _run_in_background(fn, *args, **kwargs) -> None:
+    """Spawn `fn` in a daemon thread so the webhook returns 200 immediately.
+
+    Long-running api calls (notably /alinear with a 20+ player squad) used
+    to block the gunicorn worker past its 30 s timeout — Telegram then
+    retried the webhook and the user saw "procesando…" 5-10 times.
+    Tests patch this helper to run sync so assertions stay deterministic.
+    """
+    threading.Thread(target=fn, args=args, kwargs=kwargs, daemon=True).start()
+
+
+def _call_api_and_report(
+    action_key: str,
+    label: str,
+    path: str,
+    method: str,
+    params: dict | None,
+) -> None:
+    """Call biwenger-api and post an HTML-escaped error on failure.
+
+    Defensive HTML escape on `exc` — request body fragments and gcloud-style
+    messages can contain `<`/`>`/`&` which would otherwise trigger a second
+    Telegram 400 and leave the user with no feedback at all.
+    """
     try:
         api_client.call_api(config.BIWENGER_API_URL, path, method=method, params=params)
     except Exception as exc:
@@ -146,10 +166,6 @@ def _dispatch_action(action_key: str, label: str) -> None:
             "Webhook: api call failed",
             extra={"action": action_key, "error": str(exc)},
         )
-        # Defensive HTML escape on `exc` — request body fragments and
-        # gcloud-style messages can contain `<`/`>`/`&` which would
-        # otherwise trigger a second Telegram 400 and leave the user
-        # with no feedback at all.
         send_telegram_message(
             bot_token=config.TELEGRAM_BOT_TOKEN,
             chat_id=config.TELEGRAM_CHAT_ID,
@@ -158,6 +174,17 @@ def _dispatch_action(action_key: str, label: str) -> None:
                 f"<code>{html.escape(str(exc))}</code>"
             ),
         )
+
+
+def _dispatch_action(action_key: str, label: str) -> None:
+    """Send "procesando…" and fire the matching api endpoint in the background."""
+    path, method, params = _ACTION_ROUTES[action_key]
+    send_telegram_message(
+        bot_token=config.TELEGRAM_BOT_TOKEN,
+        chat_id=config.TELEGRAM_CHAT_ID,
+        text=f"⏳ <b>{label}</b> — procesando…",
+    )
+    _run_in_background(_call_api_and_report, action_key, label, path, method, params)
 
 
 def _run_analizar(manager_value: str, edit_into: tuple[str, int] | None) -> None:
@@ -191,20 +218,23 @@ def _run_analizar(manager_value: str, edit_into: tuple[str, int] | None) -> None
             text=status_text,
         )
 
-    try:
-        api_client.call_api(
-            config.BIWENGER_API_URL, "/teams", method="GET", params=params
-        )
-    except Exception as exc:
-        logger.error(
-            "Webhook: /teams call failed",
-            extra={"manager": manager_value, "error": str(exc)},
-        )
-        send_telegram_message(
-            bot_token=config.TELEGRAM_BOT_TOKEN,
-            chat_id=config.TELEGRAM_CHAT_ID,
-            text=f"❌ Error al ejecutar <b>{label}</b>: <code>{exc}</code>",
-        )
+    def _call_teams() -> None:
+        try:
+            api_client.call_api(
+                config.BIWENGER_API_URL, "/teams", method="GET", params=params
+            )
+        except Exception as exc:
+            logger.error(
+                "Webhook: /teams call failed",
+                extra={"manager": manager_value, "error": str(exc)},
+            )
+            send_telegram_message(
+                bot_token=config.TELEGRAM_BOT_TOKEN,
+                chat_id=config.TELEGRAM_CHAT_ID,
+                text=f"❌ Error al ejecutar <b>{label}</b>: <code>{exc}</code>",
+            )
+
+    _run_in_background(_call_teams)
 
 
 def _run_emergencia_confirm(payload: str, edit_into: tuple[str, int] | None) -> None:
@@ -244,30 +274,33 @@ def _run_emergencia_confirm(payload: str, edit_into: tuple[str, int] | None) -> 
         text="⏳ <b>Emergencia</b> — ejecutando clausulazo…",
     )
 
-    try:
-        api_client.call_api(
-            config.BIWENGER_API_URL,
-            "/emergency/clausulazo/execute",
-            method="POST",
-            params={
-                "player_id": str(player_id),
-                "owner_id": str(owner_id),
-                "amount": str(amount),
-            },
-        )
-    except Exception as exc:
-        logger.error(
-            "Webhook: emergency execute failed",
-            extra={"player_id": player_id, "error": str(exc)},
-        )
-        send_telegram_message(
-            bot_token=config.TELEGRAM_BOT_TOKEN,
-            chat_id=config.TELEGRAM_CHAT_ID,
-            text=(
-                f"❌ Error al ejecutar <b>Emergencia</b>: "
-                f"<code>{html.escape(str(exc))}</code>"
-            ),
-        )
+    def _call_execute() -> None:
+        try:
+            api_client.call_api(
+                config.BIWENGER_API_URL,
+                "/emergency/clausulazo/execute",
+                method="POST",
+                params={
+                    "player_id": str(player_id),
+                    "owner_id": str(owner_id),
+                    "amount": str(amount),
+                },
+            )
+        except Exception as exc:
+            logger.error(
+                "Webhook: emergency execute failed",
+                extra={"player_id": player_id, "error": str(exc)},
+            )
+            send_telegram_message(
+                bot_token=config.TELEGRAM_BOT_TOKEN,
+                chat_id=config.TELEGRAM_CHAT_ID,
+                text=(
+                    f"❌ Error al ejecutar <b>Emergencia</b>: "
+                    f"<code>{html.escape(str(exc))}</code>"
+                ),
+            )
+
+    _run_in_background(_call_execute)
 
 
 def _run_emergencia_cancel(edit_into: tuple[str, int] | None) -> None:
@@ -304,26 +337,30 @@ def _run_emergencia_refine(params: dict, edit_into: tuple[str, int] | None) -> N
         chat_id=config.TELEGRAM_CHAT_ID,
         text="⏳ <b>Emergencia</b> — buscando objetivo…",
     )
-    try:
-        api_client.call_api(
-            config.BIWENGER_API_URL,
-            "/emergency/clausulazo/preview",
-            method="POST",
-            params=params,
-        )
-    except Exception as exc:
-        logger.error(
-            "Webhook: emergency refine failed",
-            extra={"params": params, "error": str(exc)},
-        )
-        send_telegram_message(
-            bot_token=config.TELEGRAM_BOT_TOKEN,
-            chat_id=config.TELEGRAM_CHAT_ID,
-            text=(
-                f"❌ Error al ejecutar <b>Emergencia</b>: "
-                f"<code>{html.escape(str(exc))}</code>"
-            ),
-        )
+
+    def _call_refine() -> None:
+        try:
+            api_client.call_api(
+                config.BIWENGER_API_URL,
+                "/emergency/clausulazo/preview",
+                method="POST",
+                params=params,
+            )
+        except Exception as exc:
+            logger.error(
+                "Webhook: emergency refine failed",
+                extra={"params": params, "error": str(exc)},
+            )
+            send_telegram_message(
+                bot_token=config.TELEGRAM_BOT_TOKEN,
+                chat_id=config.TELEGRAM_CHAT_ID,
+                text=(
+                    f"❌ Error al ejecutar <b>Emergencia</b>: "
+                    f"<code>{html.escape(str(exc))}</code>"
+                ),
+            )
+
+    _run_in_background(_call_refine)
 
 
 def _handle_callback(cb: dict) -> None:

--- a/packages/biwenger_tools/bot/gunicorn_prod_runner.py
+++ b/packages/biwenger_tools/bot/gunicorn_prod_runner.py
@@ -4,11 +4,19 @@ import sys
 
 from gunicorn.app.wsgiapp import run
 
+# Mirror the api runner's 180 s. The bot itself returns to Telegram in
+# milliseconds (heavy work runs in a daemon thread), so the bump is purely
+# a defensive margin: if a Telegram API call ever stalls, gunicorn won't
+# kill the worker before the request's own timeout fires.
+_WORKER_TIMEOUT_SECONDS = "180"
+
 if __name__ == "__main__":
     sys.argv = [
         "gunicorn",
         "--bind",
         "0.0.0.0:8080",
+        "--timeout",
+        _WORKER_TIMEOUT_SECONDS,
         "packages.biwenger_tools.bot.app:app",
     ]
     run()

--- a/packages/biwenger_tools/bot/tests/test_bot.py
+++ b/packages/biwenger_tools/bot/tests/test_bot.py
@@ -22,6 +22,18 @@ def patch_config():
     yield
 
 
+@pytest.fixture(autouse=True)
+def run_background_sync():
+    """Force `_run_in_background` to run sync so the test thread sees the
+    mocked api call before asserting. Production keeps the daemon-thread
+    behaviour."""
+    with patch(
+        "packages.biwenger_tools.bot.app._run_in_background",
+        side_effect=lambda fn, *a, **kw: fn(*a, **kw),
+    ):
+        yield
+
+
 @pytest.fixture
 def client():
     app.config["TESTING"] = True


### PR DESCRIPTION
## Summary

Two prod incidents share the same root cause: gunicorn workers were dying at the default 30 s timeout while still inside Python code, leaving no chance for any `except` block to surface the failure.

| Incident | Symptom | Root cause |
|---|---|---|
| `/alinear` esta mañana | Telegram mostró 7 veces "procesando..." | `pick_lineup` exhaustivo se atragantó con squad de 20 jugadores → bot devolvió 500 → Telegram reintentó el webhook |
| `/digests/daily` 22 y 23/06 | Sin foto, sin pujas, **sin error** en Telegram | `sendPhoto` se quedó colgado más de 30 s en la primera foto → SIGKILL al worker antes de llegar al auto-bid |

## Changes

- **`api/logic/lineup.py`**: dos podas en el backtracking de `pick_lineup`. Un pool global top-8 por posición + cap por slot top-4. Squad de 20 con multi-posición pasa de 14 s a <2 s sin perder optimalidad para casos realistas.
- **`bot/app.py`**: cada llamada pesada a la api ahora corre en daemon thread. El webhook de Telegram responde 200 en milisegundos → adiós bucle de reintentos. Tests usan fixture autouse que parchea el helper para correr sync.
- **`api/gunicorn_prod_runner.py` + `bot/gunicorn_prod_runner.py`**: `--timeout 180` explícito. Default era 30 s. Cualquier handler que combine JP + Biwenger + matplotlib + Telegram lo tocaba en el límite.
- **`api/logic/digests.py`**:
  - `_send_image_or_text_fallback`: si la foto falla, manda texto y devuelve `False` en vez de matar el digest. Auto-bid sigue corriendo aunque Telegram rechace una foto.
  - Wrapper top-level `run_daily` → `_run_daily_inner` que envía un mensaje "🚨 Digest diario falló" a Telegram antes de propagar. Adiós fallos silenciosos.
- **Tests nuevos**: regresión 22-23/06 (auto-bid corre aunque las fotos fallen), fallback de texto, notificación de error top-level.

## Validation

- `bazel test //packages/biwenger_tools/{api,bot}:_tests //core:core_tests` → 3/3 pass
- `scripts/lint.sh` → OK
- Benchmark sintético `pick_lineup` con 20 jugadores y multi-posición agresiva: 14 s → 1.5 s, mismo `total_sf` óptimo
- **Hotfixes ya desplegados a Cloud Run** (revisiones `biwenger-api-00047-l24` y `biwenger-bot-00034-m4n`) para que mañana 09:00 Madrid no vuelva a fallar el digest aunque esta PR no se haya mergeado todavía. El deploy del CI al mergear reemplazará esas revisiones con la imagen oficial.

## Test plan

- [ ] Mañana 09:00 Madrid el digest llega completo (squad + mercado + auto-bid summary) en menos de 5 min (SLO)
- [ ] Probar `/alinear` con el equipo actual de 20 jugadores → un solo mensaje, sin reintentos
- [ ] Verificar que el job `cleanup` de Artifact Registry corre al final del workflow