### PR TITLE
fix(api): make /analizar TODOS resilient to per-photo Telegram failures

### DIFF
--- a/packages/biwenger_tools/api/logic/actions.py
+++ b/packages/biwenger_tools/api/logic/actions.py
@@ -26,6 +26,7 @@ from packages.biwenger_tools.api.logic.orchestration import (
     build_biwenger_session,
     build_context,
     require_telegram,
+    send_image_or_text_fallback,
 )
 from packages.biwenger_tools.api.logic.rows import build_market_rows, build_squad_rows
 
@@ -141,6 +142,10 @@ def run_teams(manager_id: int | None = None) -> dict:
         return {"sent": 1, "manager": manager_name, "size": len(rows)}
 
     # All-managers mode (original /analizar): every squad + market.
+    # Uses `send_image_or_text_fallback` so a single Telegram refusal
+    # doesn't kill the rest of the run — with 10+ sequential photo
+    # uploads, compounding flakiness used to leave the user with a
+    # partial output and a generic "❌ Error" from the bot.
     my_team: list[dict] = []
     rivals: dict[str, list[dict]] = {}
 
@@ -158,27 +163,35 @@ def run_teams(manager_id: int | None = None) -> dict:
             )
         time.sleep(0.5)
 
-    _send_image(
+    sent_count = 0
+    if send_image_or_text_fallback(
         token, chat_id, build_table_image(my_team, "🛡️ Mi equipo"), "🛡️ Mi equipo"
-    )
+    ):
+        sent_count += 1
     for manager_name, rows in rivals.items():
         img = build_table_image(
             rows, f"👤 {manager_name}", extra_cols=["Clausulable", "Cláusula"]
         )
-        _send_image(token, chat_id, img, f"👤 {manager_name}")
+        if send_image_or_text_fallback(token, chat_id, img, f"👤 {manager_name}"):
+            sent_count += 1
 
     market_players = biwenger.get_market_players(config.MARKET_URL)
     market_rows = build_market_rows(market_players, biwenger_players, jp_index)
-    _send_image(
+    if send_image_or_text_fallback(
         token, chat_id, build_table_image(market_rows, "🛒 Mercado"), "🛒 Mercado"
-    )
+    ):
+        sent_count += 1
 
     logger.info(
         "All-teams analysis sent.",
-        extra={"teams": 1 + len(rivals), "market": len(market_rows)},
+        extra={
+            "teams": 1 + len(rivals),
+            "market": len(market_rows),
+            "images_sent": sent_count,
+        },
     )
     return {
-        "sent": 2 + len(rivals),
+        "sent": sent_count,
         "teams": 1 + len(rivals),
         "market": len(market_rows),
     }

--- a/packages/biwenger_tools/api/logic/digests.py
+++ b/packages/biwenger_tools/api/logic/digests.py
@@ -6,13 +6,7 @@ gives the user a coherent morning message (squad → market → bids) in
 guaranteed order, instead of two independent Scheduler jobs racing.
 """
 
-import time
-
-from core.sdk.telegram import (
-    TelegramDeliveryError,
-    send_telegram_message,
-    send_telegram_photo_or_raise,
-)
+from core.sdk.telegram import send_telegram_message
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
 from packages.biwenger_tools.api.logic import auto_bid
@@ -20,42 +14,11 @@ from packages.biwenger_tools.api.logic.image_formatter import build_table_image
 from packages.biwenger_tools.api.logic.orchestration import (
     build_context,
     require_telegram,
+    send_image_or_text_fallback,
 )
 from packages.biwenger_tools.api.logic.rows import build_market_rows, build_squad_rows
 
 logger = get_logger(__name__)
-
-
-def _send_image_or_text_fallback(
-    token: str, chat_id: str, image: bytes, caption: str
-) -> bool:
-    """sendPhoto + a small pause to stay under Telegram's send-rate cap.
-
-    Returns True on success. On photo failure (Telegram refusal, network
-    blip), sends a short text fallback instead and returns False. The
-    digest must NOT raise here — a single broken photo would otherwise
-    skip every later step (mercado, auto-bid). The user gets nothing.
-    The text fallback at least flags that something rendered but couldn't
-    be delivered as image so the auto-bid still runs.
-    """
-    try:
-        send_telegram_photo_or_raise(token, chat_id, image, caption)
-        time.sleep(0.5)
-        return True
-    except TelegramDeliveryError as exc:
-        logger.error(
-            "Digest: photo delivery failed, sending text fallback.",
-            extra={"caption": caption, "error": str(exc)},
-        )
-        send_telegram_message(
-            bot_token=token,
-            chat_id=chat_id,
-            text=(
-                f"⚠️ <b>{caption}</b> — la foto no salió "
-                "(Telegram rechazó el envío). Continúo con el resto del digest."
-            ),
-        )
-        return False
 
 
 def _safe_run_auto_bid() -> dict:
@@ -119,13 +82,13 @@ def _run_daily_inner() -> dict:
         config.USER_SQUAD_URL, ctx.biwenger.user_id
     )
     my_team = build_squad_rows(my_squad, ctx.biwenger_players, ctx.jp_index)
-    team_sent = _send_image_or_text_fallback(
+    team_sent = send_image_or_text_fallback(
         token, chat_id, build_table_image(my_team, "Mi equipo"), "Mi equipo"
     )
 
     market_players = ctx.biwenger.get_market_players(config.MARKET_URL)
     market_rows = build_market_rows(market_players, ctx.biwenger_players, ctx.jp_index)
-    market_sent = _send_image_or_text_fallback(
+    market_sent = send_image_or_text_fallback(
         token, chat_id, build_table_image(market_rows, "Mercado"), "Mercado"
     )
 

--- a/packages/biwenger_tools/api/logic/orchestration.py
+++ b/packages/biwenger_tools/api/logic/orchestration.py
@@ -5,13 +5,21 @@
 - `build_biwenger_session()` — Biwenger only, for handlers that
   don't need JP.
 - `require_telegram()` — `(token, chat_id)` if configured, else None.
+- `send_image_or_text_fallback()` — sendPhoto with a text fallback so a
+  single Telegram refusal in a multi-photo flow doesn't kill the rest.
 """
 
+import time
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from core.sdk.biwenger import BiwengerClient
 from core.sdk.jp import check_api_health, fetch_all_players
+from core.sdk.telegram import (
+    TelegramDeliveryError,
+    send_telegram_message,
+    send_telegram_photo_or_raise,
+)
 from core.utils import get_logger
 from packages.biwenger_tools.api import config
 from packages.biwenger_tools.api.logic.player_matching import build_jp_index
@@ -73,3 +81,35 @@ def require_telegram() -> Optional[Tuple[str, str]]:
         logger.warning("Telegram credentials missing — skipping send.")
         return None
     return config.TELEGRAM_BOT_TOKEN, config.TELEGRAM_CHAT_ID
+
+
+def send_image_or_text_fallback(
+    token: str, chat_id: str, image: bytes, caption: str
+) -> bool:
+    """sendPhoto + a small pause to stay under Telegram's send-rate cap.
+
+    Returns True on success. On photo failure (Telegram refusal, network
+    blip), sends a short text fallback instead and returns False. Multi-
+    photo flows (`/digests/daily`, `/teams` ALL-managers) MUST use this
+    instead of `send_telegram_photo_or_raise` — a single broken photo
+    would otherwise skip every later step (digest auto-bid, remaining
+    manager squads, mercado).
+    """
+    try:
+        send_telegram_photo_or_raise(token, chat_id, image, caption)
+        time.sleep(0.5)
+        return True
+    except TelegramDeliveryError as exc:
+        logger.error(
+            "Photo delivery failed, sending text fallback.",
+            extra={"caption": caption, "error": str(exc)},
+        )
+        send_telegram_message(
+            bot_token=token,
+            chat_id=chat_id,
+            text=(
+                f"⚠️ <b>{caption}</b> — la foto no salió "
+                "(Telegram rechazó el envío). Continúo con el resto."
+            ),
+        )
+        return False

--- a/packages/biwenger_tools/api/tests/test_actions.py
+++ b/packages/biwenger_tools/api/tests/test_actions.py
@@ -1,0 +1,55 @@
+"""Unit tests for `api/logic/actions` — specifically the resilience of
+multi-photo flows. Route wiring is tested in `test_routes.py`."""
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+
+def _patches(target):
+    return f"packages.biwenger_tools.api.logic.actions.{target}"
+
+
+def test_run_teams_all_mode_continues_after_first_photo_fails():
+    """A single Telegram refusal in the middle of an /analizar TODOS run
+    must not skip the remaining manager squads or the mercado photo. The
+    failure is reported per-image (via the fallback) and the sent count
+    reflects only the photos that actually landed."""
+    biwenger = MagicMock()
+    biwenger.user_id = 1
+    biwenger.get_league_users.return_value = {1: "Me", 2: "Rival"}
+    biwenger.get_manager_squad.return_value = []
+    biwenger.get_market_players.return_value = []
+
+    from packages.biwenger_tools.api.logic.orchestration import OrchestratorContext
+
+    ctx = OrchestratorContext(
+        biwenger=biwenger,
+        biwenger_players={},
+        jp_index={"by_name": {}, "by_slug": {}},
+    )
+
+    stack = ExitStack()
+    stack.enter_context(patch(_patches("config")))
+    stack.enter_context(patch(_patches("build_context"), return_value=ctx))
+    stack.enter_context(
+        patch(_patches("require_telegram"), return_value=("tok", "chat"))
+    )
+    stack.enter_context(patch(_patches("build_table_image"), return_value=b""))
+    # First photo (Mi equipo) fails, the rest land. The mercado photo at the
+    # end MUST still go out — that's the regression.
+    mock_send = stack.enter_context(
+        patch(
+            _patches("send_image_or_text_fallback"),
+            side_effect=[False, True, True],
+        )
+    )
+    try:
+        from packages.biwenger_tools.api.logic import actions
+
+        result = actions.run_teams(manager_id=None)
+    finally:
+        stack.close()
+
+    assert mock_send.call_count == 3  # me + 1 rival + mercado
+    assert result["sent"] == 2  # only the two successes counted
+    assert result["teams"] == 2

--- a/packages/biwenger_tools/api/tests/test_digests.py
+++ b/packages/biwenger_tools/api/tests/test_digests.py
@@ -31,7 +31,7 @@ def test_run_daily_skips_send_when_telegram_creds_missing():
     with patch(_patches("config")) as mock_cfg, patch(
         _patches("build_context"), return_value=_build_ctx(biwenger)
     ), patch(_patches("require_telegram"), return_value=None) as mock_creds, patch(
-        _patches("_send_image_or_text_fallback")
+        _patches("send_image_or_text_fallback")
     ) as mock_send:
         mock_cfg.USER_SQUAD_URL = "x/{manager_id}"
         mock_cfg.MARKET_URL = "x"
@@ -62,7 +62,7 @@ def _digest_env(*, auto_bid_result=None, auto_bid_raises=None):
         patch(_patches("require_telegram"), return_value=("tok", "chat"))
     )
     mock_send = stack.enter_context(
-        patch(_patches("_send_image_or_text_fallback"), return_value=True)
+        patch(_patches("send_image_or_text_fallback"), return_value=True)
     )
     # `build_table_image` runs synchronously before `_send_image` — patching
     # the renderer avoids matplotlib choking on the empty-row stub data.
@@ -149,15 +149,16 @@ def test_send_image_or_text_fallback_sends_text_on_telegram_delivery_error():
     """When `sendPhoto` raises, the helper must post a text fallback so the
     user still sees the section landed even if Telegram refused the image."""
     from core.sdk.telegram import TelegramDeliveryError
-    from packages.biwenger_tools.api.logic import digests
+    from packages.biwenger_tools.api.logic import orchestration
 
+    orch = "packages.biwenger_tools.api.logic.orchestration."
     with patch(
-        _patches("send_telegram_photo_or_raise"),
+        orch + "send_telegram_photo_or_raise",
         side_effect=TelegramDeliveryError("boom"),
-    ), patch(_patches("send_telegram_message")) as mock_text, patch(
-        _patches("time.sleep")
-    ):
-        ok = digests._send_image_or_text_fallback("tok", "chat", b"img", "Mi equipo")
+    ), patch(orch + "send_telegram_message") as mock_text, patch(orch + "time.sleep"):
+        ok = orchestration.send_image_or_text_fallback(
+            "tok", "chat", b"img", "Mi equipo"
+        )
 
     assert ok is False
     mock_text.assert_called_once()


### PR DESCRIPTION
## Summary

Cierra el hueco que dejó la PR #133: la misma resiliencia que ya tenía `/digests/daily` ahora aplica a `/analizar TODOS`.

`actions.run_teams` en modo all-managers manda mi equipo + N rivales + mercado (10+ envíos consecutivos a `sendPhoto`). Si una sola foto fallaba a medio recorrido, el endpoint 500eaba y el resto no se enviaba. El bot mostraba un genérico "❌ Error" después de las fotos parciales.

## Changes

- **Extracción del helper**: `_send_image_or_text_fallback` sale de `digests.py` y se publica en `orchestration.py` como `send_image_or_text_fallback`. Lo usa `digests.py` (sin cambio funcional) y ahora también `actions.py`.
- **`run_teams` ALL-mode**: cada `sendPhoto` se envuelve con fallback. Una foto que rebote ahora deja un mensaje de texto en su lugar y el bucle continúa. El campo `sent` del JSON refleja sólo lo que aterrizó.
- **Tests**:
  - `test_actions.py` nuevo: regresión específica — la primera foto rebota, mercado todavía se manda.
  - `test_digests.py` actualizado: patches apuntan al nuevo módulo.

## Validation

- `bazel test //packages/biwenger_tools/{api,bot}:_tests //core:core_tests` → 3/3 pass
- `scripts/lint.sh` → OK

## Test plan

- [ ] Tras merge + deploy, ejecutar `/analizar TODOS` y comprobar que llegan todas las fotos
- [ ] (Opcional, difícil de reproducir) Si una jornada cae con Telegram lento, comprobar que sale "⚠️ X — la foto no salió" en vez de muerte abrupta