### PR TITLE
fix(web): drop 'Web' from iOS home-screen title

### DIFF
--- a/packages/biwenger_tools/web/templates/base.html
+++ b/packages/biwenger_tools/web/templates/base.html
@@ -12,7 +12,9 @@
           href="{{ url_for('static', filename='apple-touch-icon.png') }}">
     <link rel="icon" type="image/png" sizes="180x180"
           href="{{ url_for('static', filename='apple-touch-icon.png') }}">
-    <meta name="apple-mobile-web-app-title" content="Lloros League Web">
+    <!-- Title kept under ~12 chars; iOS strips spaces when a longer string
+         doesn't fit under the icon ("Lloros League Web" → "LlorosLeagueWeb"). -->
+    <meta name="apple-mobile-web-app-title" content="Lloros League">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="theme-color" content="#38a169">


### PR DESCRIPTION
## Summary

Verified on iPhone tras el deploy anterior: "Lloros League Web" (17 chars) no entra en el ancho del caption del icono y iOS le quita los espacios, quedando como `LlorosLeagueWeb` (visible en el screenshot del usuario).

`Lloros League` (13 chars) sí entra y se muestra correctamente.

## Changes

- `packages/biwenger_tools/web/templates/base.html` — `apple-mobile-web-app-title` pasa de "Lloros League Web" → "Lloros League".

## Test plan post-merge

- [ ] En el iPhone: borrar el shortcut "LlorosLeagueWeb" del home screen
- [ ] Safari → biwenger-summary → Compartir → Añadir a pantalla de inicio
- [ ] Verificar que ahora aparece como "Lloros League" sin aplastar espacios