### PR TITLE
fix(api): notify when on-demand /ofertas finds an empty inbox

### DIFF
--- a/packages/biwenger_tools/api/app.py
+++ b/packages/biwenger_tools/api/app.py
@@ -216,8 +216,19 @@ def emergency_clausulazo_execute():
 
 @app.route("/offers/inbox", methods=["POST"])
 def offers_inbox():
-    """List + score received offers, post one Telegram message per offer."""
-    return _run_action("offers.inbox", offers.run_offers_inbox)
+    """List + score received offers, post one Telegram message per offer.
+
+    `notify_empty=True` so an on-demand `/ofertas` always lands a reply in
+    the chat — without it the user is stuck staring at the bot's
+    "procesando…" line when the inbox happens to be empty. The digest
+    path (`digests.run_daily`) calls the function directly with the
+    default `notify_empty=False` so the morning briefing stays silent
+    on no-offers days.
+    """
+    return _run_action(
+        "offers.inbox",
+        lambda: offers.run_offers_inbox(notify_empty=True),
+    )
 
 
 @app.route("/offers/decide", methods=["POST"])

--- a/packages/biwenger_tools/api/logic/offers.py
+++ b/packages/biwenger_tools/api/logic/offers.py
@@ -64,15 +64,23 @@ STAR_OVERRIDE_OVER_MARKET_PCT = 25.0
 # ---------------------------------------------------------------------------
 
 
-def run_offers_inbox(ctx: Optional[OrchestratorContext] = None) -> dict:
+def run_offers_inbox(
+    ctx: Optional[OrchestratorContext] = None,
+    *,
+    notify_empty: bool = False,
+) -> dict:
     """Fetch + score the inbox, post one Telegram message per offer.
 
     `ctx` is optional so the digest can pass the already-built context
     instead of paying a second JP+Biwenger round-trip. When None we build
     one ourselves (manual `/ofertas` from the bot).
 
-    Silent when the inbox is empty — no spam in the daily digest if the
-    user has no pending offers.
+    `notify_empty` controls the empty-inbox UX:
+      - `False` (default) — digest mode: stay silent so a morning with no
+        pending offers doesn't add noise to the briefing.
+      - `True` — on-demand `/ofertas` from the bot: send a "📭 Sin ofertas
+        pendientes" message so the user gets a clear answer instead of
+        staring at the "procesando…" line forever.
     """
     ctx = ctx or build_context()
     telegram = require_telegram()
@@ -83,6 +91,13 @@ def run_offers_inbox(ctx: Optional[OrchestratorContext] = None) -> dict:
     inbox = ctx.biwenger.get_received_offers()
     if not inbox:
         logger.info("Offers inbox empty — skipping send.")
+        if notify_empty:
+            send_telegram_message(
+                bot_token=token,
+                chat_id=chat_id,
+                text="📭 <b>Sin ofertas pendientes.</b>",
+            )
+            return {"sent": 1, "offers": 0}
         return {"sent": 0, "offers": 0}
 
     # One squad fetch + lineup pick to drive the is-in-current-11 signal.

--- a/packages/biwenger_tools/api/tests/test_offers.py
+++ b/packages/biwenger_tools/api/tests/test_offers.py
@@ -126,7 +126,8 @@ def _ctx_with_offers(returned_offers):
     )
 
 
-def test_run_offers_inbox_silent_when_empty():
+def test_run_offers_inbox_silent_when_empty_default():
+    """Default (digest mode): empty inbox → no Telegram send."""
     ctx = _ctx_with_offers([])
     with patch(_p("require_telegram"), return_value=("tok", "chat")), patch(
         _p("send_telegram_message")
@@ -134,6 +135,20 @@ def test_run_offers_inbox_silent_when_empty():
         result = offers.run_offers_inbox(ctx)
     mock_send.assert_not_called()
     assert result == {"sent": 0, "offers": 0}
+
+
+def test_run_offers_inbox_notifies_when_empty_and_requested():
+    """On-demand mode (notify_empty=True): empty inbox → "📭 Sin ofertas
+    pendientes" so the user gets a reply instead of staring at "procesando…"."""
+    ctx = _ctx_with_offers([])
+    with patch(_p("require_telegram"), return_value=("tok", "chat")), patch(
+        _p("send_telegram_message")
+    ) as mock_send:
+        result = offers.run_offers_inbox(ctx, notify_empty=True)
+    mock_send.assert_called_once()
+    text = mock_send.call_args.kwargs.get("text", "")
+    assert "Sin ofertas" in text
+    assert result == {"sent": 1, "offers": 0}
 
 
 def test_run_offers_inbox_sends_one_message_per_offer():

--- a/packages/biwenger_tools/api/tests/test_routes.py
+++ b/packages/biwenger_tools/api/tests/test_routes.py
@@ -382,14 +382,17 @@ def test_budget_recommendations_clamps_query_params(client):
 # --- /offers/inbox and /offers/decide -------------------------------------
 
 
-def test_offers_inbox_calls_run_offers_inbox(client):
+def test_offers_inbox_calls_run_offers_inbox_with_notify_empty(client):
+    """On-demand `/offers/inbox` must pass `notify_empty=True` so an
+    empty inbox lands a "📭 Sin ofertas" reply in the chat. The digest's
+    own call (in `digests.py`) keeps the default silent mode."""
     fake = {"sent": 2, "offers": 2}
     with patch(
         "packages.biwenger_tools.api.app.offers.run_offers_inbox",
         return_value=fake,
     ) as mock_run:
         resp = client.post("/offers/inbox")
-    mock_run.assert_called_once_with()
+    mock_run.assert_called_once_with(notify_empty=True)
     assert resp.status_code == 200
     assert resp.get_json()["sent"] == 2
 


### PR DESCRIPTION
## Summary

Bug encontrado en logs producción esta tarde tras el merge de #135. El usuario lanzó \`/ofertas\` desde el bot, el endpoint procesó correctamente y la API devolvió 200, pero **el chat se quedó en blanco** tras el "📥 Ofertas — procesando…".

Logs de la API:
\`\`\`
21:03:41  Received offers fetched.
21:03:41  Offers inbox empty — skipping send.
\`\`\`

La causa: cuando aceptaste/rechazaste las 2 ofertas que tenías esta mañana, ya no hay nada pendiente. Mi código del PR original era silencioso en ese caso (correcto para el digest matutino, **mal para una invocación a demanda**).

## Fix

Parametriza el comportamiento:

- \`run_offers_inbox(notify_empty=False)\` (default) — silencio en el digest matutino, no spam.
- \`run_offers_inbox(notify_empty=True)\` — el endpoint \`/offers/inbox\` (que el bot llama al pulsar 📥 Ofertas) envía "📭 Sin ofertas pendientes" para cerrar el flujo.

## Validation

- \`bazel test\` → 3/3 pass (tests nuevos cubren ambas ramas)
- \`scripts/lint.sh\` → OK

## Test plan post-merge

- [ ] Probar \`/ofertas\` ahora mismo (sin ofertas vivas) → debe llegar "📭 Sin ofertas pendientes"
- [ ] Mañana en el digest 09:00, si no hay ofertas, **no** debe aparecer el mensaje (comportamiento silencioso preservado)