### PR TITLE
fix(offers): T2 alone → REJECT + loss-aversion rule + instant tap toast

### DIFF
--- a/core/sdk/biwenger.py
+++ b/core/sdk/biwenger.py
@@ -22,6 +22,7 @@ MARKET_URL = f"{BIWENGER_API_BASE}/market"
 OFFERS_URL = f"{BIWENGER_API_BASE}/offers"
 USER_OFFERS_URL = f"{BIWENGER_API_BASE}/user?fields=offers(*,from(*),to(*))"
 LINEUP_URL = f"{BIWENGER_API_BASE}/user?fields=*,lineup(date)"
+USER_LINEUP_URL = f"{BIWENGER_API_BASE}/user?fields=lineup(date,formation,players)"
 ALL_PLAYERS_DATA_URL = f"{BIWENGER_CF_BASE}/competitions/la-liga/data?lang=es&score=100"
 
 
@@ -466,6 +467,32 @@ class BiwengerClient:
             extra={"total": len(offers), "inbox": len(inbox)},
         )
         return inbox
+
+    def get_current_lineup_player_ids(
+        self, user_lineup_url: str = USER_LINEUP_URL
+    ) -> set[int]:
+        """Return the set of `player_id` currently in the user's starting 11.
+
+        Reads `?fields=lineup(date,formation,players)` and pulls the
+        non-null entries from `data.lineup.players` (the array has slots
+        for the chosen formation; empty slots come as `null`).
+
+        Use this — NOT `pick_lineup` — when you need to know "is this
+        player in the current Biwenger lineup" (e.g. /ofertas
+        recommendation context). `pick_lineup` computes the OPTIMAL 11 and
+        returns None if a valid one can't be formed (1 player + 10 huecos),
+        which then silently flips every player's is_starter flag to False.
+        """
+        response = self.session.get(user_lineup_url, timeout=30)
+        response.raise_for_status()
+        lineup = ((response.json().get("data") or {}).get("lineup")) or {}
+        players = lineup.get("players") or []
+        ids = {p["id"] for p in players if isinstance(p, dict) and p.get("id")}
+        logger.info(
+            "Current lineup fetched.",
+            extra={"formation": lineup.get("formation"), "filled_slots": len(ids)},
+        )
+        return ids
 
     def decide_offer(
         self, offer_id: int, decision: str, offers_url: str = OFFERS_URL

--- a/packages/biwenger_tools/api/logic/offers.py
+++ b/packages/biwenger_tools/api/logic/offers.py
@@ -58,6 +58,14 @@ ACCEPT_OVER_MARKET_PCT = 15.0
 REJECT_UNDER_MARKET_PCT = -10.0
 STAR_OVERRIDE_OVER_MARKET_PCT = 25.0
 
+# Loss-aversion threshold. A T3+ player with this much paper loss is a
+# clear REJECT (you paid X, they offer < X * (1 - LOSS_THRESHOLD)). User
+# feedback 25/06: T2 titular paid 14M, offered 7M (-50% ROI) was scored
+# DUDOSO. Algorithm previously needed is_starter=True for T2 to reject,
+# and is_starter is flaky because pick_lineup excludes players JP has no
+# SF for. This rule kicks in regardless of the starter signal.
+REJECT_LOSS_PCT = -25.0
+
 
 # ---------------------------------------------------------------------------
 # Public entry points
@@ -290,11 +298,16 @@ def _recommend(
 
     Returns ``(recommendation, reasons)`` where ``recommendation`` is
     one of ``REC_ACCEPT``, ``REC_REJECT``, ``REC_DOUBTFUL``.
+
+    `is_starter` is a soft signal surfaced in the message but no longer
+    gates the T2+ "titular fijo" rule — `pick_lineup` can drop a real
+    starter when JP has no SF for the current matchday, which used to
+    falsely demote T2 players to DUDOSO (user feedback 25/06).
     """
     reasons: list[str] = []
 
-    # 1. Estrella o titular fijo en el 11 → RECHAZAR salvo oferta indecente.
-    if sf >= ab.TIER_ALL_IN_MIN or (sf >= ab.TIER_T2_MIN and is_starter):
+    # 1. Estrella o titular fijo (T2+) → RECHAZAR salvo oferta indecente.
+    if sf >= ab.TIER_T2_MIN:
         if vs_market_pct is not None and vs_market_pct >= STAR_OVERRIDE_OVER_MARKET_PCT:
             reasons.append(
                 f"Titular fuerte (SF {sf}) pero oferta "
@@ -306,31 +319,45 @@ def _recommend(
         )
         return REC_REJECT, reasons
 
-    # 2. Descarte o fondo de armario con plusvalía → ACEPTAR.
+    # 2. Útil (T3+) con pérdida fuerte → RECHAZAR (loss aversion).
+    # Excepción: si el mercado paga claramente sobre cf-base, compensa.
+    if sf >= ab.TIER_T3_MIN and roi_pct is not None and roi_pct <= REJECT_LOSS_PCT:
+        if vs_market_pct is not None and vs_market_pct >= ACCEPT_OVER_MARKET_PCT:
+            reasons.append(
+                f"Pierdes {roi_pct:+.0f}% sobre compra, pero oferta "
+                f"{vs_market_pct:+.0f}% sobre cf-base — compensa"
+            )
+            return REC_ACCEPT, reasons
+        reasons.append(
+            f"Jugador útil (SF {sf}); pérdida {roi_pct:+.0f}% sobre compra es excesiva"
+        )
+        return REC_REJECT, reasons
+
+    # 3. Descarte o fondo de armario con plusvalía → ACEPTAR.
     if sf < ab.TIER_T3_MIN and roi_pct is not None and roi_pct > 0:
         reasons.append(
             f"Fondo de armario (SF {sf}) y plusvalía {roi_pct:+.0f}% vs compra"
         )
         return REC_ACCEPT, reasons
 
-    # 3. Oferta claramente por encima del valor cf-base → ACEPTAR.
+    # 4. Oferta claramente por encima del valor cf-base → ACEPTAR.
     if vs_market_pct is not None and vs_market_pct >= ACCEPT_OVER_MARKET_PCT:
         reasons.append(f"Oferta {vs_market_pct:+.0f}% sobre cf-base — buen momento")
         return REC_ACCEPT, reasons
 
-    # 4. Oferta claramente baja → RECHAZAR.
+    # 5. Oferta claramente baja → RECHAZAR.
     if vs_market_pct is not None and vs_market_pct <= REJECT_UNDER_MARKET_PCT:
         reasons.append(
             f"Oferta {vs_market_pct:+.0f}% bajo cf-base; aguanta o lánzalo al mercado"
         )
         return REC_REJECT, reasons
 
-    # 5. Rotación con oferta razonable → DUDOSO.
+    # 6. Rotación (T3) con oferta razonable → DUDOSO.
     if ab.TIER_T3_MIN <= sf < ab.TIER_T2_MIN:
         reasons.append(f"Rotación (SF {sf}); decide según tu necesidad de cash")
         return REC_DOUBTFUL, reasons
 
-    # 6. Catch-all.
+    # 7. Catch-all.
     reasons.append("Caso límite — decide tú")
     return REC_DOUBTFUL, reasons
 

--- a/packages/biwenger_tools/api/logic/offers.py
+++ b/packages/biwenger_tools/api/logic/offers.py
@@ -23,7 +23,6 @@ from core.sdk.telegram import send_telegram_message
 from core.utils import format_euros, get_logger
 from packages.biwenger_tools.api import config
 from packages.biwenger_tools.api.logic import auto_bid as ab
-from packages.biwenger_tools.api.logic.lineup import pick_lineup
 from packages.biwenger_tools.api.logic.orchestration import (
     OrchestratorContext,
     build_biwenger_session,
@@ -187,23 +186,25 @@ def run_offer_decision(offer_id: int, decision: str) -> dict:
 
 
 def _starter_ids(ctx: OrchestratorContext) -> set:
-    """Resolve the bw_ids that pick_lineup would put in the starting 11.
+    """Resolve the bw_ids currently in the user's Biwenger starting 11.
 
-    Best-effort: any failure returns an empty set (the recommendation
-    then treats every offer as non-starter, which is the conservative
-    default — losing the "they are a starter, don't sell" guard).
+    Reads the actual lineup Biwenger has stored (whatever the user set
+    last) — NOT what `pick_lineup` thinks is optimal. Two reasons:
+
+    1. The user's perception of "está en mi 11" is "está alineado en
+       Biwenger ahora mismo", not "el algoritmo lo metería".
+    2. `pick_lineup` returns None when a valid 11 can't be formed (a
+       squad with 1 player + 10 empty slots, for example), and that
+       silently flips every player's is_starter to False — a real-world
+       case reported 25/06 where a fixed starter showed as "En tu 11: NO".
+
+    Best-effort: any failure returns an empty set so the recommendation
+    still works without this signal.
     """
     try:
-        my_squad = ctx.biwenger.get_manager_squad(
-            config.USER_SQUAD_URL, ctx.biwenger.user_id
-        )
-        rows = build_squad_rows(my_squad, ctx.biwenger_players, ctx.jp_index)
-        result = pick_lineup(rows)
-        if not result:
-            return set()
-        return {row["bw_id"] for row, _ in result["starters"]}
+        return ctx.biwenger.get_current_lineup_player_ids()
     except Exception:
-        logger.exception("Failed to compute starter set — treating as unknown.")
+        logger.exception("Failed to fetch current lineup — treating as unknown.")
         return set()
 
 

--- a/packages/biwenger_tools/api/tests/test_offers.py
+++ b/packages/biwenger_tools/api/tests/test_offers.py
@@ -245,6 +245,46 @@ def test_run_offer_decision_invalid_raises():
         offers.run_offer_decision(offer_id=1, decision="bogus")
 
 
+def test_starter_ids_pulls_from_biwenger_lineup_not_pick_lineup():
+    """`_starter_ids` MUST hit `BiwengerClient.get_current_lineup_player_ids()`
+    (the real lineup the user has saved on Biwenger) instead of computing
+    pick_lineup's optimal 11. Regression for 25/06: user only had 1 valid
+    player + 10 empty slots in his lineup; pick_lineup returned None, and
+    is_starter went False for everyone — including the real starter."""
+    biwenger = MagicMock()
+    biwenger.user_id = 1
+    biwenger.get_current_lineup_player_ids.return_value = {42, 99}
+
+    from packages.biwenger_tools.api.logic.orchestration import OrchestratorContext
+
+    ctx = OrchestratorContext(
+        biwenger=biwenger,
+        biwenger_players={},
+        jp_index={"by_name": {}, "by_slug": {}},
+    )
+
+    assert offers._starter_ids(ctx) == {42, 99}
+    biwenger.get_current_lineup_player_ids.assert_called_once()
+
+
+def test_starter_ids_swallows_sdk_failure():
+    """If the lineup fetch blows up the recommendation must still work,
+    just without the is_starter signal."""
+    biwenger = MagicMock()
+    biwenger.user_id = 1
+    biwenger.get_current_lineup_player_ids.side_effect = RuntimeError("boom")
+
+    from packages.biwenger_tools.api.logic.orchestration import OrchestratorContext
+
+    ctx = OrchestratorContext(
+        biwenger=biwenger,
+        biwenger_players={},
+        jp_index={"by_name": {}, "by_slug": {}},
+    )
+
+    assert offers._starter_ids(ctx) == set()
+
+
 def test_run_offer_decision_forwards_to_sdk_and_notifies():
     biwenger = MagicMock()
     biwenger.decide_offer.return_value = {"id": 1, "status": "processed"}

--- a/packages/biwenger_tools/api/tests/test_offers.py
+++ b/packages/biwenger_tools/api/tests/test_offers.py
@@ -25,11 +25,49 @@ def test_recommend_rejects_star_player():
 
 
 def test_recommend_rejects_t2_starter():
-    """T2 + is_starter → still RECHAZAR (titular fijo)."""
+    """T2 + is_starter → RECHAZAR (titular fijo)."""
     rec, _ = offers._recommend(
         sf=ab.TIER_T2_MIN + 10, roi_pct=10.0, vs_market_pct=5.0, is_starter=True
     )
     assert rec == offers.REC_REJECT
+
+
+def test_recommend_rejects_t2_even_when_not_marked_as_starter():
+    """User feedback 25/06: T2 jugador titular fijo, ofrecen 7M tras pagar 14M
+    (-50% ROI, vs_market 0%), is_starter=False porque pick_lineup le excluyó
+    al no tener SF para esta jornada. Antes caía en DUDOSO; ahora RECHAZA
+    igualmente porque T2 ya es señal suficiente."""
+    rec, _ = offers._recommend(
+        sf=ab.TIER_T2_MIN + 10, roi_pct=-50.0, vs_market_pct=0.0, is_starter=False
+    )
+    assert rec == offers.REC_REJECT
+
+
+def test_recommend_rejects_useful_player_with_heavy_loss():
+    """T3 (rotación) con pérdida >= 25% sobre lo pagado → RECHAZAR.
+    Loss-aversion rule: no aceptes pérdidas grandes en jugadores útiles."""
+    rec, reasons = offers._recommend(
+        sf=ab.TIER_T3_MIN + 50,
+        roi_pct=offers.REJECT_LOSS_PCT - 5,  # peor que -25%
+        vs_market_pct=-5.0,
+        is_starter=False,
+    )
+    assert rec == offers.REC_REJECT
+    assert any("pérdida" in r.lower() for r in reasons)
+
+
+def test_recommend_loss_aversion_overridden_by_strong_market_premium():
+    """Excepción a la loss-aversion: si el mercado paga sobre cf-base
+    aunque tú pierdas mucho vs compra, ACEPTAR (al menos recuperas lo
+    que el mercado dice que vale + extra)."""
+    rec, reasons = offers._recommend(
+        sf=ab.TIER_T3_MIN + 50,
+        roi_pct=-40.0,
+        vs_market_pct=offers.ACCEPT_OVER_MARKET_PCT + 5,  # +20% sobre cf-base
+        is_starter=False,
+    )
+    assert rec == offers.REC_ACCEPT
+    assert any("compensa" in r.lower() for r in reasons)
 
 
 def test_recommend_star_with_indecent_offer_becomes_doubtful():

--- a/packages/biwenger_tools/bot/app.py
+++ b/packages/biwenger_tools/bot/app.py
@@ -445,13 +445,25 @@ def _handle_callback(cb: dict) -> None:
     - `o:a:<offer_id>` / `o:r:<offer_id>` / `o:i:<offer_id>` — accept /
       reject / ignore a received offer (the inbox flow).
     """
-    answer_callback_query(config.TELEGRAM_BOT_TOKEN, cb["id"])
     data = cb.get("data", "")
     if ":" not in data:
+        answer_callback_query(config.TELEGRAM_BOT_TOKEN, cb["id"])
         logger.info("Webhook: unknown callback_data", extra={"data": data})
         return
     prefix, value = data.split(":", 1)
     edit_into = (cb["chat_id"], cb["message_id"]) if cb.get("message_id") else None
+
+    # Ack with a per-action toast where it adds UX value, otherwise plain.
+    # The toast is the only feedback the user has between the tap and the
+    # final confirmation message (which sits behind a cold-start of the
+    # api + a Biwenger round-trip, ~8 s in the worst case).
+    cb_id = cb["id"]
+    if prefix == "o" and ":" in value and value.split(":", 1)[0] in ("a", "r"):
+        marker = value.split(":", 1)[0]
+        toast = "⏳ Aceptando…" if marker == "a" else "⏳ Rechazando…"
+        answer_callback_query(config.TELEGRAM_BOT_TOKEN, cb_id, text=toast)
+    else:
+        answer_callback_query(config.TELEGRAM_BOT_TOKEN, cb_id)
 
     if prefix == "analizar":
         _run_analizar(value, edit_into)

--- a/packages/biwenger_tools/bot/tests/test_bot.py
+++ b/packages/biwenger_tools/bot/tests/test_bot.py
@@ -417,8 +417,12 @@ def test_unknown_callback_prefix_is_ignored(client):
 
 
 def test_ofertas_accept_callback_posts_decide_accepted(client):
-    """`o:a:<id>` → POST /offers/decide?decision=accepted; keyboard stripped."""
-    with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
+    """`o:a:<id>` → POST /offers/decide?decision=accepted; keyboard stripped.
+    Also: the callback ack carries a "⏳ Aceptando…" toast so the user gets
+    instant feedback while the cold-start api PUT runs in background."""
+    with patch(
+        "packages.biwenger_tools.bot.app.answer_callback_query"
+    ) as mock_ack, patch(
         "packages.biwenger_tools.bot.app.edit_message_reply_markup"
     ) as mock_strip, patch(
         "packages.biwenger_tools.bot.app.api_client.call_api"
@@ -426,6 +430,12 @@ def test_ofertas_accept_callback_posts_decide_accepted(client):
         resp = _post(client, _callback_update(_VALID_CHAT, "o:a:12345"))
     assert resp.status_code == 200
     mock_strip.assert_called_once()
+    # answer_callback_query was called with the "⏳ Aceptando…" toast.
+    ack_args = mock_ack.call_args
+    assert ack_args.kwargs.get("text", "") or ack_args.args[-1:] == ()
+    # The toast text is the third positional arg (token, cb_id, text=) — assert
+    # via kwargs since the call uses keyword form.
+    assert "Aceptando" in mock_ack.call_args.kwargs.get("text", "")
     mock_call.assert_called_once_with(
         _API_URL,
         "/offers/decide",
@@ -435,12 +445,17 @@ def test_ofertas_accept_callback_posts_decide_accepted(client):
 
 
 def test_ofertas_reject_callback_posts_decide_rejected(client):
-    """`o:r:<id>` → POST /offers/decide?decision=rejected."""
-    with patch("packages.biwenger_tools.bot.app.answer_callback_query"), patch(
+    """`o:r:<id>` → POST /offers/decide?decision=rejected + "⏳ Rechazando…" toast."""
+    with patch(
+        "packages.biwenger_tools.bot.app.answer_callback_query"
+    ) as mock_ack, patch(
         "packages.biwenger_tools.bot.app.edit_message_reply_markup"
-    ), patch("packages.biwenger_tools.bot.app.api_client.call_api") as mock_call:
+    ), patch(
+        "packages.biwenger_tools.bot.app.api_client.call_api"
+    ) as mock_call:
         resp = _post(client, _callback_update(_VALID_CHAT, "o:r:12345"))
     assert resp.status_code == 200
+    assert "Rechazando" in mock_ack.call_args.kwargs.get("text", "")
     mock_call.assert_called_once_with(
         _API_URL,
         "/offers/decide",


### PR DESCRIPTION
## Summary

Dos issues que aparecieron tras el primer uso real de \`/ofertas\` esta mañana:

### Issue 1 — Recomendación incorrecta en titular fijo
T2 player (titular fijo, SF ≈ 650), pagaste 14 M, oferta 7 M (= cf-base, -50% ROI, 0% vs market). Salió **DUDOSO** cuando claramente debería ser **RECHAZAR** (pierdes 7 M en un jugador útil).

**Causa:** mi regla 1 requería \`sf >= TIER_T2_MIN AND is_starter\`. \`is_starter\` lo calcula \`pick_lineup\` y excluye al jugador si JP no tiene SF para esta jornada concreta — falso negativo frecuente.

### Issue 2 — Tap a rechazar se sentía lento (~8 s)
Logs confirman: \`/offers/decide\` tardó **8.37 s** por cold start de Cloud Run (minScale=0). Sin feedback intermedio, el usuario solo veía el keyboard desaparecer y se quedaba esperando.

## Fixes

### Algoritmo (\`api/logic/offers.py\`)
- **Regla 1**: ahora dispara con \`sf >= TIER_T2_MIN\` solo. \`is_starter\` se queda en los metadatos del mensaje (informativo) pero no gobierna la decisión.
- **Regla 2 nueva (loss-aversion)**: \`sf >= TIER_T3_MIN AND roi_pct <= -25%\` → REJECT. Excepción: si \`vs_market_pct >= +15%\` el premium del mercado compensa la pérdida → ACCEPT.

### UX (\`bot/app.py\`)
- El \`answer_callback_query\` para \`o:a\` / \`o:r\` ahora lleva **\"⏳ Aceptando…\"** / **\"⏳ Rechazando…\"** como texto. Telegram lo muestra como toast instantáneo en cuanto registra el tap, así el usuario sabe que la acción está en curso mientras la api completa.

## Validation

- \`bazel test\` → 3/3 pass (tests nuevos para T2 non-starter, loss-aversion, toast)
- \`scripts/lint.sh\` → OK

## Test plan post-merge

- [ ] Lanzar \`/ofertas\` (cuando aparezcan nuevas) y verificar que un titular con pérdida fuerte ahora sale como RECHAZAR
- [ ] Pulsar accept/reject — debería aparecer toast \"⏳ Rechazando…\" inmediato antes de la confirmación final